### PR TITLE
chore(git): Add config/dev.js to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+config/dev.js
 node_modules/
 sandbox/
 coverage.html


### PR DESCRIPTION
I'm surprised this hasn't annoyed anyone else enough to have been done already.

Anyway, the readme tells me to create `config/dev.js` but it isn't in the ignore file, so I'm constantly afeared of accidentally committing it to the repo.