### PR TITLE
Explicitly track account lifecycle events in the db

### DIFF
--- a/db/mysql.js
+++ b/db/mysql.js
@@ -154,7 +154,7 @@ module.exports = function (log, error) {
 
   // Insert : accounts
   // Values : uid = $1, normalizedEmail = $2, email = $3, emailCode = $4, emailVerified = $5, kA = $6, wrapWrapKb = $7, authSalt = $8, verifierVersion = $9, verifyHash = $10, verifierSetAt = $11, createdAt = $12, locale = $13
-  var CREATE_ACCOUNT = 'CALL createAccount_1(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+  var CREATE_ACCOUNT = 'CALL createAccount_2(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
 
   MySql.prototype.createAccount = function (uid, data) {
     data.normalizedEmail = data.email
@@ -360,7 +360,7 @@ module.exports = function (log, error) {
 
   // Delete : sessionTokens, keyFetchTokens, accountResetTokens, passwordChangeTokens, passwordForgotTokens, accountUnlockCodes, accounts
   // Where  : uid = $1
-  var DELETE_ACCOUNT = 'CALL deleteAccount_3(?)'
+  var DELETE_ACCOUNT = 'CALL deleteAccount_4(?)'
 
   MySql.prototype.deleteAccount = function (uid) {
     return this.write(DELETE_ACCOUNT, [uid])
@@ -416,7 +416,7 @@ module.exports = function (log, error) {
   // Update : accounts
   // Set    : verifyHash = $2, authSalt = $3, wrapWrapKb = $4, verifierSetAt = $5, verifierVersion = $6
   // Where  : uid = $1
-  var RESET_ACCOUNT = 'CALL resetAccount_3(?, ?, ?, ?, ?, ?)'
+  var RESET_ACCOUNT = 'CALL resetAccount_4(?, ?, ?, ?, ?, ?)'
 
   MySql.prototype.resetAccount = function (uid, data) {
     return this.write(
@@ -428,7 +428,7 @@ module.exports = function (log, error) {
   // Update : accounts
   // Set    : emailVerified = true
   // Where  : uid = $1
-  var VERIFY_EMAIL = 'CALL verifyEmail_1(?)'
+  var VERIFY_EMAIL = 'CALL verifyEmail_2(?)'
 
   MySql.prototype.verifyEmail = function (uid) {
     return this.write(VERIFY_EMAIL, [uid])
@@ -673,6 +673,17 @@ module.exports = function (log, error) {
       PRUNE,
       [pruneBefore, now]
     )
+  }
+
+  var GET_EVENTS_SINCE_POSITION = 'CALL getEventsSincePosition_1(?)'
+
+  MySql.prototype._getEventsSincePosition = function (pos) {
+    return this.read(GET_EVENTS_SINCE_POSITION, [pos])
+      .then(
+        function (results) {
+          return results[0]
+        }
+      )
   }
 
   return MySql

--- a/db/patch.js
+++ b/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the schema/ directory.
-module.exports.level = 8
+module.exports.level = 9

--- a/db/schema/patch-008-009.sql
+++ b/db/schema/patch-008-009.sql
@@ -1,0 +1,234 @@
+
+-- A new table to hold a history of account lifecycle events.
+-- Events are added in simple increasing auto-increment order.
+CREATE TABLE eventLog (
+  pos BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  uid BINARY(16) NOT NULL,
+  typ ENUM('create', 'verify', 'reset', 'delete') NOT NULL,
+  iat INT UNSIGNED NOT NULL
+) ENGINE=InnoDB;
+
+
+-- When an account is created, log a "create" event.
+-- Pre-verified accounts may also get a "verify" event.
+CREATE PROCEDURE `createAccount_2` (
+    IN `uid` BINARY(16) ,
+    IN `normalizedEmail` VARCHAR(255),
+    IN `email` VARCHAR(255),
+    IN `emailCode` BINARY(16),
+    IN `emailVerified` TINYINT(1),
+    IN `kA` BINARY(32),
+    IN `wrapWrapKb` BINARY(32),
+    IN `authSalt` BINARY(32),
+    IN `verifierVersion` TINYINT UNSIGNED,
+    IN `verifyHash` BINARY(32),
+    IN `verifierSetAt` BIGINT UNSIGNED,
+    IN `createdAt` BIGINT UNSIGNED,
+    IN `locale` VARCHAR(255)
+)
+BEGIN
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    START TRANSACTION;
+
+    INSERT INTO accounts(
+        uid,
+        normalizedEmail,
+        email,
+        emailCode,
+        emailVerified,
+        kA,
+        wrapWrapKb,
+        authSalt,
+        verifierVersion,
+        verifyHash,
+        verifierSetAt,
+        createdAt,
+        locale
+    )
+    VALUES(
+        uid,
+        LOWER(normalizedEmail),
+        email,
+        emailCode,
+        emailVerified,
+        kA,
+        wrapWrapKb,
+        authSalt,
+        verifierVersion,
+        verifyHash,
+        verifierSetAt,
+        createdAt,
+        locale
+    );
+
+    INSERT INTO eventLog(
+        uid,
+        typ,
+        iat
+    )
+    VALUES(
+        uid,
+        "create",
+        UNIX_TIMESTAMP()
+    );
+
+    IF emailVerified THEN
+        INSERT INTO eventLog(
+            uid,
+            typ,
+            iat
+        )
+        VALUES(
+            uid,
+            "verify",
+            UNIX_TIMESTAMP()
+        );
+    END IF;
+
+    COMMIT;
+END;
+
+
+-- When an email is verified, log a "verify" event.
+CREATE PROCEDURE `verifyEmail_2` (
+    IN `inUid` BINARY(16)
+)
+BEGIN
+
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    START TRANSACTION;
+
+    UPDATE accounts SET emailVerified = true WHERE uid = inUid;
+
+    INSERT INTO eventLog(
+        uid,
+        typ,
+        iat
+    )
+    VALUES(
+        inUid,
+        "verify",
+        UNIX_TIMESTAMP()
+    );
+
+    COMMIT;
+END;
+
+
+-- When an account is reset, log a "reset" event.
+CREATE PROCEDURE `resetAccount_4` (
+    IN `inUid` BINARY(16),
+    IN `inVerifyHash` BINARY(32),
+    IN `inAuthSalt` BINARY(32),
+    IN `inWrapWrapKb` BINARY(32),
+    IN `inVerifierSetAt` BIGINT UNSIGNED,
+    IN `inVerifierVersion` TINYINT UNSIGNED
+)
+BEGIN
+
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    START TRANSACTION;
+
+    DELETE FROM sessionTokens WHERE uid = inUid;
+    DELETE FROM keyFetchTokens WHERE uid = inUid;
+    DELETE FROM accountResetTokens WHERE uid = inUid;
+    DELETE FROM passwordChangeTokens WHERE uid = inUid;
+    DELETE FROM passwordForgotTokens WHERE uid = inUid;
+    DELETE FROM accountUnlockCodes WHERE uid = inUid;
+
+    UPDATE
+        accounts
+    SET
+        verifyHash = inVerifyHash,
+        authSalt = inAuthSalt,
+        wrapWrapKb = inWrapWrapKb,
+        verifierSetAt = inVerifierSetAt,
+        verifierVersion = inVerifierVersion
+    WHERE
+        uid = inUid
+    ;
+
+    INSERT INTO eventLog(
+        uid,
+        typ,
+        iat
+    )
+    VALUES(
+        inUid,
+        "reset",
+        UNIX_TIMESTAMP()
+    );
+
+    COMMIT;
+END;
+
+
+-- When an account is deleted, log a "delete" event.
+CREATE PROCEDURE `deleteAccount_4` (
+    IN `inUid` BINARY(16)
+)
+BEGIN
+
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    START TRANSACTION;
+
+    DELETE FROM sessionTokens WHERE uid = inUid;
+    DELETE FROM keyFetchTokens WHERE uid = inUid;
+    DELETE FROM accountResetTokens WHERE uid = inUid;
+    DELETE FROM passwordChangeTokens WHERE uid = inUid;
+    DELETE FROM passwordForgotTokens WHERE uid = inUid;
+    DELETE FROM accountUnlockCodes WHERE uid = inUid;
+    DELETE FROM accounts WHERE uid = inUid;
+
+    INSERT INTO eventLog(
+        uid,
+        typ,
+        iat
+    )
+    VALUES(
+        inUid,
+        "delete",
+        UNIX_TIMESTAMP()
+    );
+
+    COMMIT;
+
+END;
+
+
+-- A helper for reading out of the eventlog.
+-- Likely only useful for testing purposes.
+CREATE PROCEDURE `getEventsSincePosition_1` (
+    IN `inPos` BIGINT UNSIGNED
+)
+BEGIN
+    SELECT pos, uid, typ, iat
+    FROM eventLog
+    WHERE pos > inPos
+    ORDER BY pos ASC
+    LIMIT 100;
+END;
+
+
+-- Schema patch-level increment.
+UPDATE dbMetadata SET value = '9' WHERE name = 'schema-patch-level';

--- a/db/schema/patch-009-008.sql
+++ b/db/schema/patch-009-008.sql
@@ -1,0 +1,11 @@
+-- -- drop new stored procedures
+-- DROP PROCEDURE `getEventsSincePosition_1`;
+-- DROP PROCEDURE `deleteAccount_4`;
+-- DROP PROCEDURE `resetAccount_4`;
+-- DROP PROCEDURE `verifyEmail_2`;
+-- DROP PROCEDURE `createAccount_2`;
+
+-- -- drop new table
+-- DROP TABLE eventLog;
+
+-- UPDATE dbMetadata SET value = '8' WHERE name = 'schema-patch-level';

--- a/db/schema/patch-009-008.sql
+++ b/db/schema/patch-009-008.sql
@@ -1,11 +1,14 @@
 -- -- drop new stored procedures
+-- DROP PROCEDURE `ackPublishedEvents_1`;
+-- DROP PROCEDURE `getUnpublishedEvents_1`;
 -- DROP PROCEDURE `getEventsSincePosition_1`;
 -- DROP PROCEDURE `deleteAccount_4`;
 -- DROP PROCEDURE `resetAccount_4`;
 -- DROP PROCEDURE `verifyEmail_2`;
 -- DROP PROCEDURE `createAccount_2`;
 
--- -- drop new table
+-- -- drop new tables
+-- DROP TABLE eventLogPublishState;
 -- DROP TABLE eventLog;
 
 -- UPDATE dbMetadata SET value = '8' WHERE name = 'schema-patch-level';

--- a/test/local/event_log.js
+++ b/test/local/event_log.js
@@ -8,6 +8,7 @@ var log = { trace: console.log, error: console.log, info: console.log }
 var DB = require('../../db/mysql')(log, dbServer.errors)
 var fake = require('fxa-auth-db-server/test/fake')
 var config = require('../../config')
+var P = require('../../promise')
 
 
 DB.connect(config)
@@ -17,55 +18,193 @@ DB.connect(config)
       test(
         'account activity should generate event logs',
         function (t) {
-          t.plan(13);
-          var curPos = 0
+          t.plan(14);
           var user = fake.newUserDataBuffer()
           var verifiedUser = fake.newUserDataBuffer()
           verifiedUser.account.emailVerified = true
-          // First skip over any events that have already been logged.
-          return db._getEventsSincePosition(0)
-          .then(function (events) {
-            curPos = events[events.length - 1].pos
-          })
+          // First mark any events from previous tests as published.
+          return db.processUnpublishedEvents(
+            function (events) {
+              t.ok(events, 'should find a list of events')
+              return P.resolve()
+            }
+          )
           .then(function () {
-            // Logs a "create" event.
+            // Logs a 'create' event.
             return db.createAccount(user.accountId, user.account)
           })
           .then(function () {
-            // Logs a "create" event and a "verify" event.
+            // Logs a 'create' event and a 'verify' event.
             return db.createAccount(verifiedUser.accountId,
                                     verifiedUser.account)
           })
           .then(function () {
-            // Logs a "verify" event.
+            // Logs a 'verify' event.
             return db.verifyEmail(user.accountId)
           })
           .then(function () {
-            // Logs a "reset" event.
+            // Logs a 'reset' event.
             return db.resetAccount(user.accountId, user.account)
           })
           .then(function () {
-            // Logs a "delete" event.
+            // Logs a 'delete' event.
             return db.deleteAccount(verifiedUser.accountId)
           })
           .then(function () {
             // Find newly-logged events.
-            return db._getEventsSincePosition(curPos)
+            return db.processUnpublishedEvents(
+              function (events) {
+                t.equal(events.length, 6)
+                t.equal(events[0].typ, 'create')
+                t.deepEqual(events[0].uid, user.accountId)
+                t.equal(events[1].typ, 'create')
+                t.deepEqual(events[1].uid, verifiedUser.accountId)
+                t.equal(events[2].typ, 'verify')
+                t.deepEqual(events[2].uid, verifiedUser.accountId)
+                t.equal(events[3].typ, 'verify')
+                t.deepEqual(events[3].uid, user.accountId)
+                t.equal(events[4].typ, 'reset')
+                t.deepEqual(events[4].uid, user.accountId)
+                t.equal(events[5].typ, 'delete')
+                t.deepEqual(events[5].uid, verifiedUser.accountId)
+                return P.resolve()
+              }
+            )
           })
-          .then(function (events) {
-            t.equal(events.length, 6)
-            t.equal(events[0].typ, "create")
-            t.equal(events[0].uid.toString(), user.accountId.toString())
-            t.equal(events[1].typ, "create")
-            t.equal(events[1].uid.toString(), verifiedUser.accountId.toString())
-            t.equal(events[2].typ, "verify")
-            t.equal(events[2].uid.toString(), verifiedUser.accountId.toString())
-            t.equal(events[3].typ, "verify")
-            t.equal(events[3].uid.toString(), user.accountId.toString())
-            t.equal(events[4].typ, "reset")
-            t.equal(events[4].uid.toString(), user.accountId.toString())
-            t.equal(events[5].typ, "delete")
-            t.equal(events[5].uid.toString(), verifiedUser.accountId.toString())
+        }
+      )
+
+      test(
+        'processUnpublishedEvents should provide mutual exclusion',
+        function (t) {
+          t.plan(2)
+          return db.processUnpublishedEvents(
+            function (events) {
+              t.ok(events, 'first reader should receive events')
+              return db.processUnpublishedEvents(
+                function () {
+                  t.fail('second reader should not receive events')
+                  return P.resolve()
+                }
+              )
+              .then(
+                function () {
+                  t.fail('processUnpublishedEvents shoud have thrown')
+                },
+                function (err) {
+                  t.equal(err.message, 'event queue locked')
+                }
+              )
+            }
+          )
+        }
+      )
+
+      test(
+        'processUnpublishedEvents should mark events published on success',
+        function (t) {
+          t.plan(5)
+          var user = fake.newUserDataBuffer()
+          // Logs a 'create' event.
+          return db.createAccount(user.accountId, user.account)
+          .then(function () {
+            return db.processUnpublishedEvents(
+              function (events) {
+                var lastEvent = events[events.length - 1]
+                t.equal(lastEvent.typ, 'create')
+                t.deepEqual(lastEvent.uid, user.accountId)
+                return P.resolve()
+              }
+            )
+          })
+          .then(function () {
+            // Logs a 'verify' event.
+            return db.verifyEmail(user.accountId)
+          })
+          .then(function () {
+            return db.processUnpublishedEvents(
+              function (events) {
+                // There should only be one unpublished event.
+                t.equal(events.length, 1)
+                t.equal(events[0].typ, 'verify')
+                t.deepEqual(events[0].uid, user.accountId)
+                return P.resolve()
+              }
+            )
+          })
+        }
+      )
+
+      test(
+        'processUnpublishedEvents should leave events unpublished on error',
+        function (t) {
+          t.plan(6)
+          var user = fake.newUserDataBuffer()
+          var numEvents
+          // Logs a 'create' event.
+          return db.createAccount(user.accountId, user.account)
+          .then(function () {
+            return db.processUnpublishedEvents(
+              function (events) {
+                numEvents = events.length
+                t.equal(events[numEvents - 1].typ, 'create')
+                t.deepEqual(events[numEvents - 1].uid, user.accountId)
+                return P.reject(new Error('ruh-roh'))
+              }
+            )
+          })
+          .then(
+            function () {
+              t.fail('it should have propagated the error')
+            },
+            function (err) {
+              t.equal(err.message, 'ruh-roh')
+            }
+          )
+          .then(function () {
+            return db.processUnpublishedEvents(
+              function (events) {
+                // The events should be the same as before.
+                t.equal(events.length, numEvents)
+                t.equal(events[numEvents - 1].typ, 'create')
+                t.deepEqual(events[numEvents - 1].uid, user.accountId)
+                return P.resolve()
+              }
+            )
+          })
+        }
+      )
+
+      test(
+        'processUnpublishedEvents should accept ack of only some events',
+        function (t) {
+          t.plan(7)
+          var user = fake.newUserDataBuffer()
+          user.account.emailVerified = true
+          // Logs a 'create' and a 'verify' event.
+          return db.createAccount(user.accountId, user.account)
+          .then(function () {
+            return db.processUnpublishedEvents(
+              function (events) {
+                t.equal(events[events.length - 2].typ, 'create')
+                t.deepEqual(events[events.length - 2].uid, user.accountId)
+                t.equal(events[events.length - 1].typ, 'verify')
+                t.deepEqual(events[events.length - 1].uid, user.accountId)
+                // Acknowledge all but the last event.
+                return P.resolve(events.length - 1)
+              }
+            )
+          })
+          .then(function () {
+            return db.processUnpublishedEvents(
+              function (events) {
+                // There should only be one unpublished event.
+                t.equal(events.length, 1)
+                t.equal(events[0].typ, 'verify')
+                t.deepEqual(events[0].uid, user.accountId)
+                return P.resolve()
+              }
+            )
           })
         }
       )

--- a/test/local/event_log.js
+++ b/test/local/event_log.js
@@ -1,0 +1,81 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+require('ass')
+var dbServer = require('fxa-auth-db-server')
+var test = require('../ptaptest')
+var log = { trace: console.log, error: console.log, info: console.log }
+var DB = require('../../db/mysql')(log, dbServer.errors)
+var fake = require('fxa-auth-db-server/test/fake')
+var config = require('../../config')
+
+
+DB.connect(config)
+  .then(
+    function (db) {
+
+      test(
+        'account activity should generate event logs',
+        function (t) {
+          t.plan(13);
+          var curPos = 0
+          var user = fake.newUserDataBuffer()
+          var verifiedUser = fake.newUserDataBuffer()
+          verifiedUser.account.emailVerified = true
+          // First skip over any events that have already been logged.
+          return db._getEventsSincePosition(0)
+          .then(function (events) {
+            curPos = events[events.length - 1].pos
+          })
+          .then(function () {
+            // Logs a "create" event.
+            return db.createAccount(user.accountId, user.account)
+          })
+          .then(function () {
+            // Logs a "create" event and a "verify" event.
+            return db.createAccount(verifiedUser.accountId,
+                                    verifiedUser.account)
+          })
+          .then(function () {
+            // Logs a "verify" event.
+            return db.verifyEmail(user.accountId)
+          })
+          .then(function () {
+            // Logs a "reset" event.
+            return db.resetAccount(user.accountId, user.account)
+          })
+          .then(function () {
+            // Logs a "delete" event.
+            return db.deleteAccount(verifiedUser.accountId)
+          })
+          .then(function () {
+            // Find newly-logged events.
+            return db._getEventsSincePosition(curPos)
+          })
+          .then(function (events) {
+            t.equal(events.length, 6)
+            t.equal(events[0].typ, "create")
+            t.equal(events[0].uid.toString(), user.accountId.toString())
+            t.equal(events[1].typ, "create")
+            t.equal(events[1].uid.toString(), verifiedUser.accountId.toString())
+            t.equal(events[2].typ, "verify")
+            t.equal(events[2].uid.toString(), verifiedUser.accountId.toString())
+            t.equal(events[3].typ, "verify")
+            t.equal(events[3].uid.toString(), user.accountId.toString())
+            t.equal(events[4].typ, "reset")
+            t.equal(events[4].uid.toString(), user.accountId.toString())
+            t.equal(events[5].typ, "delete")
+            t.equal(events[5].uid.toString(), verifiedUser.accountId.toString())
+          })
+        }
+      )
+
+      test(
+        'teardown',
+        function (t) {
+          return db.close()
+        }
+      )
+
+    }
+  )

--- a/test/local/mysql_tests.js
+++ b/test/local/mysql_tests.js
@@ -173,7 +173,7 @@ DB.connect(config)
             'END;',
           ].join('\n')
 
-          t.plan(6)
+          t.plan(5)
 
           db.write(dropProcedure, [])
             .then(function() {
@@ -201,9 +201,20 @@ DB.connect(config)
               t.end()
             }, function(err) {
               t.pass('The call to the stored procedure failed as expected')
-              t.equal('' + err, "Error: ER_BAD_NULL_ERROR", 'error stringified is correct')
               t.equal(err.code, 500, 'error code is correct')
-              t.equal(err.errno, 1048, 'error errno is correct')
+              var possibleErrors = [
+                { msg: "ER_BAD_NULL_ERROR", errno: 1048 },
+                { msg: "ER_NO_DEFAULT_FOR_FIELD", errno: 1364 }
+              ];
+              var matchedError = false;
+              possibleErrors.forEach(function(possibleErr) {
+                if (err.message === possibleErr.msg) {
+                  if (err.errno === possibleErr.errno ) {
+                    matchedError = true;
+                  }
+                }
+              });
+              t.ok(matchedError, 'error message and errno are correct')
               t.end()
             })
         }


### PR DESCRIPTION
Here's an idea that @dannycoates and I have been kicking around, for how the auth-server might interact with the upcoming notification server (https://github.com/mozilla/fxa-notification-server).

The idea here is to transactionally track our major account-lifecycle events in the database.  There's a simple "eventLog" table to which we append create, verify, reset and delete events as they happen, with an auto-increment sequence number to ensure they're stored properly and consistently ordered.

When the notification server is ready, some background process in the server can read from this queue and schlep the events on over there asynchronously.  Details of that TBD but I added a couple of the low-level functions it'll probably need.

The advantage of this approach is that we won't lose creation or deletion events, and we're decoupled from the notification server.  The disadvantage is we're doing queueing and logging in the db, blech.  But since these events should be rare, and the data we keep for them small, it seems like a worthwhile tradeoff overall.  At least it's nice and simple!

@chilts thoughts?  @ckolos thoughts?  I remain open to the suggestion that this is a terrible idea :-)

Possible optimization: we could keep only the most recent event for any (uid, typ) pair, rather than e.g. a hundred "reset" events for a user who resets their account a hundred times.  But doing so would cost an additional index on this table, or some slow background compaction process.  And eventually we might solve this in a more general way as part of the evolving notifications infra, so we don't need to make this solution awesome right now, it just needs to work.

(This is a WIP and should not be merged yet, although if we all agree on the approach then I'd like to get it out on train-33).