### PR TITLE
fix(release): add tasks "grunt version" and "grunt version:patch" to create release tags

### DIFF
--- a/grunttasks/bump.js
+++ b/grunttasks/bump.js
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// takes care of bumping the version number in package.json
+
+module.exports = function (grunt) {
+  'use strict';
+
+  grunt.config('bump', {
+    options: {
+      files: ['package.json', 'npm-shrinkwrap.json'],
+      bumpVersion: true,
+      commit: true,
+      commitMessage: 'Release v%VERSION%',
+      commitFiles: ['package.json', 'npm-shrinkwrap.json', 'CHANGELOG'],
+      createTag: true,
+      tagName: 'v%VERSION%',
+      tagMessage: 'Version %VERSION%',
+      push: false,
+      pushTo: 'origin',
+      gitDescribeOptions: '--tags --always --abrev=1 --dirty=-d'
+    }
+  });
+};
+

--- a/grunttasks/copyright.js
+++ b/grunttasks/copyright.js
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = function (grunt) {
+  'use strict';
+
+  grunt.config('copyright', {
+    app: {
+      src: [
+        "{,bin/,config/,db/,scripts/}*.js"
+      ],
+      options: {
+        pattern: "This Source Code Form is subject to the terms of the Mozilla Public"
+      }
+    },
+    tests: {
+      src: [
+        'test/{remote,local,backend}/*.js'
+      ],
+      options: {
+        pattern: 'Any copyright is dedicated to the Public Domain.'
+      }
+    }
+  })
+}

--- a/grunttasks/jshint.js
+++ b/grunttasks/jshint.js
@@ -3,9 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 module.exports = function (grunt) {
-  require('load-grunt-tasks')(grunt);
+  'use strict';
 
-  grunt.loadTasks('grunttasks');
-
-  grunt.registerTask('default', ['jshint', 'copyright']);
-};
+  grunt.config('jshint', {
+    files: [
+      "{,bin/,config/,db/,scripts/,test/**/}*.{js,json}"
+    ],
+    options: {
+      jshintrc: ".jshintrc"
+    }
+  })
+}

--- a/grunttasks/version.js
+++ b/grunttasks/version.js
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//
+// A task to stamp a new version.
+//
+// Before running this task you should update CHANGELOG with the
+// changes for this release. Protip: you only need to make changes
+// to CHANGELOG; this task will add and commit for you.
+//
+// * version is updated in package.json
+// * git tag with version name is created.
+// * git commit with updated package.json created.
+//
+// NOTE: This task will not push this commit for you.
+//
+
+module.exports = function (grunt) {
+  'use strict';
+
+  grunt.registerTask('version', [
+    'bump-only:minor',
+    'bump-commit'
+  ]);
+
+  grunt.registerTask('version:patch', [
+    'bump-only:patch',
+    'bump-commit'
+  ]);
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -966,6 +966,16 @@
         }
       }
     },
+    "grunt-bump": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/grunt-bump/-/grunt-bump-0.3.0.tgz",
+      "dependencies": {
+        "semver": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.2.2.tgz"
+        }
+      }
+    },
     "grunt-contrib-jshint": {
       "version": "0.10.0",
       "from": "grunt-contrib-jshint@0.10.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "ass": "git://github.com/jrgm/ass.git#5be99ee",
     "grunt": "0.4.5",
+    "grunt-bump": "0.3.0",
     "grunt-contrib-jshint": "0.10.0",
     "grunt-copyright": "0.1.0",
     "grunt-nsp-shrinkwrap": "0.0.3",


### PR DESCRIPTION
Same as fxa-auth-server; similar to fxa-content-server but doesn't write the CHANGELOG for you from 'fix(foo): yoop' comments. @chilts @pdehaan r?