### PR TITLE
chore(package): Update to mysql-patcher@0.7.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -263,61 +263,61 @@
     },
     "fxa-auth-db-server": {
       "version": "0.35.0",
-      "from": "git://github.com/mozilla/fxa-auth-db-server.git",
+      "from": "git://github.com/mozilla/fxa-auth-db-server.git#71191002ca74e730234b6a401df1ed8119d6d8e1",
       "resolved": "git://github.com/mozilla/fxa-auth-db-server.git#71191002ca74e730234b6a401df1ed8119d6d8e1",
       "dependencies": {
         "restify": {
           "version": "2.8.2",
-          "from": "restify@2.8.2",
+          "from": "https://registry.npmjs.org/restify/-/restify-2.8.2.tgz",
           "resolved": "https://registry.npmjs.org/restify/-/restify-2.8.2.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.5",
-              "from": "assert-plus@>=0.1.5 <0.2.0",
+              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "backoff": {
               "version": "2.4.1",
-              "from": "backoff@>=2.3.0 <3.0.0",
+              "from": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
               "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
               "dependencies": {
                 "precond": {
                   "version": "0.2.3",
-                  "from": "precond@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
                   "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
                 }
               }
             },
             "bunyan": {
               "version": "0.23.1",
-              "from": "bunyan@>=0.23.1 <0.24.0",
+              "from": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
               "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
               "dependencies": {
                 "mv": {
                   "version": "2.0.3",
-                  "from": "mv@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/mv/-/mv-2.0.3.tgz",
                   "dependencies": {
                     "mkdirp": {
                       "version": "0.5.0",
-                      "from": "mkdirp@>=0.5.0 <0.6.0",
+                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "minimist@0.0.8",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                         }
                       }
                     },
                     "ncp": {
                       "version": "0.6.0",
-                      "from": "ncp@>=0.6.0 <0.7.0",
+                      "from": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz",
                       "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
                     },
                     "rimraf": {
                       "version": "2.2.8",
-                      "from": "rimraf@>=2.2.8 <2.3.0",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                     }
                   }
@@ -326,135 +326,135 @@
             },
             "csv": {
               "version": "0.4.1",
-              "from": "csv@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/csv/-/csv-0.4.1.tgz",
               "resolved": "https://registry.npmjs.org/csv/-/csv-0.4.1.tgz",
               "dependencies": {
                 "csv-generate": {
                   "version": "0.0.4",
-                  "from": "csv-generate@*",
+                  "from": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.4.tgz"
                 },
                 "csv-parse": {
                   "version": "0.1.0",
-                  "from": "csv-parse@*",
+                  "from": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.0.tgz"
                 },
                 "stream-transform": {
                   "version": "0.0.7",
-                  "from": "stream-transform@*",
+                  "from": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.0.7.tgz"
                 },
                 "csv-stringify": {
                   "version": "0.0.6",
-                  "from": "csv-stringify@*",
+                  "from": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.6.tgz"
                 }
               }
             },
             "deep-equal": {
               "version": "0.2.2",
-              "from": "deep-equal@>=0.2.1 <0.3.0",
+              "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
               "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz"
             },
             "escape-regexp-component": {
               "version": "1.0.2",
-              "from": "escape-regexp-component@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
             },
             "formidable": {
               "version": "1.0.17",
-              "from": "formidable@>=1.0.14 <2.0.0",
+              "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
               "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "http-signature@>=0.10.0 <0.11.0",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "asn1@0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.3",
-                  "from": "ctype@0.5.3",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
             "keep-alive-agent": {
               "version": "0.0.1",
-              "from": "keep-alive-agent@>=0.0.1 <0.0.2",
+              "from": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
             },
             "lru-cache": {
               "version": "2.6.1",
-              "from": "lru-cache@>=2.5.0 <3.0.0",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.1.tgz",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.1.tgz"
             },
             "mime": {
               "version": "1.3.4",
-              "from": "mime@>=1.2.11 <2.0.0",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "negotiator": {
               "version": "0.4.9",
-              "from": "negotiator@>=0.4.5 <0.5.0",
+              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
               "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
             },
             "node-uuid": {
               "version": "1.4.3",
-              "from": "node-uuid@>=1.4.1 <2.0.0",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "once": {
               "version": "1.3.1",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "qs": {
               "version": "1.2.2",
-              "from": "qs@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
             },
             "semver": {
               "version": "2.3.2",
-              "from": "semver@>=2.3.0 <3.0.0",
+              "from": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
               "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
             },
             "spdy": {
               "version": "1.31.0",
-              "from": "spdy@>=1.26.5 <2.0.0",
+              "from": "https://registry.npmjs.org/spdy/-/spdy-1.31.0.tgz",
               "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.31.0.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "verror": {
               "version": "1.6.0",
-              "from": "verror@>=1.4.0 <2.0.0",
+              "from": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
               "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
               "dependencies": {
                 "extsprintf": {
                   "version": "1.2.0",
-                  "from": "extsprintf@1.2.0",
+                  "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz"
                 }
               }
             },
             "dtrace-provider": {
               "version": "0.2.8",
-              "from": "dtrace-provider@>=0.2.8 <0.3.0",
+              "from": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz",
               "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
             }
           }
@@ -1432,28 +1432,93 @@
       }
     },
     "mysql-patcher": {
-      "version": "0.5.1",
-      "from": "https://registry.npmjs.org/mysql-patcher/-/mysql-patcher-0.5.1.tgz",
-      "resolved": "https://registry.npmjs.org/mysql-patcher/-/mysql-patcher-0.5.1.tgz",
+      "version": "0.7.0",
+      "from": "mysql-patcher@0.7.0",
+      "resolved": "https://registry.npmjs.org/mysql-patcher/-/mysql-patcher-0.7.0.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.0",
-          "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+          "from": "async@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
         },
         "bluebird": {
-          "version": "2.9.21",
-          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.21.tgz",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.21.tgz"
+          "version": "2.9.24",
+          "from": "bluebird@>=2.3.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.24.tgz"
         },
         "clone": {
           "version": "0.1.19",
-          "from": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz",
+          "from": "clone@>=0.1.18 <0.2.0",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz"
+        },
+        "glob": {
+          "version": "5.0.5",
+          "from": "glob@>=5.0.3 <6.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.5.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "2.0.4",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.1",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+            }
+          }
         },
         "xtend": {
           "version": "4.0.0",
-          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+          "from": "xtend@>=4.0.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "grunt-copyright": "0.1.0",
     "grunt-nsp-shrinkwrap": "0.0.3",
     "load-grunt-tasks": "0.6.0",
-    "mysql-patcher": "0.5.1",
+    "mysql-patcher": "0.7.0",
     "nock": "1.2.0",
     "restify": "2.8.1",
     "tap": "0.4.13"


### PR DESCRIPTION
To be able to add other files to the db/schema/ directory we need to update
to mysql-patcher@0.7.0 so that it will ignore non-sql patch files. It also
has a few minor updates too.