### PR TITLE
fix(notifications): always return a promise from db.processUnpublishedEvents, fixes #49

### DIFF
--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -730,7 +730,7 @@ module.exports = function (log, error) {
                 // Luckily MySQL will clear it if our connection dies,
                 // and we kill the connection in the event of error.
                 var events = results[2]
-                return fn(events)
+                return P.resolve(events).then(fn)
                   .then(
                     function (numProcessed) {
                       var ackPos

--- a/test/local/event_log.js
+++ b/test/local/event_log.js
@@ -16,6 +16,21 @@ DB.connect(config)
     function (db) {
 
       test(
+        'processUnpublishedEvents guards for callback not returning promise',
+        function (t) {
+          t.plan(2);
+          return db.processUnpublishedEvents(function (events) {
+            t.ok(true, 'The db.processUnpublishedEvents callback was called')
+            // ... but the callback itself returns nothing
+          })
+          .then(function () {
+            // Yet a promise is returned
+            t.ok(true, 'The following thenable is called')
+          })
+        }
+      )
+
+      test(
         'account activity should generate event logs',
         function (t) {
           t.plan(14);


### PR DESCRIPTION
r? anyone. Is this the best way to do this. Not needed for production, but would be nice to remove this spew in fxa-dev log asap.