### PR TITLE
fix(tests): pass server object to backend tests (and update shrinkwrap to latest)

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "ass": {
       "version": "1.0.0",
-      "from": "git://github.com/jrgm/ass.git#5be99ee",
+      "from": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
       "resolved": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
       "dependencies": {
         "async": {
@@ -262,9 +262,9 @@
       }
     },
     "fxa-auth-db-server": {
-      "version": "0.41.0",
-      "from": "git://github.com/mozilla/fxa-auth-db-server.git",
-      "resolved": "git://github.com/mozilla/fxa-auth-db-server.git#b62d2000758d56b3bb1955437920d2958e19d41f",
+      "version": "0.42.0",
+      "from": "git://github.com/mozilla/fxa-auth-db-server.git#3d5f649de3324be6c9c37076ea094b2fe3b7bdcd",
+      "resolved": "git://github.com/mozilla/fxa-auth-db-server.git#3d5f649de3324be6c9c37076ea094b2fe3b7bdcd",
       "dependencies": {
         "restify": {
           "version": "2.8.2",
@@ -273,7 +273,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "0.1.5",
-              "from": "assert-plus@0.1.5",
+              "from": "assert-plus@>=0.1.5 <0.2.0",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "backoff": {
@@ -316,14 +316,14 @@
                       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
                     },
                     "rimraf": {
-                      "version": "2.4.1",
+                      "version": "2.4.2",
                       "from": "rimraf@>=2.4.0 <2.5.0",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz",
                       "dependencies": {
                         "glob": {
-                          "version": "4.5.3",
-                          "from": "glob@>=4.4.2 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                          "version": "5.0.14",
+                          "from": "glob@>=5.0.14 <6.0.0",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
                           "dependencies": {
                             "inflight": {
                               "version": "1.0.4",
@@ -343,9 +343,9 @@
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             },
                             "minimatch": {
-                              "version": "2.0.8",
+                              "version": "2.0.10",
                               "from": "minimatch@>=2.0.1 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                               "dependencies": {
                                 "brace-expansion": {
                                   "version": "1.1.0",
@@ -365,6 +365,11 @@
                                   }
                                 }
                               }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.0",
+                              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                             }
                           }
                         }
@@ -408,7 +413,7 @@
             },
             "escape-regexp-component": {
               "version": "1.0.2",
-              "from": "escape-regexp-component@1.0.2",
+              "from": "escape-regexp-component@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
             },
             "formidable": {
@@ -435,12 +440,12 @@
             },
             "keep-alive-agent": {
               "version": "0.0.1",
-              "from": "keep-alive-agent@0.0.1",
+              "from": "keep-alive-agent@>=0.0.1 <0.0.2",
               "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
             },
             "lru-cache": {
               "version": "2.6.5",
-              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "from": "lru-cache@>=2.5.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
             },
             "mime": {
@@ -455,7 +460,7 @@
             },
             "node-uuid": {
               "version": "1.4.3",
-              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "from": "node-uuid@>=1.4.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "once": {
@@ -481,9 +486,9 @@
               "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
             },
             "spdy": {
-              "version": "1.32.0",
+              "version": "1.32.4",
               "from": "spdy@>=1.26.5 <2.0.0",
-              "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.32.0.tgz"
+              "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.32.4.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.1",
@@ -504,7 +509,7 @@
             },
             "dtrace-provider": {
               "version": "0.2.8",
-              "from": "dtrace-provider@0.2.8",
+              "from": "dtrace-provider@>=0.2.8 <0.3.0",
               "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
             }
           }
@@ -527,9 +532,9 @@
           "resolved": "https://registry.npmjs.org/jws/-/jws-2.0.0.tgz",
           "dependencies": {
             "jwa": {
-              "version": "1.0.1",
+              "version": "1.0.2",
               "from": "jwa@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.0.2.tgz",
               "dependencies": {
                 "base64url": {
                   "version": "0.0.6",
@@ -547,9 +552,9 @@
                   "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.2.tgz",
                   "dependencies": {
                     "asn1.js": {
-                      "version": "2.1.2",
+                      "version": "2.1.3",
                       "from": "asn1.js@>=2.0.3 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.3.tgz",
                       "dependencies": {
                         "bn.js": {
                           "version": "2.2.0",
@@ -644,9 +649,9 @@
                       }
                     },
                     "indent-string": {
-                      "version": "1.2.1",
+                      "version": "1.2.2",
                       "from": "indent-string@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                       "dependencies": {
                         "get-stdin": {
                           "version": "4.0.1",
@@ -675,9 +680,9 @@
                       }
                     },
                     "minimist": {
-                      "version": "1.1.1",
+                      "version": "1.1.2",
                       "from": "minimist@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
                     },
                     "object-assign": {
                       "version": "1.0.0",
@@ -702,7 +707,7 @@
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimalistic-assert": {
@@ -784,9 +789,9 @@
                       }
                     },
                     "indent-string": {
-                      "version": "1.2.1",
+                      "version": "1.2.2",
                       "from": "indent-string@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                       "dependencies": {
                         "get-stdin": {
                           "version": "4.0.1",
@@ -815,9 +820,9 @@
                       }
                     },
                     "minimist": {
-                      "version": "1.1.1",
+                      "version": "1.1.2",
                       "from": "minimist@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
                     },
                     "object-assign": {
                       "version": "1.0.0",
@@ -874,7 +879,7 @@
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@*",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
@@ -1119,7 +1124,7 @@
             },
             "exit": {
               "version": "0.1.2",
-              "from": "exit@>=0.1.1 <0.2.0",
+              "from": "exit@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "htmlparser2": {
@@ -1299,12 +1304,12 @@
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.1 <3.3.0",
+              "from": "glob@>=3.2.9 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@*",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
@@ -1408,7 +1413,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
@@ -1420,7 +1425,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
@@ -1521,9 +1526,9 @@
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         },
         "bluebird": {
-          "version": "2.9.32",
+          "version": "2.9.34",
           "from": "bluebird@>=2.3.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.32.tgz"
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
         },
         "clone": {
           "version": "0.1.19",
@@ -1531,9 +1536,9 @@
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz"
         },
         "glob": {
-          "version": "5.0.13",
+          "version": "5.0.14",
           "from": "glob@>=5.0.3 <6.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.13.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
@@ -1553,9 +1558,9 @@
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
-              "version": "2.0.8",
+              "version": "2.0.10",
               "from": "minimatch@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
@@ -1650,7 +1655,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {

--- a/test/backend/remote.js
+++ b/test/backend/remote.js
@@ -27,12 +27,12 @@ DB.connect(config)
     server = dbServer.createServer(db)
     var d = P.defer()
     server.listen(config.port, config.hostname, function() {
-      d.resolve()
+      d.resolve(server)
     })
     return d.promise
   })
-  .then(function() {
-    return backendTests.remote(config)
+  .then(function(server) {
+    return backendTests.remote(config, server)
   })
   .then(function() {
     server.close()


### PR DESCRIPTION
This updates `test/backend/remote.js` to match the change in https://github.com/mozilla/fxa-auth-db-mem/commit/122bc686b9b45f9a9886f19a23b880d9a0291232

It also updates shrinkwrap to pick up current HEAD of fxa-auth-db-server, which revealed this broken test. Uugghhh. 

Clearly we need to fold these repos together - https://github.com/mozilla/fxa-auth-db-mysql/pull/56

May I propose that no further changes to fxa-auth-db* be made, until that change can happen (modulo, of course, any changes that absolutely cannot be deferred).

