### PR TITLE
reshuffle package.json

### DIFF
--- a/bin/mem.js
+++ b/bin/mem.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var config = require('../config')
-var dbServer = require('fxa-auth-db-server')
+var dbServer = require('../fxa-auth-db-server')
 var error = dbServer.errors
 var logger = require('../lib/logging')('bin.server')
 var DB = require('../lib/db/mem')(logger, error)

--- a/bin/server.js
+++ b/bin/server.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var config = require('../config')
-var dbServer = require('fxa-auth-db-server')
+var dbServer = require('../fxa-auth-db-server')
 var error = dbServer.errors
 var logger = require('../lib/logging')('bin.server')
 var DB = require('../lib/db/mysql')(logger, error)

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var config = require('./config')
-var dbServer = require('fxa-auth-db-server')
+var dbServer = require('./fxa-auth-db-server')
 var error = dbServer.errors
 var logger = require('./lib/logging')('bin.server')
 var DB = require('./lib/db/mem')(logger, error)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -261,260 +261,10 @@
         }
       }
     },
-    "fxa-auth-db-server": {
-      "version": "0.39.0",
-      "from": "fxa-auth-db-server",
-      "resolved": "file:fxa-auth-db-server",
-      "dependencies": {
-        "restify": {
-          "version": "2.8.2",
-          "from": "restify@2.8.2",
-          "resolved": "https://registry.npmjs.org/restify/-/restify-2.8.2.tgz",
-          "dependencies": {
-            "assert-plus": {
-              "version": "0.1.5",
-              "from": "assert-plus@0.1.5",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-            },
-            "backoff": {
-              "version": "2.4.1",
-              "from": "backoff@>=2.3.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
-              "dependencies": {
-                "precond": {
-                  "version": "0.2.3",
-                  "from": "precond@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
-                }
-              }
-            },
-            "bunyan": {
-              "version": "0.23.1",
-              "from": "bunyan@>=0.23.1 <0.24.0",
-              "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
-              "dependencies": {
-                "mv": {
-                  "version": "2.1.1",
-                  "from": "mv@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
-                  "dependencies": {
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "from": "mkdirp@>=0.5.1 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.8",
-                          "from": "minimist@0.0.8",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                        }
-                      }
-                    },
-                    "ncp": {
-                      "version": "2.0.0",
-                      "from": "ncp@>=2.0.0 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
-                    },
-                    "rimraf": {
-                      "version": "2.4.2",
-                      "from": "rimraf@>=2.4.0 <2.5.0",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz",
-                      "dependencies": {
-                        "glob": {
-                          "version": "5.0.14",
-                          "from": "glob@>=5.0.14 <6.0.0",
-                          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
-                          "dependencies": {
-                            "inflight": {
-                              "version": "1.0.4",
-                              "from": "inflight@>=1.0.4 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                }
-                              }
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            },
-                            "minimatch": {
-                              "version": "2.0.10",
-                              "from": "minimatch@>=2.0.1 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                              "dependencies": {
-                                "brace-expansion": {
-                                  "version": "1.1.0",
-                                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                                  "dependencies": {
-                                    "balanced-match": {
-                                      "version": "0.2.0",
-                                      "from": "balanced-match@>=0.2.0 <0.3.0",
-                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                                    },
-                                    "concat-map": {
-                                      "version": "0.0.1",
-                                      "from": "concat-map@0.0.1",
-                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "path-is-absolute": {
-                              "version": "1.0.0",
-                              "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "csv": {
-              "version": "0.4.5",
-              "from": "csv@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/csv/-/csv-0.4.5.tgz",
-              "dependencies": {
-                "csv-generate": {
-                  "version": "0.0.6",
-                  "from": "csv-generate@>=0.0.6 <0.0.7",
-                  "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.6.tgz"
-                },
-                "csv-parse": {
-                  "version": "0.1.3",
-                  "from": "csv-parse@>=0.1.3 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.3.tgz"
-                },
-                "stream-transform": {
-                  "version": "0.1.0",
-                  "from": "stream-transform@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.1.0.tgz"
-                },
-                "csv-stringify": {
-                  "version": "0.0.8",
-                  "from": "csv-stringify@>=0.0.8 <0.0.9",
-                  "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.8.tgz"
-                }
-              }
-            },
-            "deep-equal": {
-              "version": "0.2.2",
-              "from": "deep-equal@>=0.2.1 <0.3.0",
-              "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz"
-            },
-            "escape-regexp-component": {
-              "version": "1.0.2",
-              "from": "escape-regexp-component@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
-            },
-            "formidable": {
-              "version": "1.0.17",
-              "from": "formidable@>=1.0.14 <2.0.0",
-              "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
-            },
-            "http-signature": {
-              "version": "0.10.1",
-              "from": "http-signature@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-              "dependencies": {
-                "asn1": {
-                  "version": "0.1.11",
-                  "from": "asn1@0.1.11",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                },
-                "ctype": {
-                  "version": "0.5.3",
-                  "from": "ctype@0.5.3",
-                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                }
-              }
-            },
-            "keep-alive-agent": {
-              "version": "0.0.1",
-              "from": "keep-alive-agent@0.0.1",
-              "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
-            },
-            "lru-cache": {
-              "version": "2.6.5",
-              "from": "lru-cache@>=2.5.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
-            },
-            "mime": {
-              "version": "1.3.4",
-              "from": "mime@>=1.2.11 <2.0.0",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
-            },
-            "negotiator": {
-              "version": "0.4.9",
-              "from": "negotiator@>=0.4.5 <0.5.0",
-              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
-            },
-            "node-uuid": {
-              "version": "1.4.3",
-              "from": "node-uuid@>=1.4.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
-            },
-            "once": {
-              "version": "1.3.2",
-              "from": "once@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            },
-            "qs": {
-              "version": "1.2.2",
-              "from": "qs@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
-            },
-            "semver": {
-              "version": "2.3.2",
-              "from": "semver@>=2.3.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
-            },
-            "spdy": {
-              "version": "1.32.4",
-              "from": "spdy@>=1.26.5 <2.0.0",
-              "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.32.4.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.4.1",
-              "from": "tunnel-agent@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-            },
-            "verror": {
-              "version": "1.6.0",
-              "from": "verror@>=1.4.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
-              "dependencies": {
-                "extsprintf": {
-                  "version": "1.2.0",
-                  "from": "extsprintf@1.2.0",
-                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz"
-                }
-              }
-            },
-            "dtrace-provider": {
-              "version": "0.2.8",
-              "from": "dtrace-provider@0.2.8",
-              "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
-            }
-          }
-        }
-      }
+    "eslint-config-fxa": {
+      "version": "1.2.0",
+      "from": "eslint-config-fxa@1.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-fxa/-/eslint-config-fxa-1.2.0.tgz"
     },
     "fxa-jwtool": {
       "version": "0.4.0",
@@ -584,7 +334,7 @@
             },
             "base64url": {
               "version": "1.0.4",
-              "from": "base64url@1.0.4",
+              "from": "base64url@>=1.0.4 <1.1.0",
               "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.4.tgz",
               "dependencies": {
                 "concat-stream": {
@@ -594,7 +344,7 @@
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <3.0.0",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "typedarray": {
@@ -637,9 +387,9 @@
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
-                          "version": "1.1.0",
+                          "version": "1.2.1",
                           "from": "camelcase@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                         },
                         "map-obj": {
                           "version": "1.0.1",
@@ -734,7 +484,7 @@
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <3.0.0",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "typedarray": {
@@ -777,9 +527,9 @@
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
-                          "version": "1.1.0",
+                          "version": "1.2.1",
                           "from": "camelcase@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                         },
                         "map-obj": {
                           "version": "1.0.1",
@@ -1069,6 +819,484 @@
       "from": "grunt-copyright@0.2.0",
       "resolved": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.2.0.tgz"
     },
+    "grunt-eslint": {
+      "version": "14.0.0",
+      "from": "grunt-eslint@14.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-14.0.0.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "eslint": {
+          "version": "0.22.1",
+          "from": "eslint@>=0.22.0 <0.23.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.22.1.tgz",
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.5.0",
+              "from": "concat-stream@>=1.4.6 <2.0.0",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "typedarray": {
+                  "version": "0.0.6",
+                  "from": "typedarray@>=0.0.5 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                },
+                "readable-stream": {
+                  "version": "2.0.2",
+                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.2",
+                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.1",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "debug@>=2.1.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "doctrine": {
+              "version": "0.6.4",
+              "from": "doctrine@>=0.6.2 <0.7.0",
+              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "1.1.6",
+                  "from": "esutils@>=1.1.6 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                }
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "escope": {
+              "version": "3.2.0",
+              "from": "escope@>=3.1.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
+              "dependencies": {
+                "es6-map": {
+                  "version": "0.1.1",
+                  "from": "es6-map@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
+                  "dependencies": {
+                    "d": {
+                      "version": "0.1.1",
+                      "from": "d@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                    },
+                    "es5-ext": {
+                      "version": "0.10.7",
+                      "from": "es5-ext@>=0.10.4 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+                      "dependencies": {
+                        "es6-symbol": {
+                          "version": "2.0.1",
+                          "from": "es6-symbol@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "es6-iterator": {
+                      "version": "0.1.3",
+                      "from": "es6-iterator@>=0.1.3 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                      "dependencies": {
+                        "es6-symbol": {
+                          "version": "2.0.1",
+                          "from": "es6-symbol@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "es6-set": {
+                      "version": "0.1.1",
+                      "from": "es6-set@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz"
+                    },
+                    "es6-symbol": {
+                      "version": "0.1.1",
+                      "from": "es6-symbol@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                    },
+                    "event-emitter": {
+                      "version": "0.3.3",
+                      "from": "event-emitter@>=0.3.1 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                    }
+                  }
+                },
+                "es6-weak-map": {
+                  "version": "0.1.4",
+                  "from": "es6-weak-map@>=0.1.2 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+                  "dependencies": {
+                    "d": {
+                      "version": "0.1.1",
+                      "from": "d@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                    },
+                    "es5-ext": {
+                      "version": "0.10.7",
+                      "from": "es5-ext@>=0.10.6 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz"
+                    },
+                    "es6-iterator": {
+                      "version": "0.1.3",
+                      "from": "es6-iterator@>=0.1.3 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                    },
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "from": "es6-symbol@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                    }
+                  }
+                },
+                "esrecurse": {
+                  "version": "3.1.1",
+                  "from": "esrecurse@>=3.1.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz"
+                },
+                "estraverse": {
+                  "version": "3.1.0",
+                  "from": "estraverse@>=3.1.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
+                }
+              }
+            },
+            "espree": {
+              "version": "2.2.3",
+              "from": "espree@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.3.tgz"
+            },
+            "estraverse": {
+              "version": "2.0.0",
+              "from": "estraverse@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-2.0.0.tgz"
+            },
+            "estraverse-fb": {
+              "version": "1.3.1",
+              "from": "estraverse-fb@>=1.3.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
+            },
+            "globals": {
+              "version": "6.4.1",
+              "from": "globals@>=6.1.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
+            },
+            "inquirer": {
+              "version": "0.8.5",
+              "from": "inquirer@>=0.8.2 <0.9.0",
+              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                },
+                "cli-width": {
+                  "version": "1.0.1",
+                  "from": "cli-width@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz"
+                },
+                "figures": {
+                  "version": "1.3.5",
+                  "from": "figures@>=1.3.5 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.3.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "readline2": {
+                  "version": "0.1.1",
+                  "from": "readline2@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+                  "dependencies": {
+                    "mute-stream": {
+                      "version": "0.0.4",
+                      "from": "mute-stream@0.0.4",
+                      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+                    },
+                    "strip-ansi": {
+                      "version": "2.0.1",
+                      "from": "strip-ansi@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
+                    }
+                  }
+                },
+                "rx": {
+                  "version": "2.5.3",
+                  "from": "rx@>=2.4.3 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz"
+                },
+                "through": {
+                  "version": "2.3.8",
+                  "from": "through@>=2.3.6 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                }
+              }
+            },
+            "is-my-json-valid": {
+              "version": "2.12.1",
+              "from": "is-my-json-valid@>=2.10.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
+              "dependencies": {
+                "generate-function": {
+                  "version": "2.0.0",
+                  "from": "generate-function@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                },
+                "generate-object-property": {
+                  "version": "1.2.0",
+                  "from": "generate-object-property@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                  "dependencies": {
+                    "is-property": {
+                      "version": "1.0.2",
+                      "from": "is-property@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                    }
+                  }
+                },
+                "jsonpointer": {
+                  "version": "1.1.0",
+                  "from": "jsonpointer@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            },
+            "js-yaml": {
+              "version": "3.3.1",
+              "from": "js-yaml@>=3.2.5 <4.0.0",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.2",
+                  "from": "argparse@>=1.0.2 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "3.10.1",
+                      "from": "lodash@>=3.2.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                    },
+                    "sprintf-js": {
+                      "version": "1.0.3",
+                      "from": "sprintf-js@>=1.0.2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.2.0",
+                  "from": "esprima@>=2.2.0 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.1.1",
+              "from": "object-assign@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+            },
+            "optionator": {
+              "version": "0.5.0",
+              "from": "optionator@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+              "dependencies": {
+                "prelude-ls": {
+                  "version": "1.1.2",
+                  "from": "prelude-ls@>=1.1.1 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                },
+                "deep-is": {
+                  "version": "0.1.3",
+                  "from": "deep-is@>=0.1.2 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                },
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                },
+                "type-check": {
+                  "version": "0.3.1",
+                  "from": "type-check@>=0.3.1 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                },
+                "levn": {
+                  "version": "0.2.5",
+                  "from": "levn@>=0.2.5 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                },
+                "fast-levenshtein": {
+                  "version": "1.0.6",
+                  "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+            },
+            "strip-json-comments": {
+              "version": "1.0.4",
+              "from": "strip-json-comments@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "from": "text-table@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+            },
+            "user-home": {
+              "version": "1.1.1",
+              "from": "user-home@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+            },
+            "xml-escape": {
+              "version": "1.0.0",
+              "from": "xml-escape@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
     "grunt-nsp-shrinkwrap": {
       "version": "0.0.3",
       "from": "grunt-nsp-shrinkwrap@0.0.3",
@@ -1142,7 +1370,7 @@
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.6.5",
-                      "from": "lru-cache@>=2.5.0 <3.0.0",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                     },
                     "sigmund": {
@@ -1190,7 +1418,7 @@
               "dependencies": {
                 "lru-cache": {
                   "version": "2.6.5",
-                  "from": "lru-cache@>=2.5.0 <3.0.0",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                 },
                 "sigmund": {
@@ -1478,7 +1706,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
@@ -1575,7 +1803,7 @@
         },
         "node-uuid": {
           "version": "1.4.3",
-          "from": "node-uuid@>=1.4.1 <2.0.0",
+          "from": "node-uuid@>=1.4.0 <1.5.0",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
         },
         "qs": {
@@ -1677,41 +1905,149 @@
       }
     },
     "restify": {
-      "version": "2.8.1",
-      "from": "restify@2.8.1",
-      "resolved": "https://registry.npmjs.org/restify/-/restify-2.8.1.tgz",
+      "version": "2.8.2",
+      "from": "restify@2.8.2",
+      "resolved": "https://registry.npmjs.org/restify/-/restify-2.8.2.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "0.1.5",
-          "from": "assert-plus@0.1.5",
+          "from": "assert-plus@>=0.1.5 <0.2.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
         },
         "backoff": {
-          "version": "2.3.0",
-          "from": "backoff@2.3.0",
-          "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.3.0.tgz"
+          "version": "2.4.1",
+          "from": "backoff@>=2.3.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
+          "dependencies": {
+            "precond": {
+              "version": "0.2.3",
+              "from": "precond@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
+            }
+          }
         },
         "bunyan": {
-          "version": "0.22.1",
-          "from": "bunyan@0.22.1",
-          "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.22.1.tgz",
+          "version": "0.23.1",
+          "from": "bunyan@>=0.23.1 <0.24.0",
+          "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.23.1.tgz",
           "dependencies": {
             "mv": {
-              "version": "0.0.5",
-              "from": "mv@0.0.5",
-              "resolved": "https://registry.npmjs.org/mv/-/mv-0.0.5.tgz"
+              "version": "2.1.1",
+              "from": "mv@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+              "dependencies": {
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "mkdirp@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "ncp": {
+                  "version": "2.0.0",
+                  "from": "ncp@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
+                },
+                "rimraf": {
+                  "version": "2.4.2",
+                  "from": "rimraf@>=2.4.0 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "5.0.14",
+                      "from": "glob@>=5.0.14 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "inflight@>=1.0.4 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "2.0.10",
+                          "from": "minimatch@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.0",
+                              "from": "brace-expansion@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.2.0",
+                                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "concat-map@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         },
         "csv": {
-          "version": "0.3.7",
-          "from": "csv@0.3.7",
-          "resolved": "https://registry.npmjs.org/csv/-/csv-0.3.7.tgz"
+          "version": "0.4.5",
+          "from": "csv@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/csv/-/csv-0.4.5.tgz",
+          "dependencies": {
+            "csv-generate": {
+              "version": "0.0.6",
+              "from": "csv-generate@>=0.0.6 <0.0.7",
+              "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.6.tgz"
+            },
+            "csv-parse": {
+              "version": "0.1.4",
+              "from": "csv-parse@>=0.1.3 <0.2.0",
+              "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-0.1.4.tgz"
+            },
+            "stream-transform": {
+              "version": "0.1.0",
+              "from": "stream-transform@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.1.0.tgz"
+            },
+            "csv-stringify": {
+              "version": "0.0.8",
+              "from": "csv-stringify@>=0.0.8 <0.0.9",
+              "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-0.0.8.tgz"
+            }
+          }
         },
         "deep-equal": {
-          "version": "0.0.0",
-          "from": "deep-equal@>=0.0.0 <0.1.0",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
+          "version": "0.2.2",
+          "from": "deep-equal@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz"
         },
         "escape-regexp-component": {
           "version": "1.0.2",
@@ -1719,97 +2055,99 @@
           "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
         },
         "formidable": {
-          "version": "1.0.14",
-          "from": "formidable@1.0.14",
-          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
+          "version": "1.0.17",
+          "from": "formidable@>=1.0.14 <2.0.0",
+          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
         },
         "http-signature": {
-          "version": "0.10.0",
-          "from": "http-signature@0.10.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+          "version": "0.10.1",
+          "from": "http-signature@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
           "dependencies": {
-            "assert-plus": {
-              "version": "0.1.2",
-              "from": "assert-plus@0.1.2",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
-            },
             "asn1": {
               "version": "0.1.11",
               "from": "asn1@0.1.11",
               "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
             },
             "ctype": {
-              "version": "0.5.2",
-              "from": "ctype@0.5.2",
-              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+              "version": "0.5.3",
+              "from": "ctype@0.5.3",
+              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
             }
           }
         },
         "keep-alive-agent": {
           "version": "0.0.1",
-          "from": "keep-alive-agent@0.0.1",
+          "from": "keep-alive-agent@>=0.0.1 <0.0.2",
           "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
         },
         "lru-cache": {
-          "version": "2.3.1",
-          "from": "lru-cache@2.3.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz"
+          "version": "2.6.5",
+          "from": "lru-cache@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
         },
         "mime": {
-          "version": "1.2.11",
-          "from": "mime@1.2.11",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+          "version": "1.3.4",
+          "from": "mime@>=1.2.11 <2.0.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         },
         "negotiator": {
-          "version": "0.3.0",
-          "from": "negotiator@0.3.0",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz"
+          "version": "0.4.9",
+          "from": "negotiator@>=0.4.5 <0.5.0",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
         },
         "node-uuid": {
-          "version": "1.4.1",
-          "from": "node-uuid@1.4.1",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+          "version": "1.4.3",
+          "from": "node-uuid@>=1.4.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
         },
         "once": {
-          "version": "1.3.0",
-          "from": "once@1.3.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.0.tgz"
+          "version": "1.3.2",
+          "from": "once@>=1.3.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+          "dependencies": {
+            "wrappy": {
+              "version": "1.0.1",
+              "from": "wrappy@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+            }
+          }
         },
         "qs": {
-          "version": "0.6.6",
-          "from": "qs@0.6.6",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+          "version": "1.2.2",
+          "from": "qs@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
         },
         "semver": {
-          "version": "2.2.1",
-          "from": "semver@2.2.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz"
+          "version": "2.3.2",
+          "from": "semver@>=2.3.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
         },
         "spdy": {
-          "version": "1.19.3",
-          "from": "spdy@1.19.3",
-          "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.19.3.tgz"
+          "version": "1.32.4",
+          "from": "spdy@>=1.26.5 <2.0.0",
+          "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.32.4.tgz"
         },
         "tunnel-agent": {
-          "version": "0.4.0",
-          "from": "tunnel-agent@0.4.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+          "version": "0.4.1",
+          "from": "tunnel-agent@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
         },
         "verror": {
-          "version": "1.3.7",
-          "from": "verror@1.3.7",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.7.tgz",
+          "version": "1.6.0",
+          "from": "verror@>=1.4.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
           "dependencies": {
             "extsprintf": {
-              "version": "1.0.2",
-              "from": "extsprintf@1.0.2",
-              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+              "version": "1.2.0",
+              "from": "extsprintf@1.2.0",
+              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz"
             }
           }
         },
         "dtrace-provider": {
           "version": "0.2.8",
-          "from": "dtrace-provider@0.2.8",
+          "from": "dtrace-provider@>=0.2.8 <0.3.0",
           "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
         }
       }
@@ -1853,7 +2191,7 @@
         },
         "glob": {
           "version": "3.2.11",
-          "from": "glob@>=3.2.9 <3.3.0",
+          "from": "glob@>=3.2.1 <3.3.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "minimatch": {
@@ -1877,7 +2215,7 @@
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "inherits@>=2.0.0 <3.0.0",
+          "from": "inherits@*",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "mkdirp": {

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
     "bluebird": "2.1.3",
     "clone": "0.2.0",
     "convict": "0.4.2",
-    "fxa-auth-db-server": "file:fxa-auth-db-server",
     "fxa-jwtool": "0.4.0",
     "mozlog": "2.0.0",
     "mysql": "2.3.2",
-    "request": "2.53.0"
+    "request": "2.53.0",
+    "restify": "2.8.2"
   },
   "devDependencies": {
     "ass": "git://github.com/jrgm/ass.git#5be99ee",
@@ -46,7 +46,6 @@
     "load-grunt-tasks": "0.6.0",
     "mysql-patcher": "0.7.0",
     "nock": "1.2.0",
-    "restify": "2.8.1",
     "tap": "0.4.13"
   },
   "keywords": [

--- a/test/backend/db_tests.js
+++ b/test/backend/db_tests.js
@@ -2,8 +2,8 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 require('ass')
-var dbServer = require('fxa-auth-db-server')
-var dbTests = require('fxa-auth-db-server/test/backend').dbTests
+var dbServer = require('../../fxa-auth-db-server')
+var dbTests = require('../../fxa-auth-db-server/test/backend').dbTests
 var log = { trace: console.log, error: console.log, stat: console.log, info: console.log }
 var DB = require('../../lib/db/mysql')(log, dbServer.errors)
 var config = require('../../config')

--- a/test/backend/remote.js
+++ b/test/backend/remote.js
@@ -2,8 +2,8 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 require('ass')
-var dbServer = require('fxa-auth-db-server')
-var backendTests = require('fxa-auth-db-server/test/backend')
+var dbServer = require('../../fxa-auth-db-server')
+var backendTests = require('../../fxa-auth-db-server/test/backend')
 var config = require('../../config')
 var noop = function () {}
 var log = { trace: noop, error: noop, stat: noop, info: noop }

--- a/test/local/event_log.js
+++ b/test/local/event_log.js
@@ -2,11 +2,11 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 require('ass')
-var dbServer = require('fxa-auth-db-server')
+var dbServer = require('../../fxa-auth-db-server')
 var test = require('../ptaptest')
 var log = { trace: console.log, error: console.log, info: console.log }
 var DB = require('../../lib/db/mysql')(log, dbServer.errors)
-var fake = require('fxa-auth-db-server/test/fake')
+var fake = require('../../fxa-auth-db-server/test/fake')
 var config = require('../../config')
 var P = require('../../lib/promise')
 

--- a/test/local/incorrect-patch-level.js
+++ b/test/local/incorrect-patch-level.js
@@ -2,7 +2,7 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 require('ass')
-var dbServer = require('fxa-auth-db-server')
+var dbServer = require('../../fxa-auth-db-server')
 var log = { trace: console.log, error: console.log, stat: console.log, info: console.log }
 var DB = require('../../lib/db/mysql')(log, dbServer.errors)
 var config = require('../../config')

--- a/test/local/log-stats.js
+++ b/test/local/log-stats.js
@@ -2,7 +2,7 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 require('ass')
-var dbServer = require('fxa-auth-db-server')
+var dbServer = require('../../fxa-auth-db-server')
 var test = require('../ptaptest')
 var P = require('../../lib/promise')
 var config = require('../../config')

--- a/test/local/mysql_tests.js
+++ b/test/local/mysql_tests.js
@@ -2,7 +2,7 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 require('ass')
-var dbServer = require('fxa-auth-db-server')
+var dbServer = require('../../fxa-auth-db-server')
 var log = { trace: console.log, error: console.log, stat: console.log, info: console.log }
 var DB = require('../../lib/db/mysql')(log, dbServer.errors)
 var config = require('../../config')

--- a/test/local/prune_tokens.js
+++ b/test/local/prune_tokens.js
@@ -2,11 +2,11 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 require('ass')
-var dbServer = require('fxa-auth-db-server')
+var dbServer = require('../../fxa-auth-db-server')
 var test = require('../ptaptest')
 var log = { trace: console.log, error: console.log, info: console.log }
 var DB = require('../../lib/db/mysql')(log, dbServer.errors)
-var fake = require('fxa-auth-db-server/test/fake')
+var fake = require('../../fxa-auth-db-server/test/fake')
 var config = require('../../config')
 
 var oneDay = 24 * 60 * 60 * 1000

--- a/test/mem/db_tests.js
+++ b/test/mem/db_tests.js
@@ -2,8 +2,8 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 require('ass')
-var dbServer = require('fxa-auth-db-server')
-var dbTests = require('fxa-auth-db-server/test/backend').dbTests
+var dbServer = require('../../fxa-auth-db-server')
+var dbTests = require('../../fxa-auth-db-server/test/backend').dbTests
 var log = { trace: console.log, error: console.log, stat: console.log, info: console.log }
 var DB = require('../../lib/db/mem')(log, dbServer.errors)
 var config = require('../../config')

--- a/test/mem/remote.js
+++ b/test/mem/remote.js
@@ -2,8 +2,8 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 require('ass')
-var dbServer = require('fxa-auth-db-server')
-var backendTests = require('fxa-auth-db-server/test/backend')
+var dbServer = require('../../fxa-auth-db-server')
+var backendTests = require('../../fxa-auth-db-server/test/backend')
 var config = require('../../config')
 var noop = function () {}
 var log = { trace: noop, error: noop, stat: noop, info: noop }


### PR DESCRIPTION
The npm 'file' trick doesn't work when this package is required by another, i.e. fxa-auth-server. Instead, directly require files in the fxa-auth-db-server dir and duplicate the restify dep.

@philbooth @jrgm 