### PR TITLE
Preliminary support for authenticating with OpenID

### DIFF
--- a/fxa-auth-db-server/index.js
+++ b/fxa-auth-db-server/index.js
@@ -106,6 +106,8 @@ function createServer(db) {
   api.get('/emailRecord/:id', reply(db.emailRecord))
   api.head('/emailRecord/:id', reply(db.accountExists))
 
+  api.get('/openIdRecord/:id', reply(db.openIdRecord))
+
   api.get('/__heartbeat__', reply(db.ping))
 
   api.get(

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the schema/ directory.
-module.exports.level = 15
+module.exports.level = 16

--- a/lib/db/schema/patch-015-016.sql
+++ b/lib/db/schema/patch-015-016.sql
@@ -1,0 +1,177 @@
+
+-- A new table to hold a history of account lifecycle events.
+-- Events are added in simple increasing auto-increment order.
+CREATE TABLE openids (
+    hash BINARY(32) PRIMARY KEY,
+    id VARCHAR(255) NOT NULL,
+    uid BINARY(16) NOT NULL,
+    INDEX openid_uid (uid)
+) ENGINE=InnoDB;
+
+
+-- added openid
+CREATE PROCEDURE `createAccount_3` (
+    IN `uid` BINARY(16) ,
+    IN `normalizedEmail` VARCHAR(255),
+    IN `email` VARCHAR(255),
+    IN `emailCode` BINARY(16),
+    IN `emailVerified` TINYINT(1),
+    IN `kA` BINARY(32),
+    IN `wrapWrapKb` BINARY(32),
+    IN `authSalt` BINARY(32),
+    IN `verifierVersion` TINYINT UNSIGNED,
+    IN `verifyHash` BINARY(32),
+    IN `verifierSetAt` BIGINT UNSIGNED,
+    IN `createdAt` BIGINT UNSIGNED,
+    IN `locale` VARCHAR(255),
+    IN `openid` VARCHAR(255),
+    IN `openidHash` BINARY(32)
+)
+BEGIN
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    START TRANSACTION;
+
+    INSERT INTO accounts(
+        uid,
+        normalizedEmail,
+        email,
+        emailCode,
+        emailVerified,
+        kA,
+        wrapWrapKb,
+        authSalt,
+        verifierVersion,
+        verifyHash,
+        verifierSetAt,
+        createdAt,
+        locale
+    )
+    VALUES(
+        uid,
+        LOWER(normalizedEmail),
+        email,
+        emailCode,
+        emailVerified,
+        kA,
+        wrapWrapKb,
+        authSalt,
+        verifierVersion,
+        verifyHash,
+        verifierSetAt,
+        createdAt,
+        locale
+    );
+
+    IF openid IS NOT NULL THEN
+        INSERT INTO openids(
+            hash,
+            id,
+            uid
+        )
+        VALUES(
+            openidHash,
+            openid,
+            uid
+        );
+    END IF;
+
+    INSERT INTO eventLog(
+        uid,
+        typ,
+        iat
+    )
+    VALUES(
+        uid,
+        "create",
+        UNIX_TIMESTAMP()
+    );
+
+    IF emailVerified THEN
+        INSERT INTO eventLog(
+            uid,
+            typ,
+            iat
+        )
+        VALUES(
+            uid,
+            "verify",
+            UNIX_TIMESTAMP()
+        );
+    END IF;
+
+    COMMIT;
+END;
+
+CREATE PROCEDURE `openIdRecord_1` (
+    IN `openidHash` BINARY(32)
+)
+BEGIN
+    SELECT
+        a.uid,
+        a.email,
+        a.normalizedEmail,
+        a.emailVerified,
+        a.emailCode,
+        a.kA,
+        a.wrapWrapKb,
+        a.verifierVersion,
+        a.authSalt,
+        a.verifierSetAt,
+        a.lockedAt,
+        o.id as openId
+    FROM
+        accounts a,
+        openids o
+    WHERE
+        o.hash = openidHash
+    AND
+        o.uid = a.uid
+    ;
+END;
+
+
+CREATE PROCEDURE `deleteAccount_5` (
+    IN `inUid` BINARY(16)
+)
+BEGIN
+
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    START TRANSACTION;
+
+    DELETE FROM sessionTokens WHERE uid = inUid;
+    DELETE FROM keyFetchTokens WHERE uid = inUid;
+    DELETE FROM accountResetTokens WHERE uid = inUid;
+    DELETE FROM passwordChangeTokens WHERE uid = inUid;
+    DELETE FROM passwordForgotTokens WHERE uid = inUid;
+    DELETE FROM accountUnlockCodes WHERE uid = inUid;
+    DELETE FROM accounts WHERE uid = inUid;
+    DELETE FROM openids WHERE uid = inUid;
+
+    INSERT INTO eventLog(
+        uid,
+        typ,
+        iat
+    )
+    VALUES(
+        inUid,
+        "delete",
+        UNIX_TIMESTAMP()
+    );
+
+    COMMIT;
+
+END;
+
+
+-- Schema patch-level increment.
+UPDATE dbMetadata SET value = '16' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-016-015.sql
+++ b/lib/db/schema/patch-016-015.sql
@@ -1,0 +1,7 @@
+-- DROP PROCEDURE `createAccount_3`;
+-- DROP PROCEDURE `openIdRecord_1`;
+-- DROP PROCEDURE `deleteAccount_5`;
+
+-- DROP TABLE `openids`;
+
+-- UPDATE dbMetadata SET value = '15' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
This adds an endpoint for getting account info with an OpenID identifier and updates account create/delete for an optional OpenID.

A new table `openids` stores the relation between OpenID identifier and uid. Since these identifiers can be fairly long I added a sha256 hash as the primary key. I'm not 100% sure whether that's a good idea or not.