### PR TITLE
fix(db): do not set createdAt, verifierSetAt or normalizedEmail here

### DIFF
--- a/db/mysql.js
+++ b/db/mysql.js
@@ -158,9 +158,6 @@ module.exports = function (log, error) {
   var CREATE_ACCOUNT = 'CALL createAccount_2(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
 
   MySql.prototype.createAccount = function (uid, data) {
-    data.normalizedEmail = data.email
-    data.createdAt = data.verifierSetAt = Date.now()
-
     return this.write(
       CREATE_ACCOUNT,
       [
@@ -422,7 +419,7 @@ module.exports = function (log, error) {
   MySql.prototype.resetAccount = function (uid, data) {
     return this.write(
       RESET_ACCOUNT,
-      [uid, data.verifyHash, data.authSalt, data.wrapWrapKb, Date.now(), data.verifierVersion]
+      [uid, data.verifyHash, data.authSalt, data.wrapWrapKb, data.verifierSetAt, data.verifierVersion]
     )
   }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -87,7 +87,7 @@
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@1.1",
+                  "from": "readable-stream@~1.1.9",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
@@ -263,8 +263,8 @@
     },
     "fxa-auth-db-server": {
       "version": "0.33.0",
-      "from": "fxa-auth-db-server@git://github.com/mozilla/fxa-auth-db-server.git#train-33",
-      "resolved": "git://github.com/mozilla/fxa-auth-db-server.git#f3d111b3f895a4f6c9bb76efc80e505b52eed074",
+      "from": "fxa-auth-db-server@git://github.com/mozilla/fxa-auth-db-server.git",
+      "resolved": "git://github.com/mozilla/fxa-auth-db-server.git#f1bf9b526f67daf278ce5539c6521f145570a842",
       "dependencies": {
         "restify": {
           "version": "2.8.2",
@@ -800,7 +800,7 @@
       "dependencies": {
         "bluebird": {
           "version": "2.9.14",
-          "from": "bluebird@^2.3.0",
+          "from": "bluebird@2.9.14",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.14.tgz"
         },
         "jws": {
@@ -847,7 +847,7 @@
                     },
                     "readable-stream": {
                       "version": "1.1.13",
-                      "from": "readable-stream@~1.1.9",
+                      "from": "readable-stream@1.1",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
@@ -955,7 +955,7 @@
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@^2.0.1",
+                  "from": "inherits@~2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimalistic-assert": {
@@ -972,7 +972,7 @@
             },
             "base64url": {
               "version": "1.0.4",
-              "from": "base64url@1.0.4",
+              "from": "base64url@~1.0.4",
               "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.4.tgz",
               "dependencies": {
                 "concat-stream": {
@@ -1288,7 +1288,7 @@
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
+              "from": "lodash@2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "underscore.string": {
@@ -1535,12 +1535,12 @@
       "dependencies": {
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@~0.1.2",
+          "from": "findup-sync@^0.1.2",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@~3.2.1",
+              "from": "glob@~3.2.9",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
@@ -1762,9 +1762,9 @@
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
         },
         "bluebird": {
-          "version": "2.9.14",
+          "version": "2.9.15",
           "from": "bluebird@^2.3.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.14.tgz"
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.15.tgz"
         },
         "clone": {
           "version": "0.1.19",
@@ -1821,7 +1821,7 @@
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@2.4.1",
+          "from": "lodash@~2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "mkdirp": {
@@ -1933,7 +1933,7 @@
         },
         "tunnel-agent": {
           "version": "0.4.0",
-          "from": "tunnel-agent@~0.4.0",
+          "from": "tunnel-agent@0.4.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
         },
         "tough-cookie": {
@@ -1981,9 +1981,9 @@
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
           "dependencies": {
             "hoek": {
-              "version": "2.11.1",
+              "version": "2.12.0",
               "from": "hoek@2.x.x",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.1.tgz"
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.12.0.tgz"
             },
             "boom": {
               "version": "2.6.1",
@@ -2038,7 +2038,7 @@
       "dependencies": {
         "assert-plus": {
           "version": "0.1.5",
-          "from": "assert-plus@0.1.5",
+          "from": "assert-plus@^0.1.5",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
         },
         "backoff": {
@@ -2065,7 +2065,7 @@
         },
         "deep-equal": {
           "version": "0.0.0",
-          "from": "deep-equal@0.0.0",
+          "from": "deep-equal@~0.0.0",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
         },
         "escape-regexp-component": {
@@ -2232,7 +2232,7 @@
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "inherits@*",
+          "from": "inherits@2",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "mkdirp": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bluebird": "2.1.3",
     "clone": "0.2.0",
     "convict": "0.4.2",
-    "fxa-auth-db-server": "git://github.com/mozilla/fxa-auth-db-server.git#train-33",
+    "fxa-auth-db-server": "git://github.com/mozilla/fxa-auth-db-server.git",
     "fxa-jwtool": "0.4.0",
     "mozlog": "2.0.0",
     "mysql": "2.3.2",


### PR DESCRIPTION
Since the fxa-auth-server always sends these fields, then we shouldn't
set them to anything in this backend.

Fixes #12 - Be consistent about how timestamps are generated.