### PR TITLE
fix(shrinkwrap): [train-31] regenerated npm-shrinkwrap.json that uses the correct version of fxa-auth-db-server

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,3 @@
 train-31
   * Only fail with a DB patch level less than the one expected
+  * (hotfix) regenerated npm-shrinkwrap.json that uses the correct version of fxa-auth-db-server - #15

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-auth-db-mysql",
-  "version": "0.0.0",
+  "version": "0.31.0",
   "dependencies": {
     "ass": {
       "version": "1.0.0",
@@ -9,32 +9,32 @@
       "dependencies": {
         "async": {
           "version": "0.9.0",
-          "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+          "from": "async@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
         },
         "blanket": {
           "version": "1.1.6",
-          "from": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
+          "from": "blanket@1.1.6",
           "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
           "dependencies": {
             "esprima": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "from": "esprima@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             },
             "falafel": {
               "version": "0.1.6",
-              "from": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz",
+              "from": "falafel@>=0.1.6 <0.2.0",
               "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz"
             },
             "xtend": {
               "version": "2.1.2",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+              "from": "xtend@>=2.1.1 <2.2.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
               "dependencies": {
                 "object-keys": {
                   "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+                  "from": "object-keys@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                 }
               }
@@ -43,52 +43,66 @@
         },
         "cheerio": {
           "version": "0.14.0",
-          "from": "https://registry.npmjs.org/cheerio/-/cheerio-0.14.0.tgz",
+          "from": "cheerio@0.14.0",
           "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.14.0.tgz",
           "dependencies": {
             "htmlparser2": {
               "version": "3.7.3",
-              "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
+              "from": "htmlparser2@>=3.7.0 <3.8.0",
               "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.2.1",
-                  "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz",
+                  "from": "domhandler@>=2.2.0 <2.3.0",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz"
                 },
                 "domutils": {
-                  "version": "1.5.0",
-                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz"
+                  "version": "1.5.1",
+                  "from": "domutils@>=1.5.0 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                  "dependencies": {
+                    "dom-serializer": {
+                      "version": "0.1.0",
+                      "from": "dom-serializer@>=0.0.0 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                      "dependencies": {
+                        "entities": {
+                          "version": "1.1.1",
+                          "from": "entities@>=1.1.1 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                        }
+                      }
+                    }
+                  }
                 },
                 "domelementtype": {
                   "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                  "from": "domelementtype@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "from": "readable-stream@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -97,27 +111,27 @@
             },
             "entities": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+              "from": "entities@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
             },
             "CSSselect": {
               "version": "0.4.1",
-              "from": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
+              "from": "CSSselect@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
               "dependencies": {
                 "CSSwhat": {
                   "version": "0.4.7",
-                  "from": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz",
+                  "from": "CSSwhat@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
                 },
                 "domutils": {
                   "version": "1.4.3",
-                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+                  "from": "domutils@>=1.4.0 <1.5.0",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
                   "dependencies": {
                     "domelementtype": {
                       "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                      "from": "domelementtype@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                     }
                   }
@@ -126,19 +140,19 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "temp": {
           "version": "0.8.1",
-          "from": "https://registry.npmjs.org/temp/-/temp-0.8.1.tgz",
+          "from": "temp@0.8.1",
           "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.1.tgz",
           "dependencies": {
             "rimraf": {
               "version": "2.2.8",
-              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+              "from": "rimraf@>=2.2.8 <2.3.0",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             }
           }
@@ -147,98 +161,98 @@
     },
     "bluebird": {
       "version": "2.1.3",
-      "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.1.3.tgz",
+      "from": "bluebird@2.1.3",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.1.3.tgz"
     },
     "bunyan": {
       "version": "0.23.1",
-      "from": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
+      "from": "bunyan@0.23.1",
       "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
       "dependencies": {
         "mv": {
           "version": "2.0.3",
-          "from": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
+          "from": "mv@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
           "dependencies": {
             "mkdirp": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "from": "minimist@0.0.8",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "ncp": {
               "version": "0.6.0",
-              "from": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz",
+              "from": "ncp@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
             },
             "rimraf": {
               "version": "2.2.8",
-              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+              "from": "rimraf@>=2.2.8 <2.3.0",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             }
           }
         },
         "dtrace-provider": {
           "version": "0.2.8",
-          "from": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz",
+          "from": "dtrace-provider@0.2.8",
           "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
         }
       }
     },
     "clone": {
       "version": "0.2.0",
-      "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+      "from": "clone@0.2.0",
       "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
     },
     "convict": {
       "version": "0.4.2",
-      "from": "https://registry.npmjs.org/convict/-/convict-0.4.2.tgz",
+      "from": "convict@0.4.2",
       "resolved": "https://registry.npmjs.org/convict/-/convict-0.4.2.tgz",
       "dependencies": {
         "cjson": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
+          "from": "cjson@0.3.0",
           "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
           "dependencies": {
             "jsonlint": {
               "version": "1.6.0",
-              "from": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
+              "from": "jsonlint@1.6.0",
               "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
               "dependencies": {
                 "nomnom": {
                   "version": "1.8.1",
-                  "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+                  "from": "nomnom@>=1.5.0",
                   "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.6.0",
-                      "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+                      "from": "underscore@>=1.6.0 <1.7.0",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                     },
                     "chalk": {
                       "version": "0.4.0",
-                      "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+                      "from": "chalk@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "dependencies": {
                         "has-color": {
                           "version": "0.1.7",
-                          "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                          "from": "has-color@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                         },
                         "ansi-styles": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+                          "from": "ansi-styles@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                         },
                         "strip-ansi": {
                           "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+                          "from": "strip-ansi@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                         }
                       }
@@ -247,7 +261,7 @@
                 },
                 "JSV": {
                   "version": "4.0.2",
-                  "from": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+                  "from": "JSV@>=4.0.0",
                   "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                 }
               }
@@ -256,27 +270,27 @@
         },
         "validator": {
           "version": "1.5.1",
-          "from": "https://registry.npmjs.org/validator/-/validator-1.5.1.tgz",
+          "from": "validator@1.5.1",
           "resolved": "https://registry.npmjs.org/validator/-/validator-1.5.1.tgz"
         },
         "moment": {
           "version": "2.3.1",
-          "from": "https://registry.npmjs.org/moment/-/moment-2.3.1.tgz",
+          "from": "moment@2.3.1",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.3.1.tgz"
         },
         "optimist": {
           "version": "0.6.0",
-          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.0.tgz",
+          "from": "optimist@0.6.0",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.0.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "from": "minimist@>=0.0.1 <0.1.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
@@ -284,9 +298,9 @@
       }
     },
     "fxa-auth-db-server": {
-      "version": "1.18.1",
-      "from": "fxa-auth-db-server@git://github.com/chilts/fxa-auth-db-server.git#3536bbfe2cf468ca898dc9f331b6497be5142fad",
-      "resolved": "git://github.com/chilts/fxa-auth-db-server.git#3536bbfe2cf468ca898dc9f331b6497be5142fad",
+      "version": "0.31.0",
+      "from": "fxa-auth-db-server@git://github.com/mozilla/fxa-auth-db-server.git#95bda6e1d56a67ba37e85c6ed2fad2bd02d13c9e",
+      "resolved": "git://github.com/mozilla/fxa-auth-db-server.git#95bda6e1d56a67ba37e85c6ed2fad2bd02d13c9e",
       "dependencies": {
         "restify": {
           "version": "2.8.2",
@@ -295,7 +309,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "0.1.5",
-              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+              "from": "assert-plus@0.1.5",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "backoff": {
@@ -344,7 +358,7 @@
             },
             "escape-regexp-component": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
+              "from": "escape-regexp-component@1.0.2",
               "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
             },
             "formidable": {
@@ -354,24 +368,24 @@
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "from": "http-signature@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "from": "asn1@0.1.11",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.3",
-                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "from": "ctype@0.5.3",
                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
             "keep-alive-agent": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
+              "from": "keep-alive-agent@0.0.1",
               "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
             },
             "lru-cache": {
@@ -381,7 +395,7 @@
             },
             "mime": {
               "version": "1.2.11",
-              "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+              "from": "mime@>=1.2.9 <1.3.0",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             },
             "negotiator": {
@@ -391,7 +405,7 @@
             },
             "node-uuid": {
               "version": "1.4.2",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
+              "from": "node-uuid@>=1.4.0 <1.5.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
             },
             "once": {
@@ -423,7 +437,7 @@
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "verror": {
@@ -440,7 +454,7 @@
             },
             "dtrace-provider": {
               "version": "0.2.8",
-              "from": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz",
+              "from": "dtrace-provider@0.2.8",
               "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
             }
           }
@@ -449,62 +463,62 @@
     },
     "grunt": {
       "version": "0.4.5",
-      "from": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "from": "grunt@0.4.5",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "from": "async@>=0.1.22 <0.2.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+          "from": "coffee-script@>=1.3.3 <1.4.0",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "from": "colors@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
           "version": "1.0.2-1.2.3",
-          "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+          "from": "dateformat@1.0.2-1.2.3",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+          "from": "eventemitter2@>=0.4.13 <0.5.0",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@>=3.2.9 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -513,144 +527,144 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "from": "glob@>=3.1.21 <3.2.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+              "from": "graceful-fs@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
+              "from": "inherits@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+          "from": "iconv-lite@>=0.2.11 <0.3.0",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "from": "minimatch@>=0.2.12 <0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "from": "nopt@>=1.0.10 <1.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
+              "from": "abbrev@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "from": "rimraf@>=2.2.8 <2.3.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+          "from": "lodash@>=0.9.2 <0.10.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+          "from": "underscore.string@>=2.2.1 <2.3.0",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
-          "version": "1.0.8",
-          "from": "https://registry.npmjs.org/which/-/which-1.0.8.tgz",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
+          "version": "1.0.9",
+          "from": "which@>=1.0.5 <1.1.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "from": "js-yaml@>=2.0.5 <2.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "from": "argparse@>=0.1.11 <0.2.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+                  "from": "underscore@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "from": "esprima@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+          "from": "exit@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+          "from": "getobject@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
           "version": "0.1.1",
-          "from": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
+          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+              "from": "underscore.string@>=2.3.3 <2.4.0",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
@@ -659,42 +673,42 @@
     },
     "grunt-contrib-jshint": {
       "version": "0.10.0",
-      "from": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
+      "from": "grunt-contrib-jshint@0.10.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
       "dependencies": {
         "jshint": {
           "version": "2.5.11",
-          "from": "https://registry.npmjs.org/jshint/-/jshint-2.5.11.tgz",
+          "from": "jshint@>=2.5.0 <2.6.0",
           "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.11.tgz",
           "dependencies": {
             "cli": {
               "version": "0.6.5",
-              "from": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
+              "from": "cli@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
-                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "from": "glob@>=3.2.1 <3.3.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
@@ -705,149 +719,163 @@
             },
             "console-browserify": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+              "from": "console-browserify@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "dependencies": {
                 "date-now": {
                   "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+                  "from": "date-now@>=0.1.4 <0.2.0",
                   "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
                 }
               }
             },
             "exit": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+              "from": "exit@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "htmlparser2": {
               "version": "3.8.2",
-              "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
+              "from": "htmlparser2@>=3.8.0 <3.9.0",
               "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.3.0",
-                  "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+                  "from": "domhandler@>=2.3.0 <2.4.0",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
                 },
                 "domutils": {
-                  "version": "1.5.0",
-                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz"
+                  "version": "1.5.1",
+                  "from": "domutils@>=1.5.0 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                  "dependencies": {
+                    "dom-serializer": {
+                      "version": "0.1.0",
+                      "from": "dom-serializer@>=0.0.0 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                      "dependencies": {
+                        "entities": {
+                          "version": "1.1.1",
+                          "from": "entities@>=1.1.1 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                        }
+                      }
+                    }
+                  }
                 },
                 "domelementtype": {
                   "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                  "from": "domelementtype@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "from": "readable-stream@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "entities": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+                  "from": "entities@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+              "from": "minimatch@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "shelljs": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+              "from": "shelljs@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
             },
             "strip-json-comments": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz",
+              "from": "strip-json-comments@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
             },
             "underscore": {
               "version": "1.6.0",
-              "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+              "from": "underscore@>=1.6.0 <1.7.0",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         }
       }
     },
     "grunt-copyright": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.1.0.tgz",
+      "from": "grunt-copyright@0.1.0",
       "resolved": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.1.0.tgz"
     },
     "grunt-nsp-shrinkwrap": {
       "version": "0.0.3",
-      "from": "https://registry.npmjs.org/grunt-nsp-shrinkwrap/-/grunt-nsp-shrinkwrap-0.0.3.tgz",
+      "from": "grunt-nsp-shrinkwrap@0.0.3",
       "resolved": "https://registry.npmjs.org/grunt-nsp-shrinkwrap/-/grunt-nsp-shrinkwrap-0.0.3.tgz",
       "dependencies": {
         "cli-color": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
+          "from": "cli-color@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
           "dependencies": {
             "es5-ext": {
               "version": "0.9.2",
-              "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz",
+              "from": "es5-ext@>=0.9.2 <0.10.0",
               "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz"
             },
             "memoizee": {
               "version": "0.2.6",
-              "from": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
+              "from": "memoizee@>=0.2.5 <0.3.0",
               "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
               "dependencies": {
                 "event-emitter": {
                   "version": "0.2.2",
-                  "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz",
+                  "from": "event-emitter@>=0.2.2 <0.3.0",
                   "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz"
                 },
                 "next-tick": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz",
+                  "from": "next-tick@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz"
                 }
               }
@@ -856,49 +884,49 @@
         },
         "colors": {
           "version": "0.6.2",
-          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "from": "colors@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "from": "text-table@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
     },
     "load-grunt-tasks": {
       "version": "0.6.0",
-      "from": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.6.0.tgz",
+      "from": "load-grunt-tasks@0.6.0",
       "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.6.0.tgz",
       "dependencies": {
         "findup-sync": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@>=3.2.9 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -907,46 +935,46 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "multimatch": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/multimatch/-/multimatch-0.3.0.tgz",
+          "from": "multimatch@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-0.3.0.tgz",
           "dependencies": {
             "array-differ": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz",
+              "from": "array-differ@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz"
             },
             "array-union": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
+              "from": "array-union@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
               "dependencies": {
                 "array-uniq": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz",
+                  "from": "array-uniq@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "from": "minimatch@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
@@ -957,44 +985,44 @@
     },
     "mysql": {
       "version": "2.3.2",
-      "from": "https://registry.npmjs.org/mysql/-/mysql-2.3.2.tgz",
+      "from": "mysql@2.3.2",
       "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.3.2.tgz",
       "dependencies": {
         "bignumber.js": {
           "version": "1.4.0",
-          "from": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-1.4.0.tgz",
+          "from": "bignumber.js@1.4.0",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-1.4.0.tgz"
         },
         "readable-stream": {
           "version": "1.1.13",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "from": "readable-stream@>=1.1.13 <1.2.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "from": "isarray@0.0.1",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "from": "string_decoder@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "require-all": {
           "version": "0.0.8",
-          "from": "https://registry.npmjs.org/require-all/-/require-all-0.0.8.tgz",
+          "from": "require-all@0.0.8",
           "resolved": "https://registry.npmjs.org/require-all/-/require-all-0.0.8.tgz"
         }
       }
@@ -1006,351 +1034,351 @@
       "dependencies": {
         "async": {
           "version": "0.9.0",
-          "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+          "from": "async@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
         },
         "bluebird": {
-          "version": "2.9.3",
-          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.3.tgz",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.3.tgz"
+          "version": "2.9.13",
+          "from": "bluebird@>=2.3.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.13.tgz"
         },
         "clone": {
           "version": "0.1.19",
-          "from": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz",
+          "from": "clone@>=0.1.18 <0.2.0",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz"
         },
         "xtend": {
           "version": "4.0.0",
-          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+          "from": "xtend@>=4.0.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
         }
       }
     },
     "request": {
       "version": "2.36.0",
-      "from": "https://registry.npmjs.org/request/-/request-2.36.0.tgz",
+      "from": "request@2.36.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.36.0.tgz",
       "dependencies": {
         "qs": {
           "version": "0.6.6",
-          "from": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+          "from": "qs@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
         },
         "json-stringify-safe": {
           "version": "5.0.0",
-          "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
+          "from": "json-stringify-safe@>=5.0.0 <5.1.0",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
         },
         "mime": {
           "version": "1.2.11",
-          "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+          "from": "mime@>=1.2.9 <1.3.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
         },
         "forever-agent": {
           "version": "0.5.2",
-          "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+          "from": "forever-agent@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
         },
         "node-uuid": {
           "version": "1.4.2",
-          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
+          "from": "node-uuid@>=1.4.0 <1.5.0",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
         },
         "tough-cookie": {
           "version": "0.12.1",
-          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+          "from": "tough-cookie@>=0.12.0",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.3.2",
-              "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+              "from": "punycode@>=0.2.0",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
             }
           }
         },
         "form-data": {
           "version": "0.1.4",
-          "from": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+          "from": "form-data@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
           "dependencies": {
             "combined-stream": {
               "version": "0.0.7",
-              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "from": "combined-stream@>=0.0.4 <0.1.0",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                  "from": "delayed-stream@0.0.5",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                 }
               }
             },
             "async": {
               "version": "0.9.0",
-              "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+              "from": "async@>=0.9.0 <0.10.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
             }
           }
         },
         "tunnel-agent": {
           "version": "0.4.0",
-          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+          "from": "tunnel-agent@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
         },
         "http-signature": {
           "version": "0.10.1",
-          "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+          "from": "http-signature@>=0.10.0 <0.11.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.5",
-              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+              "from": "assert-plus@>=0.1.5 <0.2.0",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "asn1": {
               "version": "0.1.11",
-              "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+              "from": "asn1@0.1.11",
               "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
             },
             "ctype": {
               "version": "0.5.3",
-              "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+              "from": "ctype@0.5.3",
               "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
             }
           }
         },
         "oauth-sign": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
+          "from": "oauth-sign@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
         },
         "hawk": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+          "from": "hawk@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
           "dependencies": {
             "hoek": {
               "version": "0.9.1",
-              "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+              "from": "hoek@>=0.9.0 <0.10.0",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
             },
             "boom": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+              "from": "boom@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
             },
             "cryptiles": {
               "version": "0.2.2",
-              "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+              "from": "cryptiles@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
             },
             "sntp": {
               "version": "0.2.4",
-              "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+              "from": "sntp@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
             }
           }
         },
         "aws-sign2": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+          "from": "aws-sign2@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
         }
       }
     },
     "restify": {
       "version": "2.8.1",
-      "from": "https://registry.npmjs.org/restify/-/restify-2.8.1.tgz",
+      "from": "restify@2.8.1",
       "resolved": "https://registry.npmjs.org/restify/-/restify-2.8.1.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "0.1.5",
-          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+          "from": "assert-plus@0.1.5",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
         },
         "backoff": {
           "version": "2.3.0",
-          "from": "https://registry.npmjs.org/backoff/-/backoff-2.3.0.tgz",
+          "from": "backoff@2.3.0",
           "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.3.0.tgz"
         },
         "bunyan": {
           "version": "0.22.1",
-          "from": "https://registry.npmjs.org/bunyan/-/bunyan-0.22.1.tgz",
+          "from": "bunyan@0.22.1",
           "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.22.1.tgz",
           "dependencies": {
             "mv": {
               "version": "0.0.5",
-              "from": "https://registry.npmjs.org/mv/-/mv-0.0.5.tgz",
+              "from": "mv@0.0.5",
               "resolved": "https://registry.npmjs.org/mv/-/mv-0.0.5.tgz"
             }
           }
         },
         "csv": {
           "version": "0.3.7",
-          "from": "https://registry.npmjs.org/csv/-/csv-0.3.7.tgz",
+          "from": "csv@0.3.7",
           "resolved": "https://registry.npmjs.org/csv/-/csv-0.3.7.tgz"
         },
         "deep-equal": {
           "version": "0.0.0",
-          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz",
+          "from": "deep-equal@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
         },
         "escape-regexp-component": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
+          "from": "escape-regexp-component@1.0.2",
           "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
         },
         "formidable": {
           "version": "1.0.14",
-          "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz",
+          "from": "formidable@1.0.14",
           "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
         },
         "http-signature": {
           "version": "0.10.0",
-          "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+          "from": "http-signature@0.10.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz",
+              "from": "assert-plus@0.1.2",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
             },
             "asn1": {
               "version": "0.1.11",
-              "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+              "from": "asn1@0.1.11",
               "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
             },
             "ctype": {
               "version": "0.5.2",
-              "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz",
+              "from": "ctype@0.5.2",
               "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
             }
           }
         },
         "keep-alive-agent": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
+          "from": "keep-alive-agent@0.0.1",
           "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
         },
         "lru-cache": {
           "version": "2.3.1",
-          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz",
+          "from": "lru-cache@2.3.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz"
         },
         "mime": {
           "version": "1.2.11",
-          "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+          "from": "mime@>=1.2.9 <1.3.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
         },
         "negotiator": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz",
+          "from": "negotiator@0.3.0",
           "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz"
         },
         "node-uuid": {
           "version": "1.4.1",
-          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz",
+          "from": "node-uuid@1.4.1",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
         },
         "once": {
           "version": "1.3.0",
-          "from": "https://registry.npmjs.org/once/-/once-1.3.0.tgz",
+          "from": "once@1.3.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.0.tgz"
         },
         "qs": {
           "version": "0.6.6",
-          "from": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+          "from": "qs@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
         },
         "semver": {
           "version": "2.2.1",
-          "from": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz",
+          "from": "semver@2.2.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz"
         },
         "spdy": {
           "version": "1.19.3",
-          "from": "https://registry.npmjs.org/spdy/-/spdy-1.19.3.tgz",
+          "from": "spdy@1.19.3",
           "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.19.3.tgz"
         },
         "tunnel-agent": {
           "version": "0.4.0",
-          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+          "from": "tunnel-agent@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
         },
         "verror": {
           "version": "1.3.7",
-          "from": "https://registry.npmjs.org/verror/-/verror-1.3.7.tgz",
+          "from": "verror@1.3.7",
           "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.7.tgz",
           "dependencies": {
             "extsprintf": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+              "from": "extsprintf@1.0.2",
               "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
             }
           }
         },
         "dtrace-provider": {
           "version": "0.2.8",
-          "from": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz",
+          "from": "dtrace-provider@0.2.8",
           "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
         }
       }
     },
     "tap": {
       "version": "0.4.13",
-      "from": "https://registry.npmjs.org/tap/-/tap-0.4.13.tgz",
+      "from": "tap@0.4.13",
       "resolved": "https://registry.npmjs.org/tap/-/tap-0.4.13.tgz",
       "dependencies": {
         "buffer-equal": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
+          "from": "buffer-equal@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
         },
         "deep-equal": {
           "version": "0.0.0",
-          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz",
+          "from": "deep-equal@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
         },
         "difflet": {
           "version": "0.2.6",
-          "from": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
+          "from": "difflet@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
           "dependencies": {
             "traverse": {
               "version": "0.6.6",
-              "from": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+              "from": "traverse@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
             },
             "charm": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
+              "from": "charm@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
             },
             "deep-is": {
               "version": "0.1.3",
-              "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+              "from": "deep-is@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
             }
           }
         },
         "glob": {
           "version": "3.2.11",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "from": "glob@>=3.2.9 <3.3.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "from": "minimatch@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
@@ -1359,56 +1387,56 @@
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "from": "inherits@*",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "nopt": {
           "version": "2.2.1",
-          "from": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+          "from": "nopt@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
+              "from": "abbrev@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "runforcover": {
           "version": "0.0.2",
-          "from": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
+          "from": "runforcover@>=0.0.2 <0.1.0",
           "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
           "dependencies": {
             "bunker": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
+              "from": "bunker@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
               "dependencies": {
                 "burrito": {
                   "version": "0.2.12",
-                  "from": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
+                  "from": "burrito@>=0.2.5 <0.3.0",
                   "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
                   "dependencies": {
                     "traverse": {
                       "version": "0.5.2",
-                      "from": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz",
+                      "from": "traverse@>=0.5.1 <0.6.0",
                       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
                     },
                     "uglify-js": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz",
+                      "from": "uglify-js@>=1.1.1 <1.2.0",
                       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz"
                     }
                   }
@@ -1419,19 +1447,19 @@
         },
         "slide": {
           "version": "1.1.6",
-          "from": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "from": "slide@*",
           "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
         },
         "yamlish": {
           "version": "0.0.6",
-          "from": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.6.tgz",
+          "from": "yamlish@*",
           "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.6.tgz"
         }
       }
     },
     "uuid": {
       "version": "1.4.1",
-      "from": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz",
+      "from": "uuid@1.4.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
     }
   }


### PR DESCRIPTION
@chilts, @dannycoates, @rfk, r? - fixes https://github.com/mozilla/fxa-auth-db-mysql/issues/14 for the train-31 branch

This is a re-generated `npm-shrinkwrap.json` file on the train-31 branch that will use the intended train-31 branch of `fxa-auth-db-server`. (It was generated with `/bin/rm -rf ./node_modules ./npm-shrinkwrap.json ; npm cache clear; npm install; npm -d prune; npm shrinkwrap --dev`, and node 0.10.36 and npm 2.6.1 (latest stable). The prune is something needed because shrinkwrap was complaining about having redundant copies of `bluebird`, `ass` and `tap` and refusing to write a new `npm-shrinkwrap.json` file. (Given that it was a clean `npm install`, it seems odd that `npm shrinkwrap` was unhappy with the result, but anyways...).

So, besides putting the installed fxa-auth-db-server at train-31 (95bda6e1d56a67ba37e85c6ed2fad2bd02d13c9e), the other changes are to sub-dependencies of dev tools: `grunt`, `mysql-patcher`, `ass`, `grunt-contrib-jshint`.

```
grunt > which
mysql-patcher > bluebird
ass > cheerio > htmlparser2 > domutils > dom-serializer > entities
grunt-contrib-jshint > hooker > jshint > htmlparser2 > domutils > dom-serializer > entities


$ git diff --cached | grep -v '"from": "' | grep -v '^ '
diff --git a/npm-shrinkwrap.json b/npm-shrinkwrap.json
index 0a14645..7288d68 100644
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,40 +1,40 @@
-  "version": "0.0.0",
+  "version": "0.31.0",
@@ -43,52 +43,66 @@
-                  "version": "1.5.0",
-                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz"
+                  "version": "1.5.1",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                  "dependencies": {
+                    "dom-serializer": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                      "dependencies": {
+                        "entities": {
+                          "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                        }
+                      }
+                    }
+                  }
@@ -97,27 +111,27 @@
@@ -126,19 +140,19 @@
@@ -147,98 +161,98 @@
@@ -247,7 +261,7 @@
@@ -256,27 +270,27 @@
@@ -284,9 +298,9 @@
-      "version": "1.18.1",
-      "resolved": "git://github.com/chilts/fxa-auth-db-server.git#3536bbfe2cf468ca898dc9f331b6497be5142fad",
+      "version": "0.31.0",
+      "resolved": "git://github.com/mozilla/fxa-auth-db-server.git#95bda6e1d56a67ba37e85c6ed2fad2bd02d13c9e",
@@ -295,7 +309,7 @@
@@ -344,7 +358,7 @@
@@ -354,24 +368,24 @@
@@ -381,7 +395,7 @@
@@ -391,7 +405,7 @@
@@ -423,7 +437,7 @@
@@ -440,7 +454,7 @@
@@ -449,62 +463,62 @@
@@ -513,144 +527,144 @@
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
@@ -659,42 +673,42 @@
@@ -705,149 +719,163 @@
-                  "version": "1.5.0",
-                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz"
+                  "version": "1.5.1",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                  "dependencies": {
+                    "dom-serializer": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                      "dependencies": {
+                        "entities": {
+                          "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                        }
+                      }
+                    }
+                  }
@@ -856,49 +884,49 @@
@@ -907,46 +935,46 @@
@@ -957,44 +985,44 @@
@@ -1006,351 +1034,351 @@
-          "version": "2.9.3",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.3.tgz"
+          "version": "2.9.13",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.13.tgz"
@@ -1359,56 +1387,56 @@
@@ -1419,19 +1447,19 @@

```