### PR TITLE
fix(db): Fix reverse patches 8->7 and 9->8

### DIFF
--- a/db/schema/patch-008-007.sql
+++ b/db/schema/patch-008-007.sql
@@ -9,7 +9,7 @@
 -- DROP PROCEDURE `lockAccount_1`;
 
 -- -- drop new table
--- DROP TABLE accountUnlockCodes
+-- DROP TABLE accountUnlockCodes;
 
 -- -- drop new column
 -- ALTER TABLE accounts DROP COLUMN lockedAt;

--- a/db/schema/patch-009-008.sql
+++ b/db/schema/patch-009-008.sql
@@ -1,7 +1,6 @@
 -- -- drop new stored procedures
 -- DROP PROCEDURE `ackPublishedEvents_1`;
 -- DROP PROCEDURE `getUnpublishedEvents_1`;
--- DROP PROCEDURE `getEventsSincePosition_1`;
 -- DROP PROCEDURE `deleteAccount_4`;
 -- DROP PROCEDURE `resetAccount_4`;
 -- DROP PROCEDURE `verifyEmail_2`;


### PR DESCRIPTION
When upgrading to a new mysql-patcher and testing old patches, these were
failing on the reverse patches. Fixed both a syntax error and a non-existant
stored procedure.