### PR TITLE
refactor(db): Change table access in stored procedures to be consistent

### DIFF
--- a/db/mysql.js
+++ b/db/mysql.js
@@ -449,7 +449,7 @@ module.exports = function (log, error) {
   // Delete : accountUnlockCodes
   // Where  : uid = $4
   //
-  var FORGOT_PASSWORD_VERIFIED = 'CALL forgotPasswordVerified_3(?, ?, ?, ?, ?)'
+  var FORGOT_PASSWORD_VERIFIED = 'CALL forgotPasswordVerified_4(?, ?, ?, ?, ?)'
 
   MySql.prototype.forgotPasswordVerified = function (tokenId, accountResetToken) {
     return this.write(
@@ -480,7 +480,7 @@ module.exports = function (log, error) {
   // Update : accountUnlockCodes
   // Set    : unlockCode = $3
   // Where  : uid = $1
-  var LOCK_ACCOUNT = 'CALL lockAccount_1(?, ?, ?)'
+  var LOCK_ACCOUNT = 'CALL lockAccount_2(?, ?, ?)'
 
   MySql.prototype.lockAccount = function (uid, data) {
     return this.write(LOCK_ACCOUNT, [uid, data.unlockCode, data.lockedAt])
@@ -491,7 +491,7 @@ module.exports = function (log, error) {
   // Where  : uid = $1
   // Delete : accountUnlockCodes
   // Where  : uid = $1
-  var UNLOCK_ACCOUNT = 'CALL unlockAccount_1(?)'
+  var UNLOCK_ACCOUNT = 'CALL unlockAccount_2(?)'
 
   MySql.prototype.unlockAccount = function (uid) {
     return this.write(UNLOCK_ACCOUNT, [uid])

--- a/db/patch.js
+++ b/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the schema/ directory.
-module.exports.level = 9
+module.exports.level = 10

--- a/db/schema/README.md
+++ b/db/schema/README.md
@@ -1,0 +1,63 @@
+## Schema
+
+This project uses the [mysql-patcher](https://www.npmjs.com/package/mysql-patcher) project to perform its database
+schema migrations, however this is only used in development, testing and staging but not in production. Production is
+performed manually making sure each step succeeds properly.
+
+When adding a new patch file you need to provide two things:
+
+1. the forward and reverse patches in `db/schema/patch-xxx-xxx.sql`
+2. update `db/patch.js` to point to the new patches
+
+Each forward patch should perform it's actions and finally update the `dbMetadata` to the new patch level.
+
+Every reverse patch should perform the same actions but in exactly the same reverse order, but still update
+the `dbMetadata` table last. Also note that for this project we decided to comment out the reverse patch
+so that it couldn't be run accidentally.
+
+## Database Table Access Order
+
+MySql tells us that we
+[should expect deadlocks to occur](https://docs.oracle.com/cd/E17952_01/refman-5.0-en/innodb-deadlocks.html) every so
+often and that they are normal, unless they occur frequently enough to disrupt your normal operations. However, there
+are also things we can do to try and minimise the chance that they do occur. One of these approaches is to try the following:
+
+"When modifying multiple tables within a transaction, or different sets of rows in the same table, do those operations
+in a consistent order each time."
+
+To document this, we're trying to keep to the following order though obviously deviations can occur if necessary:
+
+* sessionTokens
+* keyFetchTokens
+* accountResetTokens
+* passwordChangeTokens
+* passwordForgotTokens
+* accountUnlockCodes
+* accounts
+* eventLog
+
+As a slice of history related to this decision, you can follow along in cronological order in these four issues/pulls:
+
+* https://github.com/mozilla/fxa-auth-server/issues/785
+* https://github.com/mozilla/fxa-auth-db-server/issues/101
+* https://github.com/mozilla/fxa-auth-db-mysql/issues/28
+* https://github.com/mozilla/fxa-auth-db-mysql/pull/36
+
+## Stored Procedures and Future Patches
+
+When a new stored procedure is added no further actions need to be taken. However, when a new version of a stored
+procedure is added, the older version should also be removed. However, due to the way we may have two subsequent
+versions of a stack accessing the database the old stored procedure should be removed in the next patch. As an example
+consider the following:
+
+* a stored procedure `doSomething_2` already exists
+* a new version `doSomething_3` is added in patch 12 during release 50
+* upon release:
+    * the old stack (release 49) is still using `doSomething_2`
+    * the new stack (release 50) is using `doSomething_3`
+* a new patch 13 should be added for release during release 51 which removes `doSomething_2`
+
+This works because by the time we get to release 51, the stack for release 49 has already been pulled down and nothing
+is using `doSomething_2` any longer.
+
+(Ends)

--- a/db/schema/patch-009-010.sql
+++ b/db/schema/patch-009-010.sql
@@ -1,0 +1,97 @@
+
+-- forgotPasswordVerified v4
+CREATE PROCEDURE `forgotPasswordVerified_4` (
+    IN `inPasswordForgotTokenId` BINARY(32),
+    IN `inAccountResetTokenId` BINARY(32),
+    IN `inTokenData` BINARY(32),
+    IN `inUid` BINARY(16),
+    IN `inCreatedAt` BIGINT UNSIGNED
+)
+BEGIN
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        -- ERROR
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    START TRANSACTION;
+
+    -- Since we only ever want one accountResetToken per uid, then we
+    -- do a replace - generally due to a collision on the unique uid field.
+    REPLACE INTO accountResetTokens(
+        tokenId,
+        tokenData,
+        uid,
+        createdAt
+    )
+    VALUES(
+        inAccountResetTokenId,
+        inTokenData,
+        inUid,
+        inCreatedAt
+    );
+
+    DELETE FROM passwordForgotTokens WHERE tokenId = inPasswordForgotTokenId;
+
+    DELETE FROM accountUnlockCodes WHERE uid = inUid;
+
+    UPDATE accounts SET emailVerified = true, lockedAt = null WHERE uid = inUid;
+
+    COMMIT;
+END;
+
+-- lockAccount v2
+CREATE PROCEDURE `lockAccount_2` (
+    IN `inUid` BINARY(16),
+    IN `inUnlockCode` BINARY(16),
+    IN `inLockedAt` BIGINT UNSIGNED
+)
+BEGIN
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        -- ERROR
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    START TRANSACTION;
+
+    -- Any old values for the account should be removed
+    -- before new values are inserted.
+    REPLACE INTO accountUnlockCodes (
+      uid,
+      unlockCode
+    )
+    VALUES(
+      inUid,
+      inUnlockCode
+    );
+
+    UPDATE accounts SET lockedAt = inLockedAt WHERE uid = inUid;
+
+    COMMIT;
+END;
+
+-- unlockAccount v2
+CREATE PROCEDURE `unlockAccount_2` (
+    IN `inUid` BINARY(16)
+)
+BEGIN
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        -- ERROR
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    START TRANSACTION;
+
+    DELETE FROM accountUnlockCodes WHERE uid = inUid;
+    UPDATE accounts SET lockedAt = null WHERE uid = inUid;
+
+    COMMIT;
+END;
+
+-- Schema patch-level increment.
+UPDATE dbMetadata SET value = '10' WHERE name = 'schema-patch-level';

--- a/db/schema/patch-010-009.sql
+++ b/db/schema/patch-010-009.sql
@@ -1,0 +1,7 @@
+-- -- drop the procedures we created
+-- DROP PROCEDURE `unlockAccount_2`;
+-- DROP PROCEDURE `lockAccount_2`;
+-- DROP PROCEDURE `forgotPasswordVerified_4`;
+
+-- -- Schema patch-level increment.
+-- UPDATE dbMetadata SET value = '9' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
Every now and again, we get a deadlock in the database. Whilst these are
expected from time to time we may be able to mitigate it further by making
sure we access our tables in a consistent order. This may not always be
possible but we can do it with these three stored procedures.

Fixes #28