### PR TITLE
fix(package): Remove uuid completely since no longer needed

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,36 +4,37 @@
   "dependencies": {
     "ass": {
       "version": "1.0.0",
+      "from": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
       "resolved": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
       "dependencies": {
         "async": {
           "version": "0.9.0",
-          "from": "async@>=0.9.0 <0.10.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
         },
         "blanket": {
           "version": "1.1.6",
-          "from": "blanket@1.1.6",
+          "from": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
           "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
           "dependencies": {
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@>=1.0.2 <1.1.0",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             },
             "falafel": {
               "version": "0.1.6",
-              "from": "falafel@>=0.1.6 <0.2.0",
+              "from": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz",
               "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz"
             },
             "xtend": {
               "version": "2.1.2",
-              "from": "xtend@>=2.1.1 <2.2.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
               "dependencies": {
                 "object-keys": {
                   "version": "0.4.0",
-                  "from": "object-keys@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                 }
               }
@@ -42,37 +43,37 @@
         },
         "cheerio": {
           "version": "0.14.0",
-          "from": "cheerio@0.14.0",
+          "from": "https://registry.npmjs.org/cheerio/-/cheerio-0.14.0.tgz",
           "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.14.0.tgz",
           "dependencies": {
             "htmlparser2": {
               "version": "3.7.3",
-              "from": "htmlparser2@>=3.7.0 <3.8.0",
+              "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
               "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.2.1",
-                  "from": "domhandler@>=2.2.0 <2.3.0",
+                  "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz"
                 },
                 "domutils": {
                   "version": "1.5.1",
-                  "from": "domutils@>=1.5.0 <1.6.0",
+                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
                   "dependencies": {
                     "dom-serializer": {
                       "version": "0.1.0",
-                      "from": "dom-serializer@>=0.0.0 <1.0.0",
+                      "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                       "dependencies": {
                         "domelementtype": {
                           "version": "1.1.3",
-                          "from": "domelementtype@>=1.1.1 <1.2.0",
+                          "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                         },
                         "entities": {
                           "version": "1.1.1",
-                          "from": "entities@>=1.1.1 <1.2.0",
+                          "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                         }
                       }
@@ -81,32 +82,32 @@
                 },
                 "domelementtype": {
                   "version": "1.3.0",
-                  "from": "domelementtype@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.0 <1.2.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -115,27 +116,27 @@
             },
             "entities": {
               "version": "1.0.0",
-              "from": "entities@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
             },
             "CSSselect": {
               "version": "0.4.1",
-              "from": "CSSselect@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
               "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
               "dependencies": {
                 "CSSwhat": {
                   "version": "0.4.7",
-                  "from": "CSSwhat@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz",
                   "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
                 },
                 "domutils": {
                   "version": "1.4.3",
-                  "from": "domutils@>=1.4.0 <1.5.0",
+                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
                   "dependencies": {
                     "domelementtype": {
                       "version": "1.3.0",
-                      "from": "domelementtype@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                     }
                   }
@@ -144,19 +145,19 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@>=2.4.1 <2.5.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "temp": {
           "version": "0.8.1",
-          "from": "temp@0.8.1",
+          "from": "https://registry.npmjs.org/temp/-/temp-0.8.1.tgz",
           "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.1.tgz",
           "dependencies": {
             "rimraf": {
               "version": "2.2.8",
-              "from": "rimraf@>=2.2.6 <2.3.0",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             }
           }
@@ -165,57 +166,57 @@
     },
     "bluebird": {
       "version": "2.1.3",
-      "from": "bluebird@2.1.3",
+      "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.1.3.tgz",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.1.3.tgz"
     },
     "clone": {
       "version": "0.2.0",
-      "from": "clone@0.2.0",
+      "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
     },
     "convict": {
       "version": "0.4.2",
-      "from": "convict@0.4.2",
+      "from": "https://registry.npmjs.org/convict/-/convict-0.4.2.tgz",
       "resolved": "https://registry.npmjs.org/convict/-/convict-0.4.2.tgz",
       "dependencies": {
         "cjson": {
           "version": "0.3.0",
-          "from": "cjson@0.3.0",
+          "from": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
           "dependencies": {
             "jsonlint": {
               "version": "1.6.0",
-              "from": "jsonlint@1.6.0",
+              "from": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
               "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
               "dependencies": {
                 "nomnom": {
                   "version": "1.8.1",
-                  "from": "nomnom@>=1.5.0",
+                  "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.6.0",
-                      "from": "underscore@>=1.6.0 <1.7.0",
+                      "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                     },
                     "chalk": {
                       "version": "0.4.0",
-                      "from": "chalk@>=0.4.0 <0.5.0",
+                      "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "dependencies": {
                         "has-color": {
                           "version": "0.1.7",
-                          "from": "has-color@>=0.1.0 <0.2.0",
+                          "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
                           "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                         },
                         "ansi-styles": {
                           "version": "1.0.0",
-                          "from": "ansi-styles@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                         },
                         "strip-ansi": {
                           "version": "0.1.1",
-                          "from": "strip-ansi@>=0.1.0 <0.2.0",
+                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                         }
                       }
@@ -224,7 +225,7 @@
                 },
                 "JSV": {
                   "version": "4.0.2",
-                  "from": "JSV@>=4.0.0",
+                  "from": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                 }
               }
@@ -233,27 +234,27 @@
         },
         "validator": {
           "version": "1.5.1",
-          "from": "validator@1.5.1",
+          "from": "https://registry.npmjs.org/validator/-/validator-1.5.1.tgz",
           "resolved": "https://registry.npmjs.org/validator/-/validator-1.5.1.tgz"
         },
         "moment": {
           "version": "2.3.1",
-          "from": "moment@2.3.1",
+          "from": "https://registry.npmjs.org/moment/-/moment-2.3.1.tgz",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.3.1.tgz"
         },
         "optimist": {
           "version": "0.6.0",
-          "from": "optimist@0.6.0",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.0.tgz",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.0.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
@@ -261,61 +262,62 @@
       }
     },
     "fxa-auth-db-server": {
-      "version": "0.33.0",
-      "resolved": "git://github.com/mozilla/fxa-auth-db-server.git#b10eac986317ffffd77549d1c1dda103d3f297a2",
+      "version": "0.35.0",
+      "from": "git://github.com/mozilla/fxa-auth-db-server.git",
+      "resolved": "git://github.com/mozilla/fxa-auth-db-server.git#71191002ca74e730234b6a401df1ed8119d6d8e1",
       "dependencies": {
         "restify": {
           "version": "2.8.2",
-          "from": "https://registry.npmjs.org/restify/-/restify-2.8.2.tgz",
+          "from": "restify@2.8.2",
           "resolved": "https://registry.npmjs.org/restify/-/restify-2.8.2.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.5",
-              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+              "from": "assert-plus@>=0.1.5 <0.2.0",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "backoff": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
+              "from": "backoff@>=2.3.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
               "dependencies": {
                 "precond": {
                   "version": "0.2.3",
-                  "from": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+                  "from": "precond@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
                 }
               }
             },
             "bunyan": {
               "version": "0.23.1",
-              "from": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
+              "from": "bunyan@>=0.23.1 <0.24.0",
               "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
               "dependencies": {
                 "mv": {
                   "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
+                  "from": "mv@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
                   "dependencies": {
                     "mkdirp": {
                       "version": "0.5.0",
-                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                      "from": "mkdirp@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "from": "minimist@0.0.8",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                         }
                       }
                     },
                     "ncp": {
                       "version": "0.6.0",
-                      "from": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz",
+                      "from": "ncp@>=0.6.0 <0.7.0",
                       "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
                     },
                     "rimraf": {
                       "version": "2.2.8",
-                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                      "from": "rimraf@>=2.2.8 <2.3.0",
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                     }
                   }
@@ -324,135 +326,135 @@
             },
             "csv": {
               "version": "0.4.1",
-              "from": "https://registry.npmjs.org/csv/-/csv-0.4.1.tgz",
+              "from": "csv@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/csv/-/csv-0.4.1.tgz",
               "dependencies": {
                 "csv-generate": {
                   "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.4.tgz",
+                  "from": "csv-generate@*",
                   "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.4.tgz"
                 },
                 "csv-parse": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.0.tgz",
+                  "from": "csv-parse@*",
                   "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.0.tgz"
                 },
                 "stream-transform": {
                   "version": "0.0.7",
-                  "from": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.0.7.tgz",
+                  "from": "stream-transform@*",
                   "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.0.7.tgz"
                 },
                 "csv-stringify": {
                   "version": "0.0.6",
-                  "from": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.6.tgz",
+                  "from": "csv-stringify@*",
                   "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.6.tgz"
                 }
               }
             },
             "deep-equal": {
               "version": "0.2.2",
-              "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+              "from": "deep-equal@>=0.2.1 <0.3.0",
               "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz"
             },
             "escape-regexp-component": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
+              "from": "escape-regexp-component@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
             },
             "formidable": {
               "version": "1.0.17",
-              "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
+              "from": "formidable@>=1.0.14 <2.0.0",
               "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "from": "http-signature@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "from": "asn1@0.1.11",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.3",
-                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "from": "ctype@0.5.3",
                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
             "keep-alive-agent": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
+              "from": "keep-alive-agent@>=0.0.1 <0.0.2",
               "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
             },
             "lru-cache": {
-              "version": "2.5.0",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+              "version": "2.6.1",
+              "from": "lru-cache@>=2.5.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.1.tgz"
             },
             "mime": {
               "version": "1.3.4",
-              "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "from": "mime@>=1.2.11 <2.0.0",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "negotiator": {
               "version": "0.4.9",
-              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
+              "from": "negotiator@>=0.4.5 <0.5.0",
               "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
             },
             "node-uuid": {
               "version": "1.4.3",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+              "from": "node-uuid@>=1.4.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "once": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "qs": {
               "version": "1.2.2",
-              "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
+              "from": "qs@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
             },
             "semver": {
               "version": "2.3.2",
-              "from": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
+              "from": "semver@>=2.3.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
             },
             "spdy": {
               "version": "1.31.0",
-              "from": "https://registry.npmjs.org/spdy/-/spdy-1.31.0.tgz",
+              "from": "spdy@>=1.26.5 <2.0.0",
               "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.31.0.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "verror": {
               "version": "1.6.0",
-              "from": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
+              "from": "verror@>=1.4.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
               "dependencies": {
                 "extsprintf": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
+                  "from": "extsprintf@1.2.0",
                   "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz"
                 }
               }
             },
             "dtrace-provider": {
               "version": "0.2.8",
-              "from": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz",
+              "from": "dtrace-provider@>=0.2.8 <0.3.0",
               "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
             }
           }
@@ -461,74 +463,74 @@
     },
     "fxa-jwtool": {
       "version": "0.4.0",
-      "from": "fxa-jwtool@0.4.0",
+      "from": "https://registry.npmjs.org/fxa-jwtool/-/fxa-jwtool-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/fxa-jwtool/-/fxa-jwtool-0.4.0.tgz",
       "dependencies": {
         "bluebird": {
           "version": "2.9.14",
-          "from": "bluebird@2.9.14",
+          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.14.tgz",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.14.tgz"
         },
         "jws": {
           "version": "2.0.0",
-          "from": "jws@2.0.0",
+          "from": "https://registry.npmjs.org/jws/-/jws-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/jws/-/jws-2.0.0.tgz",
           "dependencies": {
             "jwa": {
               "version": "1.0.0",
-              "from": "jwa@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/jwa/-/jwa-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.0.0.tgz",
               "dependencies": {
                 "base64url": {
                   "version": "0.0.6",
-                  "from": "base64url@>=0.0.4 <0.1.0",
+                  "from": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz"
                 },
                 "buffer-equal-constant-time": {
                   "version": "1.0.1",
-                  "from": "buffer-equal-constant-time@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
                 }
               }
             },
             "base64url": {
               "version": "1.0.4",
-              "from": "base64url@>=1.0.4 <1.1.0",
+              "from": "https://registry.npmjs.org/base64url/-/base64url-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.4.tgz",
               "dependencies": {
                 "concat-stream": {
                   "version": "1.4.7",
-                  "from": "concat-stream@>=1.4.7 <1.5.0",
+                  "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
                   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "typedarray": {
                       "version": "0.0.6",
-                      "from": "typedarray@>=0.0.5 <0.1.0",
+                      "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
                       "version": "1.1.13",
-                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         }
                       }
@@ -537,54 +539,54 @@
                 },
                 "meow": {
                   "version": "2.0.0",
-                  "from": "meow@>=2.0.0 <2.1.0",
+                  "from": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "1.0.0",
-                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "1.0.2",
-                          "from": "camelcase@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
                         },
                         "map-obj": {
                           "version": "1.0.0",
-                          "from": "map-obj@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
                         }
                       }
                     },
                     "indent-string": {
                       "version": "1.2.1",
-                      "from": "indent-string@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
                       "dependencies": {
                         "get-stdin": {
                           "version": "4.0.1",
-                          "from": "get-stdin@>=4.0.1 <5.0.0",
+                          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                         },
                         "repeating": {
                           "version": "1.1.2",
-                          "from": "repeating@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.0",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
                             },
                             "meow": {
                               "version": "3.1.0",
-                              "from": "meow@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
                               "dependencies": {
                                 "object-assign": {
                                   "version": "2.0.0",
-                                  "from": "object-assign@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
                                 }
                               }
@@ -595,12 +597,12 @@
                     },
                     "minimist": {
                       "version": "1.1.1",
-                      "from": "minimist@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
                     },
                     "object-assign": {
                       "version": "1.0.0",
-                      "from": "object-assign@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
                     }
                   }
@@ -611,69 +613,69 @@
         },
         "pem-jwk": {
           "version": "1.2.2",
-          "from": "pem-jwk@1.2.2",
+          "from": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-1.2.2.tgz",
           "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-1.2.2.tgz",
           "dependencies": {
             "asn1.js": {
               "version": "1.0.3",
-              "from": "asn1.js@1.0.3",
+              "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimalistic-assert": {
                   "version": "1.0.0",
-                  "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                 },
                 "bn.js": {
                   "version": "1.3.0",
-                  "from": "bn.js@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                 }
               }
             },
             "base64url": {
               "version": "1.0.4",
-              "from": "base64url@>=1.0.4 <1.1.0",
+              "from": "https://registry.npmjs.org/base64url/-/base64url-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.4.tgz",
               "dependencies": {
                 "concat-stream": {
                   "version": "1.4.7",
-                  "from": "concat-stream@>=1.4.7 <1.5.0",
+                  "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
                   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "typedarray": {
                       "version": "0.0.6",
-                      "from": "typedarray@>=0.0.5 <0.1.0",
+                      "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
                       "version": "1.1.13",
-                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         }
                       }
@@ -682,54 +684,54 @@
                 },
                 "meow": {
                   "version": "2.0.0",
-                  "from": "meow@>=2.0.0 <2.1.0",
+                  "from": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "1.0.0",
-                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "1.0.2",
-                          "from": "camelcase@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
                         },
                         "map-obj": {
                           "version": "1.0.0",
-                          "from": "map-obj@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
                         }
                       }
                     },
                     "indent-string": {
                       "version": "1.2.1",
-                      "from": "indent-string@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
                       "dependencies": {
                         "get-stdin": {
                           "version": "4.0.1",
-                          "from": "get-stdin@>=4.0.1 <5.0.0",
+                          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                         },
                         "repeating": {
                           "version": "1.1.2",
-                          "from": "repeating@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.0",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
                             },
                             "meow": {
                               "version": "3.1.0",
-                              "from": "meow@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
                               "dependencies": {
                                 "object-assign": {
                                   "version": "2.0.0",
-                                  "from": "object-assign@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
                                 }
                               }
@@ -740,12 +742,12 @@
                     },
                     "minimist": {
                       "version": "1.1.1",
-                      "from": "minimist@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
                     },
                     "object-assign": {
                       "version": "1.0.0",
-                      "from": "object-assign@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
                     }
                   }
@@ -758,62 +760,62 @@
     },
     "grunt": {
       "version": "0.4.5",
-      "from": "grunt@0.4.5",
+      "from": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "async@>=0.1.22 <0.2.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "coffee-script@>=1.3.3 <1.4.0",
+          "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@>=0.6.2 <0.7.0",
+          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
           "version": "1.0.2-1.2.3",
-          "from": "dateformat@1.0.2-1.2.3",
+          "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "eventemitter2@>=0.4.13 <0.5.0",
+          "from": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@>=0.1.2 <0.2.0",
+          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.9 <3.3.0",
+              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -822,144 +824,144 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@>=2.4.1 <2.5.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@>=3.1.21 <3.2.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@>=1.2.0 <1.3.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "inherits@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@>=0.2.3 <0.3.0",
+          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "iconv-lite@>=0.2.11 <0.3.0",
+          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@>=0.2.12 <0.3.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@>=1.0.10 <1.1.0",
+          "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@>=2.2.8 <2.3.0",
+          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "lodash@>=0.9.2 <0.10.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "underscore.string@>=2.2.1 <2.3.0",
+          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
           "version": "1.0.9",
-          "from": "which@>=1.0.5 <1.1.0",
+          "from": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "js-yaml@>=2.0.5 <2.1.0",
+          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@>=0.1.11 <0.2.0",
+              "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "underscore@>=1.7.0 <1.8.0",
+                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "underscore.string@>=2.4.0 <2.5.0",
+                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@>=1.0.2 <1.1.0",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@>=0.1.1 <0.2.0",
+          "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "getobject@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
           "version": "0.1.1",
-          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@>=2.4.1 <2.5.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "underscore.string@>=2.3.3 <2.4.0",
+              "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
@@ -968,52 +970,54 @@
     },
     "grunt-bump": {
       "version": "0.3.0",
+      "from": "https://registry.npmjs.org/grunt-bump/-/grunt-bump-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-bump/-/grunt-bump-0.3.0.tgz",
       "dependencies": {
         "semver": {
           "version": "4.2.2",
+          "from": "https://registry.npmjs.org/semver/-/semver-4.2.2.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.2.2.tgz"
         }
       }
     },
     "grunt-contrib-jshint": {
       "version": "0.10.0",
-      "from": "grunt-contrib-jshint@0.10.0",
+      "from": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
       "dependencies": {
         "jshint": {
           "version": "2.5.11",
-          "from": "jshint@>=2.5.0 <2.6.0",
+          "from": "https://registry.npmjs.org/jshint/-/jshint-2.5.11.tgz",
           "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.11.tgz",
           "dependencies": {
             "cli": {
               "version": "0.6.6",
-              "from": "cli@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
               "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
-                  "from": "glob@>=3.2.1 <3.3.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "0.3.0",
-                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
@@ -1024,49 +1028,49 @@
             },
             "console-browserify": {
               "version": "1.1.0",
-              "from": "console-browserify@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "dependencies": {
                 "date-now": {
                   "version": "0.1.4",
-                  "from": "date-now@>=0.1.4 <0.2.0",
+                  "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
                 }
               }
             },
             "exit": {
               "version": "0.1.2",
-              "from": "exit@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "htmlparser2": {
               "version": "3.8.2",
-              "from": "htmlparser2@>=3.8.0 <3.9.0",
+              "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
               "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.3.0",
-                  "from": "domhandler@>=2.3.0 <2.4.0",
+                  "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
                 },
                 "domutils": {
                   "version": "1.5.1",
-                  "from": "domutils@>=1.5.0 <1.6.0",
+                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
                   "dependencies": {
                     "dom-serializer": {
                       "version": "0.1.0",
-                      "from": "dom-serializer@>=0.0.0 <1.0.0",
+                      "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                       "dependencies": {
                         "domelementtype": {
                           "version": "1.1.3",
-                          "from": "domelementtype@>=1.1.1 <1.2.0",
+                          "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                         },
                         "entities": {
                           "version": "1.1.1",
-                          "from": "entities@>=1.1.1 <1.2.0",
+                          "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                         }
                       }
@@ -1075,117 +1079,117 @@
                 },
                 "domelementtype": {
                   "version": "1.3.0",
-                  "from": "domelementtype@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.0 <1.2.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "entities": {
                   "version": "1.0.0",
-                  "from": "entities@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "1.0.0",
-              "from": "minimatch@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "shelljs": {
               "version": "0.3.0",
-              "from": "shelljs@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
             },
             "strip-json-comments": {
               "version": "1.0.2",
-              "from": "strip-json-comments@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
             },
             "underscore": {
               "version": "1.6.0",
-              "from": "underscore@>=1.6.0 <1.7.0",
+              "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@>=0.2.3 <0.3.0",
+          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         }
       }
     },
     "grunt-copyright": {
       "version": "0.1.0",
-      "from": "grunt-copyright@0.1.0",
+      "from": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.1.0.tgz"
     },
     "grunt-nsp-shrinkwrap": {
       "version": "0.0.3",
-      "from": "grunt-nsp-shrinkwrap@0.0.3",
+      "from": "https://registry.npmjs.org/grunt-nsp-shrinkwrap/-/grunt-nsp-shrinkwrap-0.0.3.tgz",
       "resolved": "https://registry.npmjs.org/grunt-nsp-shrinkwrap/-/grunt-nsp-shrinkwrap-0.0.3.tgz",
       "dependencies": {
         "cli-color": {
           "version": "0.2.3",
-          "from": "cli-color@>=0.2.3 <0.3.0",
+          "from": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
           "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
           "dependencies": {
             "es5-ext": {
               "version": "0.9.2",
-              "from": "es5-ext@>=0.9.2 <0.10.0",
+              "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz",
               "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz"
             },
             "memoizee": {
               "version": "0.2.6",
-              "from": "memoizee@>=0.2.5 <0.3.0",
+              "from": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
               "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
               "dependencies": {
                 "event-emitter": {
                   "version": "0.2.2",
-                  "from": "event-emitter@>=0.2.2 <0.3.0",
+                  "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz"
                 },
                 "next-tick": {
                   "version": "0.1.0",
-                  "from": "next-tick@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz"
                 }
               }
@@ -1194,49 +1198,49 @@
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@>=0.6.2 <0.7.0",
+          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
     },
     "load-grunt-tasks": {
       "version": "0.6.0",
-      "from": "load-grunt-tasks@0.6.0",
+      "from": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.6.0.tgz",
       "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.6.0.tgz",
       "dependencies": {
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@>=0.1.2 <0.2.0",
+          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.9 <3.3.0",
+              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -1245,46 +1249,46 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@>=2.4.1 <2.5.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "multimatch": {
           "version": "0.3.0",
-          "from": "multimatch@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/multimatch/-/multimatch-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-0.3.0.tgz",
           "dependencies": {
             "array-differ": {
               "version": "0.1.0",
-              "from": "array-differ@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz"
             },
             "array-union": {
               "version": "0.1.0",
-              "from": "array-union@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
               "dependencies": {
                 "array-uniq": {
                   "version": "0.1.1",
-                  "from": "array-uniq@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
@@ -1295,188 +1299,188 @@
     },
     "mozlog": {
       "version": "2.0.0",
-      "from": "mozlog@2.0.0",
+      "from": "https://registry.npmjs.org/mozlog/-/mozlog-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/mozlog/-/mozlog-2.0.0.tgz",
       "dependencies": {
         "intel": {
           "version": "1.0.0",
-          "from": "intel@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/intel/-/intel-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/intel/-/intel-1.0.0.tgz",
           "dependencies": {
             "chalk": {
               "version": "0.5.1",
-              "from": "chalk@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "ansi-styles@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "has-ansi@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "strip-ansi@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "supports-color@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                 }
               }
             },
             "dbug": {
               "version": "0.4.2",
-              "from": "dbug@>=0.4.2 <0.5.0",
+              "from": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz",
               "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "stack-trace@>=0.0.9 <0.1.0",
+              "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             },
             "strftime": {
               "version": "0.8.4",
-              "from": "strftime@>=0.8.2 <0.9.0",
+              "from": "https://registry.npmjs.org/strftime/-/strftime-0.8.4.tgz",
               "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.8.4.tgz"
             },
             "symbol": {
               "version": "0.2.1",
-              "from": "symbol@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz"
             },
             "utcstring": {
               "version": "0.1.0",
-              "from": "utcstring@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
             }
           }
         },
         "merge": {
           "version": "1.2.0",
-          "from": "merge@>=1.2.0 <2.0.0",
+          "from": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
         }
       }
     },
     "mysql": {
       "version": "2.3.2",
-      "from": "mysql@2.3.2",
+      "from": "https://registry.npmjs.org/mysql/-/mysql-2.3.2.tgz",
       "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.3.2.tgz",
       "dependencies": {
         "bignumber.js": {
           "version": "1.4.0",
-          "from": "bignumber.js@1.4.0",
+          "from": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-1.4.0.tgz",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-1.4.0.tgz"
         },
         "readable-stream": {
           "version": "1.1.13",
-          "from": "readable-stream@>=1.1.13 <1.2.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@>=0.10.0 <0.11.0",
+              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "require-all": {
           "version": "0.0.8",
-          "from": "require-all@0.0.8",
+          "from": "https://registry.npmjs.org/require-all/-/require-all-0.0.8.tgz",
           "resolved": "https://registry.npmjs.org/require-all/-/require-all-0.0.8.tgz"
         }
       }
     },
     "mysql-patcher": {
       "version": "0.5.1",
-      "from": "mysql-patcher@0.5.1",
+      "from": "https://registry.npmjs.org/mysql-patcher/-/mysql-patcher-0.5.1.tgz",
       "resolved": "https://registry.npmjs.org/mysql-patcher/-/mysql-patcher-0.5.1.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.0",
-          "from": "async@>=0.9.0 <0.10.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
         },
         "bluebird": {
           "version": "2.9.21",
-          "from": "bluebird@>=2.3.0 <3.0.0",
+          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.21.tgz",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.21.tgz"
         },
         "clone": {
           "version": "0.1.19",
-          "from": "clone@>=0.1.18 <0.2.0",
+          "from": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz"
         },
         "xtend": {
           "version": "4.0.0",
-          "from": "xtend@>=4.0.0 <5.0.0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
         }
       }
     },
     "nock": {
       "version": "1.2.0",
-      "from": "nock@1.2.0",
+      "from": "https://registry.npmjs.org/nock/-/nock-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/nock/-/nock-1.2.0.tgz",
       "dependencies": {
         "chai": {
           "version": "1.10.0",
-          "from": "chai@>=1.9.2 <2.0.0",
+          "from": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
           "resolved": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
           "dependencies": {
             "assertion-error": {
               "version": "1.0.0",
-              "from": "assertion-error@1.0.0",
+              "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz"
             },
             "deep-eql": {
               "version": "0.1.3",
-              "from": "deep-eql@0.1.3",
+              "from": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
               "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
               "dependencies": {
                 "type-detect": {
                   "version": "0.1.1",
-                  "from": "type-detect@0.1.1",
+                  "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
                 }
               }
@@ -1485,73 +1489,73 @@
         },
         "debug": {
           "version": "1.0.4",
-          "from": "debug@>=1.0.4 <2.0.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "ms@0.6.2",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@>=2.4.1 <2.5.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "propagate": {
           "version": "0.3.1",
-          "from": "propagate@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz",
           "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz"
         }
       }
     },
     "request": {
       "version": "2.53.0",
-      "from": "request@2.53.0",
+      "from": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
       "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
       "dependencies": {
         "bl": {
           "version": "0.9.4",
-          "from": "bl@>=0.9.0 <0.10.0",
+          "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
           "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.26 <1.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -1560,346 +1564,346 @@
         },
         "caseless": {
           "version": "0.9.0",
-          "from": "caseless@>=0.9.0 <0.10.0",
+          "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
         },
         "forever-agent": {
           "version": "0.5.2",
-          "from": "forever-agent@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
         },
         "form-data": {
           "version": "0.2.0",
-          "from": "form-data@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
           "dependencies": {
             "async": {
               "version": "0.9.0",
-              "from": "async@>=0.9.0 <0.10.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
             }
           }
         },
         "json-stringify-safe": {
           "version": "5.0.0",
-          "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+          "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
         },
         "mime-types": {
           "version": "2.0.10",
-          "from": "mime-types@>=2.0.1 <2.1.0",
+          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
           "dependencies": {
             "mime-db": {
               "version": "1.8.0",
-              "from": "mime-db@>=1.8.0 <1.9.0",
+              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz",
               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
             }
           }
         },
         "node-uuid": {
           "version": "1.4.3",
-          "from": "node-uuid@>=1.4.0 <1.5.0",
+          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
         },
         "qs": {
           "version": "2.3.3",
-          "from": "qs@>=2.3.1 <2.4.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
         },
         "tunnel-agent": {
           "version": "0.4.0",
-          "from": "tunnel-agent@>=0.4.0 <0.5.0",
+          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
         },
         "tough-cookie": {
           "version": "0.12.1",
-          "from": "tough-cookie@>=0.12.0",
+          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.3.2",
-              "from": "punycode@>=0.2.0",
+              "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
             }
           }
         },
         "http-signature": {
           "version": "0.10.1",
-          "from": "http-signature@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.5",
-              "from": "assert-plus@>=0.1.5 <0.2.0",
+              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "asn1": {
               "version": "0.1.11",
-              "from": "asn1@0.1.11",
+              "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
               "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
             },
             "ctype": {
               "version": "0.5.3",
-              "from": "ctype@0.5.3",
+              "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
             }
           }
         },
         "oauth-sign": {
           "version": "0.6.0",
-          "from": "oauth-sign@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
         },
         "hawk": {
           "version": "2.3.1",
-          "from": "hawk@>=2.3.0 <2.4.0",
+          "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
           "dependencies": {
             "hoek": {
               "version": "2.12.0",
-              "from": "hoek@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/hoek/-/hoek-2.12.0.tgz",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.12.0.tgz"
             },
             "boom": {
               "version": "2.6.1",
-              "from": "boom@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz",
               "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
             },
             "cryptiles": {
               "version": "2.0.4",
-              "from": "cryptiles@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
             },
             "sntp": {
               "version": "1.0.9",
-              "from": "sntp@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
             }
           }
         },
         "aws-sign2": {
           "version": "0.5.0",
-          "from": "aws-sign2@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
         },
         "stringstream": {
           "version": "0.0.4",
-          "from": "stringstream@>=0.0.4 <0.1.0",
+          "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
         },
         "combined-stream": {
           "version": "0.0.7",
-          "from": "combined-stream@>=0.0.5 <0.1.0",
+          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
           "dependencies": {
             "delayed-stream": {
               "version": "0.0.5",
-              "from": "delayed-stream@0.0.5",
+              "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
               "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
             }
           }
         },
         "isstream": {
           "version": "0.1.2",
-          "from": "isstream@>=0.1.1 <0.2.0",
+          "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
         }
       }
     },
     "restify": {
       "version": "2.8.1",
-      "from": "restify@2.8.1",
+      "from": "https://registry.npmjs.org/restify/-/restify-2.8.1.tgz",
       "resolved": "https://registry.npmjs.org/restify/-/restify-2.8.1.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "0.1.5",
-          "from": "assert-plus@>=0.1.5 <0.2.0",
+          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
         },
         "backoff": {
           "version": "2.3.0",
-          "from": "backoff@2.3.0",
+          "from": "https://registry.npmjs.org/backoff/-/backoff-2.3.0.tgz",
           "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.3.0.tgz"
         },
         "bunyan": {
           "version": "0.22.1",
-          "from": "bunyan@0.22.1",
+          "from": "https://registry.npmjs.org/bunyan/-/bunyan-0.22.1.tgz",
           "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.22.1.tgz",
           "dependencies": {
             "mv": {
               "version": "0.0.5",
-              "from": "mv@0.0.5",
+              "from": "https://registry.npmjs.org/mv/-/mv-0.0.5.tgz",
               "resolved": "https://registry.npmjs.org/mv/-/mv-0.0.5.tgz"
             }
           }
         },
         "csv": {
           "version": "0.3.7",
-          "from": "csv@0.3.7",
+          "from": "https://registry.npmjs.org/csv/-/csv-0.3.7.tgz",
           "resolved": "https://registry.npmjs.org/csv/-/csv-0.3.7.tgz"
         },
         "deep-equal": {
           "version": "0.0.0",
-          "from": "deep-equal@0.0.0",
+          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
         },
         "escape-regexp-component": {
           "version": "1.0.2",
-          "from": "escape-regexp-component@1.0.2",
+          "from": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
         },
         "formidable": {
           "version": "1.0.14",
-          "from": "formidable@1.0.14",
+          "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz",
           "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
         },
         "http-signature": {
           "version": "0.10.0",
-          "from": "http-signature@0.10.0",
+          "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.2",
-              "from": "assert-plus@0.1.2",
+              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
             },
             "asn1": {
               "version": "0.1.11",
-              "from": "asn1@0.1.11",
+              "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
               "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
             },
             "ctype": {
               "version": "0.5.2",
-              "from": "ctype@0.5.2",
+              "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz",
               "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
             }
           }
         },
         "keep-alive-agent": {
           "version": "0.0.1",
-          "from": "keep-alive-agent@0.0.1",
+          "from": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
         },
         "lru-cache": {
           "version": "2.3.1",
-          "from": "lru-cache@2.3.1",
+          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz"
         },
         "mime": {
           "version": "1.2.11",
-          "from": "mime@1.2.11",
+          "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
         },
         "negotiator": {
           "version": "0.3.0",
-          "from": "negotiator@0.3.0",
+          "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz"
         },
         "node-uuid": {
           "version": "1.4.1",
-          "from": "node-uuid@1.4.1",
+          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
         },
         "once": {
           "version": "1.3.0",
-          "from": "once@1.3.0",
+          "from": "https://registry.npmjs.org/once/-/once-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.0.tgz"
         },
         "qs": {
           "version": "0.6.6",
-          "from": "qs@0.6.6",
+          "from": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
         },
         "semver": {
           "version": "2.2.1",
-          "from": "semver@2.2.1",
+          "from": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz"
         },
         "spdy": {
           "version": "1.19.3",
-          "from": "spdy@1.19.3",
+          "from": "https://registry.npmjs.org/spdy/-/spdy-1.19.3.tgz",
           "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.19.3.tgz"
         },
         "tunnel-agent": {
           "version": "0.4.0",
-          "from": "tunnel-agent@0.4.0",
+          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
         },
         "verror": {
           "version": "1.3.7",
-          "from": "verror@1.3.7",
+          "from": "https://registry.npmjs.org/verror/-/verror-1.3.7.tgz",
           "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.7.tgz",
           "dependencies": {
             "extsprintf": {
               "version": "1.0.2",
-              "from": "extsprintf@1.0.2",
+              "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
             }
           }
         },
         "dtrace-provider": {
           "version": "0.2.8",
-          "from": "dtrace-provider@0.2.8",
+          "from": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz",
           "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
         }
       }
     },
     "tap": {
       "version": "0.4.13",
-      "from": "tap@0.4.13",
+      "from": "https://registry.npmjs.org/tap/-/tap-0.4.13.tgz",
       "resolved": "https://registry.npmjs.org/tap/-/tap-0.4.13.tgz",
       "dependencies": {
         "buffer-equal": {
           "version": "0.0.1",
-          "from": "buffer-equal@>=0.0.0 <0.1.0",
+          "from": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
         },
         "deep-equal": {
           "version": "0.0.0",
-          "from": "deep-equal@>=0.0.0 <0.1.0",
+          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
         },
         "difflet": {
           "version": "0.2.6",
-          "from": "difflet@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
           "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
           "dependencies": {
             "traverse": {
               "version": "0.6.6",
-              "from": "traverse@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
               "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
             },
             "charm": {
               "version": "0.1.2",
-              "from": "charm@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
             },
             "deep-is": {
               "version": "0.1.3",
-              "from": "deep-is@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
               "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
             }
           }
         },
         "glob": {
           "version": "3.2.11",
-          "from": "glob@>=3.2.9 <3.3.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
@@ -1908,56 +1912,56 @@
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "inherits@*",
+          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "nopt": {
           "version": "2.2.1",
-          "from": "nopt@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "runforcover": {
           "version": "0.0.2",
-          "from": "runforcover@>=0.0.2 <0.1.0",
+          "from": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
           "dependencies": {
             "bunker": {
               "version": "0.1.2",
-              "from": "bunker@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
               "dependencies": {
                 "burrito": {
                   "version": "0.2.12",
-                  "from": "burrito@>=0.2.5 <0.3.0",
+                  "from": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
                   "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
                   "dependencies": {
                     "traverse": {
                       "version": "0.5.2",
-                      "from": "traverse@>=0.5.1 <0.6.0",
+                      "from": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz",
                       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
                     },
                     "uglify-js": {
                       "version": "1.1.1",
-                      "from": "uglify-js@>=1.1.1 <1.2.0",
+                      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz"
                     }
                   }
@@ -1968,20 +1972,15 @@
         },
         "slide": {
           "version": "1.1.6",
-          "from": "slide@*",
+          "from": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
           "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
         },
         "yamlish": {
           "version": "0.0.6",
-          "from": "yamlish@*",
+          "from": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.6.tgz",
           "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.6.tgz"
         }
       }
-    },
-    "uuid": {
-      "version": "1.4.1",
-      "from": "uuid@1.4.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
     "mysql-patcher": "0.5.1",
     "nock": "1.2.0",
     "restify": "2.8.1",
-    "tap": "0.4.13",
-    "uuid": "1.4.1"
+    "tap": "0.4.13"
   },
   "keywords": [ "fxa", "firefox", "firefox-accounts", "backend", "storage", "mysql" ]
 }


### PR DESCRIPTION
Since node-uuid / uuid has been removed from fxa-auth-db-server, we no
longer have to install it here. Having it here used to upset shrinkwrap
if conflicting versions were being used and/or installed (e.g. uuid v1 to
uuid v2 - the APIs were incompatible).