### PR TITLE
feat(db): add queries for metrics reporting

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -40,6 +40,15 @@ There are a number of methods that a DB storage backend should implement:
     * .ping()
     * .close()
 
+The MySQL backend also implements
+some additional methods for metrics reporting:
+
+* .countAccountsCreatedBefore(createdBefore)
+* .countVerifiedAccountsCreatedBefore(createdBefore)
+* .countAccountsWithTwoOrMoreDevices()
+* .countAccountsWithThreeOrMoreDevices()
+* .countAccountsWithMobileDevice()
+
 ## Types ##
 
 # Parameters #
@@ -359,6 +368,6 @@ Parameters:
     * tokenId
     * data
     * uid
-    * createdA
+    * createdAt
 
 (Ends)

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -554,6 +554,48 @@ module.exports = function (log, error) {
     return this.readFirstResult(GET_UNLOCK_CODE, [uid])
   }
 
+  // METRICS
+
+  // Select : accounts
+  // Where  : createdAt < $1
+  var COUNT_ACCOUNTS_CREATED_BEFORE = 'call countAccountsCreatedBefore_1(?)'
+
+  MySql.prototype.countAccountsCreatedBefore = function (createdBefore) {
+    return this.readFirstResult(COUNT_ACCOUNTS_CREATED_BEFORE, [createdBefore])
+  }
+
+  // Select : accounts
+  // Where  : emailVerified = true AND createdAt < $1
+  var COUNT_VERIFIED_ACCOUNTS_CREATED_BEFORE = 'call countVerifiedAccountsCreatedBefore_1(?)'
+
+  MySql.prototype.countVerifiedAccountsCreatedBefore = function (createdBefore) {
+    return this.readFirstResult(COUNT_VERIFIED_ACCOUNTS_CREATED_BEFORE, [createdBefore])
+  }
+
+  // Select : sessionTokens
+  // Where  : COUNT(tokenId) > 1
+  var COUNT_ACCOUNTS_WITH_TWO_OR_MORE_DEVICES = 'call countAccountsWithTwoOrMoreDevices_1'
+
+  MySql.prototype.countAccountsWithTwoOrMoreDevices = function () {
+    return this.readFirstResult(COUNT_ACCOUNTS_WITH_TWO_OR_MORE_DEVICES)
+  }
+
+  // Select : sessionTokens
+  // Where  : COUNT(tokenId) > 2
+  var COUNT_ACCOUNTS_WITH_THREE_OR_MORE_DEVICES = 'call countAccountsWithThreeOrMoreDevices_1'
+
+  MySql.prototype.countAccountsWithThreeOrMoreDevices = function () {
+    return this.readFirstResult(COUNT_ACCOUNTS_WITH_THREE_OR_MORE_DEVICES)
+  }
+
+  // Select : sessionTokens
+  // Where  : uaDeviceType = 'mobile'
+  var COUNT_ACCOUNTS_WITH_MOBILE_DEVICE = 'call countAccountsWithMobileDevice_1'
+
+  MySql.prototype.countAccountsWithMobileDevice = function () {
+    return this.readFirstResult(COUNT_ACCOUNTS_WITH_MOBILE_DEVICE)
+  }
+
   // Internal
 
   MySql.prototype.singleQuery = function (poolName, sql, params) {

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the schema/ directory.
-module.exports.level = 15
+module.exports.level = 16

--- a/lib/db/schema/patch-015-016.sql
+++ b/lib/db/schema/patch-015-016.sql
@@ -1,0 +1,46 @@
+-- Add queries for metrics reporting
+
+CREATE PROCEDURE `countAccountsCreatedBefore_1` (
+    IN createdBefore BIGINT UNSIGNED
+)
+BEGIN
+    SELECT COUNT(*) AS count FROM accounts
+    WHERE createdAt < createdBefore;
+END;
+
+CREATE PROCEDURE `countVerifiedAccountsCreatedBefore_1` (
+    IN createdBefore BIGINT UNSIGNED
+)
+BEGIN
+    SELECT COUNT(*) AS count FROM accounts
+    WHERE createdAt < createdBefore
+    AND emailVerified = true;
+END;
+
+CREATE PROCEDURE `countAccountsWithTwoOrMoreDevices_1` ()
+BEGIN
+    SELECT COUNT(*) AS count FROM (
+        SELECT uid FROM sessionTokens
+        GROUP BY uid
+        HAVING COUNT(tokenId) > 1
+    ) AS s;
+END;
+
+CREATE PROCEDURE `countAccountsWithThreeOrMoreDevices_1` ()
+BEGIN
+    SELECT COUNT(*) AS count FROM (
+        SELECT uid FROM sessionTokens
+        GROUP BY uid
+        HAVING COUNT(tokenId) > 2
+    ) AS s;
+END;
+
+CREATE PROCEDURE `countAccountsWithMobileDevice_1` ()
+BEGIN
+    SELECT COUNT(DISTINCT uid) AS count
+    FROM sessionTokens
+    WHERE uaDeviceType = 'mobile';
+END;
+
+UPDATE dbMetadata SET value = '16' WHERE name = 'schema-patch-level';
+

--- a/lib/db/schema/patch-016-015.sql
+++ b/lib/db/schema/patch-016-015.sql
@@ -1,0 +1,9 @@
+-- -- drop new stored procedures
+-- DROP PROCEDURE `countAccountsCreatedBefore_1`;
+-- DROP PROCEDURE `countVerifiedAccountsCreatedBefore_1`;
+-- DROP PROCEDURE `countAccountsWithTwoOrMoreDevices_1`;
+-- DROP PROCEDURE `countAccountsWithThreeOrMoreDevices_1`;
+-- DROP PROCEDURE `countAccountsWithMobileDevice_1`;
+
+-- -- Schema patch-level decrement.
+-- UPDATE dbMetadata SET value = '15' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
Fixes #72.

I was unsure about a couple of things:

1. Naming. Both generally, the `count...` convention, and specifically, `countMultiDeviceAccounts` / `countThreePlusDeviceAccounts`. Changing `Multi` to `TwoPlus` would make those two more consistent but I *hate* the name of the `ThreePlus` procedure anyway, so it would only make them consistently bad imho. Suggestions?

2. Tests. I'm testing that the procedures don't fail and that they return a non-negative count. But I'm not testing that the queries actually work, because I don't know the state of the database that they'll be run against. Do we do any database testing against known fixture data like that?