### PR TITLE
feat(docker): Dockerfile and README update for basic docker development workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:trusty
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install nodejs npm git
+RUN ln -sf /usr/bin/nodejs /usr/local/bin/node
+
+RUN useradd --home-dir /opt/fxa fxa
+USER fxa
+
+WORKDIR /opt/fxa
+
+CMD npm start

--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ mysql -u root -p -e 'DROP DATABASE fxa'
 
 The server will automatically re-create it on next use.
 
+## Docker Based Development
+
+To run the auth db MySQL backend via Docker, three steps are required:
+
+    $ docker build --rm -t mozilla/fxa_auth_db_mysql
+    $ docker run --rm -v $PWD:/opt/fxa mozilla/fxa_auth_db_mysql npm install
+    $ docker run -it --rm -v $PWD:/opt/fxa --net=host mozilla/fxa_auth_db_mysql
+
+This method shares the codebase into the running container so that you can install npm and various modules required by package.json. It then runs FxA auth db MySQL backend in a container, while allowing you to use your IDE of choice from your normal desktop environment to develop code.
+
 ## License
 
 MPL 2.0

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The server will automatically re-create it on next use.
 
 To run the auth db MySQL backend via Docker, three steps are required:
 
-    $ docker build --rm -t mozilla/fxa_auth_db_mysql
+    $ docker build --rm -t mozilla/fxa_auth_db_mysql .
     $ docker run --rm -v $PWD:/opt/fxa mozilla/fxa_auth_db_mysql npm install
     $ docker run -it --rm -v $PWD:/opt/fxa --net=host mozilla/fxa_auth_db_mysql
 


### PR DESCRIPTION
Here's a PR for running the MySQL backend via Docker. I'll make another for the auth-db-server shortly. At that point I think each FxA process will be setup to run in a container, at which point I can get to work on linking them together.