### PR TITLE
chore(copyright): Update to grunt-copyright v0.2.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1158,9 +1158,9 @@
       }
     },
     "grunt-copyright": {
-      "version": "0.1.0",
-      "from": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.1.0.tgz"
+      "version": "0.2.0",
+      "from": "grunt-copyright@0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.2.0.tgz"
     },
     "grunt-nsp-shrinkwrap": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "grunt": "0.4.5",
     "grunt-bump": "0.3.0",
     "grunt-contrib-jshint": "0.10.0",
-    "grunt-copyright": "0.1.0",
+    "grunt-copyright": "0.2.0",
     "grunt-nsp-shrinkwrap": "0.0.3",
     "load-grunt-tasks": "0.6.0",
     "mysql-patcher": "0.7.0",


### PR DESCRIPTION
When doing an `npm install` using node v0.12, it complains since grunt-copyright
v0.1 has a `"node": "0.10.x"` in it's `engines` section. v0.2 has been updated
to be `"node": ">= 0.10.0"` which is satisfied with either v0.10 or v0.12.