### PR TITLE
feat(db): add script for reporting metrics

### DIFF
--- a/bin/metrics.js
+++ b/bin/metrics.js
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+var fs = require('fs')
+
+module.exports = {
+  run: run,
+  countAccounts: [
+    'SELECT COUNT(*) AS count',
+    'FROM accounts',
+    'WHERE createdAt < ?;'
+  ].join('\n'),
+  countVerifiedAccounts: [
+    'SELECT COUNT(*) AS count',
+    'FROM accounts',
+    'WHERE createdAt < ?',
+    'AND emailVerified = true;'
+  ].join('\n'),
+  countAccountsWithTwoOrMoreDevices: [
+    'SELECT COUNT(*) AS count',
+    'FROM (',
+    '    SELECT a.uid',
+    '    FROM accounts AS a',
+    '    INNER JOIN sessionTokens AS s',
+    '    ON a.uid = s.uid',
+    '    WHERE a.createdAt < ?',
+    '    GROUP BY (a.uid)',
+    '    HAVING COUNT(s.tokenId) > 1',
+    ') AS sub;'
+  ].join('\n'),
+  countAccountsWithThreeOrMoreDevices: [
+    'SELECT COUNT(*) AS count',
+    'FROM (',
+    '    SELECT a.uid',
+    '    FROM accounts AS a',
+    '    INNER JOIN sessionTokens AS s',
+    '    ON a.uid = s.uid',
+    '    WHERE a.createdAt < ?',
+    '    GROUP BY (a.uid)',
+    '    HAVING COUNT(s.tokenId) > 2',
+    ') AS sub;'
+  ].join('\n'),
+  countAccountsWithMobileDevice: [
+    'SELECT COUNT(DISTINCT a.uid) AS count',
+    'FROM accounts AS a',
+    'INNER JOIN sessionTokens AS s',
+    'ON a.uid = s.uid',
+    'WHERE a.createdAt < ?',
+    'AND s.uaDeviceType = \'mobile\';'
+  ].join('\n')
+}
+
+if (require.main === module) {
+  module.exports.run(
+    parseConfigFile(process.argv[2] || '/etc/gather_basic_metrics.conf')
+  )
+}
+
+function run (config, now) {
+  now = now || new Date()
+  var lastMidnight = Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate(),
+    0, 0, 0, 0
+  )
+  var os = require('os')
+  var log = require('../lib/logging')('bin.metrics')
+  var mysql = require('../lib/db/mysql')(log, require('../fxa-auth-db-server').errors)
+  var P = require('../lib/promise')
+  var self = this
+  var db
+
+  return mysql.connect({
+    master: {
+      host: config.General.db_dnsname,
+      user: config.General.db_username,
+      password: config.General.db_password,
+      database: config.General.db_name
+    },
+    slave: {
+      host: config.General.db_dnsname,
+      user: config.General.db_username,
+      password: config.General.db_password,
+      database: config.General.db_name
+    },
+    patchKey: 'schema-patch-level'
+  })
+  .then(function (result) {
+    db = result
+    return db.readMultiple([
+      { sql: 'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED' },
+      { sql: 'START TRANSACTION' },
+      metricsQuery('countAccounts'),
+      metricsQuery('countVerifiedAccounts'),
+      metricsQuery('countAccountsWithTwoOrMoreDevices'),
+      metricsQuery('countAccountsWithThreeOrMoreDevices'),
+      metricsQuery('countAccountsWithMobileDevice'),
+    ], { sql: 'COMMIT' })
+  })
+  .then(function (results) {
+    assertResults(results, 2, 6)
+    fs.appendFileSync('/media/ephemeral0/fxa-admin/basic_metrics.log', JSON.stringify({
+      hostname: os.hostname(),
+      pid: process.pid,
+      op: 'account_totals',
+      total_accounts: results[2][0].count,
+      total_verified_accounts: results[3][0].count,
+      total_accounts_with_two_or_more_devices: results[4][0].count,
+      total_accounts_with_three_or_more_devices: results[5][0].count,
+      total_accounts_with_mobile_device: results[6][0].count,
+      time: (new Date(lastMidnight)).toISOString(),
+      v: 0
+    }))
+    db.close()
+  })
+  .catch(function (error) {
+    log.error('metrics.run', error)
+    db.close()
+  })
+
+  function metricsQuery (queryName) {
+    return { sql: self[queryName], params: [ lastMidnight ] }
+  }
+}
+
+function assertResults (results, firstIndex, lastIndex) {
+  results.filter(function (result, index) {
+    return index >= firstIndex && index <= lastIndex
+  }).forEach(assertResult)
+}
+
+function assertResult (result) {
+  if (Array.isArray(result) && result.length === 1 && result[0].count >= 0) {
+    return
+  }
+
+  throw new Error('unexpected metrics query result format, should be [ { count: n } ]')
+}
+
+// Very rudimentary parser for the following config file format:
+// [General]
+// db_dnsname: foo
+// db_username: bar
+// db_password: baz
+// db_name: qux
+function parseConfigFile (path) {
+  var currentSection
+
+  return fs.readFileSync(path, { encoding: 'utf8' })
+    .split('\n')
+    .map(trim)
+    .filter(filterConfig)
+    .reduce(reduceConfig, {})
+
+  function reduceConfig (parsed, line) {
+    var isSectionName = line.match(/^\[(.+)\]$/)
+
+    if (isSectionName) {
+      currentSection = isSectionName[1]
+
+      if (! parsed[currentSection]) {
+        parsed[currentSection] = {}
+      }
+    } else {
+      var setting = line.split(':').map(trim)
+
+      if (! currentSection || setting.length === 0 || setting.length > 2) {
+        throw new Error('unexpected config file format')
+      }
+
+      parsed[currentSection][setting[0]] = setting[1]
+    }
+
+    return parsed
+  }
+}
+
+function trim (string) {
+  return string.trim()
+}
+
+function filterConfig (line) {
+  return line && line[0] !== '#' && line[0] !== ';'
+}
+

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "load-grunt-tasks": "0.6.0",
     "mysql-patcher": "0.7.0",
     "nock": "1.2.0",
+    "proxyquire": "1.7.0",
+    "sinon": "1.16.0",
     "tap": "0.4.13"
   },
   "keywords": [

--- a/test/local/metrics_tests.js
+++ b/test/local/metrics_tests.js
@@ -1,0 +1,357 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+require('ass')
+var log = { trace: console.log, error: console.log, stat: console.log, info: console.log }
+var DB = require('../../lib/db/mysql')(log, require('../../fxa-auth-db-server').errors)
+var config = require('../../config')
+var test = require('../ptaptest')
+var P = require('../../lib/promise')
+var crypto = require('crypto')
+var path = require('path')
+var proxyquire = require('proxyquire')
+var sinon = require('sinon')
+
+var zeroBuffer16 = Buffer('00000000000000000000000000000000', 'hex')
+var zeroBuffer32 = Buffer('0000000000000000000000000000000000000000000000000000000000000000', 'hex')
+
+DB.connect(config)
+  .then(function (db) {
+    test(
+      'queries, with no mocking',
+      function (t) {
+        var metrics = require('../../bin/metrics')
+        var lastResults
+        var uid
+        var times = [
+          Date.now()
+        ]
+        t.plan(35)
+
+        t.equal(typeof metrics.run, 'function', 'run function was exported')
+        t.equal(typeof metrics.countAccounts, 'string', 'countAccounts string was exported')
+        t.equal(typeof metrics.countVerifiedAccounts, 'string', 'countVerifiedAccounts string was exported')
+        t.equal(typeof metrics.countAccountsWithTwoOrMoreDevices, 'string', 'countAccountsWithTwoOrMoreDevices string was exported')
+        t.equal(typeof metrics.countAccountsWithThreeOrMoreDevices, 'string', 'countAccountsWithThreeOrMoreDevices string was exported')
+        t.equal(typeof metrics.countAccountsWithMobileDevice, 'string', 'countAccountsWithMobileDevice string was exported')
+
+        return P.all([
+          db.readOneFromFirstResult(metrics.countAccounts, times[0]),
+          db.readOneFromFirstResult(metrics.countVerifiedAccounts, times[0]),
+          db.readOneFromFirstResult(metrics.countAccountsWithTwoOrMoreDevices, times[0]),
+          db.readOneFromFirstResult(metrics.countAccountsWithThreeOrMoreDevices, times[0]),
+          db.readOneFromFirstResult(metrics.countAccountsWithMobileDevice, times[0])
+        ])
+        .then(function (results) {
+          results.forEach(function (result, index) {
+            t.ok(result.count >= 0, 'returned non-negative count [' + index + ']')
+          })
+          lastResults = results
+          uid = crypto.randomBytes(16)
+          times[1] = Date.now()
+          return createAccount(uid, times[1], false)
+        })
+        .then(function () {
+          return db.readMultiple([
+            { sql: metrics.countAccounts, params: times[1] + 1 },
+            { sql: metrics.countVerifiedAccounts, params: times[1] + 1 },
+            { sql: metrics.countAccountsWithTwoOrMoreDevices, params: times[1] + 1 },
+            { sql: metrics.countAccountsWithThreeOrMoreDevices, params: times[1] + 1 },
+            { sql: metrics.countAccountsWithMobileDevice, params: times[1] + 1 }
+          ])
+        })
+        .then(function (results) {
+          t.ok(results[0][0].count === lastResults[0].count + 1, 'account count was incremented by one')
+          t.ok(results[1][0].count === lastResults[1].count, 'verified account count was not incremented')
+          t.ok(results[2][0].count === lastResults[2].count, '2+ device account count was not incremented')
+          t.ok(results[3][0].count === lastResults[3].count, '3+ device account count was not incremented')
+          t.ok(results[4][0].count === lastResults[4].count, 'mobile device account count was not incremented')
+          lastResults = results
+          return deleteAccount(uid)
+        })
+        .then(function () {
+          times[2] = Date.now()
+          return createAccount(uid, times[2], true)
+        })
+        .then(function () {
+          return db.readMultiple([
+            { sql: 'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED' },
+            { sql: 'START TRANSACTION' },
+            { sql: metrics.countAccounts, params: times[2] + 1 },
+            { sql: metrics.countVerifiedAccounts, params: times[2] + 1 },
+            { sql: metrics.countAccountsWithTwoOrMoreDevices, params: times[2] + 1 },
+            { sql: metrics.countAccountsWithThreeOrMoreDevices, params: times[2] + 1 },
+            { sql: metrics.countAccountsWithMobileDevice, params: times[2] + 1 }
+          ], { sql: 'COMMIT' })
+        })
+        .then(function (results) {
+          t.ok(results[2][0].count === lastResults[0][0].count, 'account count was not incremented')
+          t.ok(results[3][0].count === lastResults[1][0].count + 1, 'verified account count was incremented by one')
+          t.ok(results[4][0].count === lastResults[2][0].count, '2+ device account count was not incremented')
+          t.ok(results[5][0].count === lastResults[3][0].count, '3+ device account count was not incremented')
+          t.ok(results[6][0].count === lastResults[4][0].count, 'mobile device account count was not incremented')
+          lastResults = results
+          return P.all([
+            createSessionToken(uid),
+            createSessionToken(uid)
+          ])
+        })
+        .then(function () {
+          return P.all([
+            db.readOneFromFirstResult(metrics.countAccounts, times[2]),
+            db.readOneFromFirstResult(metrics.countVerifiedAccounts, times[2]),
+            db.readOneFromFirstResult(metrics.countAccountsWithTwoOrMoreDevices, times[2] + 1),
+            db.readOneFromFirstResult(metrics.countAccountsWithThreeOrMoreDevices, times[2] + 1),
+            db.readOneFromFirstResult(metrics.countAccountsWithMobileDevice, times[2] + 1)
+          ])
+        })
+        .then(function (results) {
+          t.ok(results[0].count === lastResults[2][0].count - 1, 'account count was decremented by one')
+          t.ok(results[1].count === lastResults[3][0].count - 1, 'verified account count was decremented by one')
+          t.ok(results[2].count === lastResults[4][0].count + 1, '2+ device account count was incremented by one')
+          t.ok(results[3].count === lastResults[5][0].count, '3+ device account count was not incremented')
+          t.ok(results[4].count === lastResults[6][0].count, 'mobile device account count was not incremented')
+          lastResults = results
+          return createSessionToken(uid)
+        })
+        .then(function () {
+          return P.all([
+            db.readOneFromFirstResult(metrics.countAccountsWithTwoOrMoreDevices, times[2] + 1),
+            db.readOneFromFirstResult(metrics.countAccountsWithThreeOrMoreDevices, times[2] + 1),
+            db.readOneFromFirstResult(metrics.countAccountsWithMobileDevice, times[2] + 1)
+          ])
+        })
+        .then(function (results) {
+          t.ok(results[0].count === lastResults[2].count, '2+ device account count was not incremented')
+          t.ok(results[1].count === lastResults[3].count + 1, '3+ device account count was incremented by one')
+          t.ok(results[2].count === lastResults[4].count, 'mobile device account count was not incremented')
+          lastResults = results
+          return P.all([
+            createSessionToken(uid, 'mobile'),
+            createSessionToken(uid, 'mobile')
+          ])
+        })
+        .then(function () {
+          return P.all([
+            db.readOneFromFirstResult(metrics.countAccountsWithTwoOrMoreDevices, times[2] + 1),
+            db.readOneFromFirstResult(metrics.countAccountsWithThreeOrMoreDevices, times[2] + 1),
+            db.readOneFromFirstResult(metrics.countAccountsWithMobileDevice, times[2] + 1)
+          ])
+        })
+        .then(function (results) {
+          t.ok(results[0].count === lastResults[0].count, '2+ device account count was not incremented')
+          t.ok(results[1].count === lastResults[1].count, '3+ device account count was not incremented')
+          t.ok(results[2].count === lastResults[2].count + 1, 'mobile device account count was incremented by one')
+          lastResults = results
+        })
+        .then(function () {
+          return P.all([
+            db.readOneFromFirstResult(metrics.countAccountsWithTwoOrMoreDevices, times[2]),
+            db.readOneFromFirstResult(metrics.countAccountsWithThreeOrMoreDevices, times[2]),
+            db.readOneFromFirstResult(metrics.countAccountsWithMobileDevice, times[2])
+          ])
+        })
+        .then(function (results) {
+          t.ok(results[0].count === lastResults[0].count - 1, '2+ device account count was decremented by one')
+          t.ok(results[1].count === lastResults[1].count - 1, '3+ device account count was decremented by one')
+          t.ok(results[2].count === lastResults[2].count - 1, 'mobile device account count was decremented by one')
+          return deleteAccount(uid)
+        })
+      }
+    )
+
+    test(
+      'run, with mocked queries',
+      function (t) {
+        var readMultiple = sinon.spy(function () {
+          return P.resolve([
+            null,
+            null,
+            [ { count: 1 } ],
+            [ { count: 2 } ],
+            [ { count: 3 } ],
+            [ { count: 4 } ],
+            [ { count: 5 } ]
+          ])
+        })
+        var close = sinon.spy()
+        var connect = sinon.spy(function () {
+          return P.resolve({
+            readMultiple: readMultiple,
+            close: close
+          })
+        })
+        var mocks = {
+          os: {
+            hostname: sinon.spy(function () {
+              return 'fake hostname'
+            })
+          },
+          fs: {
+            appendFileSync: sinon.spy()
+          },
+          '../lib/logging': function () {
+            return {
+              error: sinon.spy()
+            }
+          },
+          '../fxa-auth-db-server': {
+            errors: 'fake errors'
+          },
+          '../lib/db/mysql': function () {
+            return {
+              connect: connect
+            }
+          }
+        }
+        Object.keys(mocks).forEach(function (key) {
+          var instrumentedPath = getInstrumentedRequirePath(key)
+          if (instrumentedPath !== key) {
+            mocks[instrumentedPath] = mocks[key]
+            delete mocks[key]
+          }
+        })
+        var metrics = proxyquire('../../bin/metrics', mocks)
+        return metrics.run({
+          General: {
+            db_dnsname: 'foo',
+            db_username: 'bar',
+            db_password: 'baz',
+            db_name: 'qux'
+          }
+        }, new Date(1977, 5, 10, 10, 30))
+        .then(function () {
+          t.plan(81)
+
+          t.equal(connect.callCount, 1, 'mysql.connect was called once')
+          t.equal(connect.getCall(0).args.length, 1, 'mysql.connect was passed one argument')
+          var options = connect.getCall(0).args[0]
+          t.equal(Object.keys(options).length, 3, 'mysql.connect options had correct number of properties')
+          t.equal(typeof options.master, 'object', 'mysql.connect master option was object')
+          t.equal(Object.keys(options.master).length, 4, 'mysql.connect master option had correct number of properties')
+          t.equal(options.master.host, 'foo', 'mysql.connect master.host option was correct')
+          t.equal(options.master.user, 'bar', 'mysql.connect master.user option was correct')
+          t.equal(options.master.password, 'baz', 'mysql.connect master.password option was correct')
+          t.equal(options.master.database, 'qux', 'mysql.connect master.database option was correct')
+          t.equal(typeof options.slave, 'object', 'mysql.connect slave option was object')
+          t.equal(Object.keys(options.slave).length, 4, 'mysql.connect slave option had correct number of properties')
+          t.equal(options.slave.host, 'foo', 'mysql.connect slave.host option was correct')
+          t.equal(options.slave.user, 'bar', 'mysql.connect slave.user option was correct')
+          t.equal(options.slave.password, 'baz', 'mysql.connect slave.password option was correct')
+          t.equal(options.slave.database, 'qux', 'mysql.connect slave.database option was correct')
+          t.equal(options.patchKey, 'schema-patch-level', 'mysql.connect patchKey option was correct')
+
+          t.equal(readMultiple.callCount, 1, 'readMultiple was called once')
+          t.equal(readMultiple.getCall(0).args.length, 2, 'readMultiple was passed two arguments')
+          var queries = readMultiple.getCall(0).args[0]
+          t.ok(Array.isArray(queries), 'readMultiple was passed queries array')
+          t.equal(queries.length, 7, 'query array was correct length')
+
+          queries.forEach(function (query, index) {
+            t.equal(typeof query, 'object', 'query item was object [' + index + ']')
+            if (index <= 1) {
+              t.equal(Object.keys(query).length, 1, 'query item had correct number of properties [' + index + ']')
+            } else {
+              t.equal(Object.keys(query).length, 2, 'query item had correct number of properties [' + index + ']')
+              t.ok(Array.isArray(query.params), 'query item had params array [' + index + ']')
+              t.equal(query.params.length, 1, 'query item had correct number of params [' + index + ']')
+              t.equal(query.params[0], Date.UTC(1977, 5, 10, 0, 0, 0, 0), 'query item had correct param [' + index + ']')
+            }
+          })
+          t.equal(queries[0].sql, 'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED', 'first query had correct SQL')
+          t.equal(queries[1].sql, 'START TRANSACTION', 'second query had correct SQL')
+          t.equal(queries[2].sql, metrics.countAccounts, 'third query had correct SQL')
+          t.equal(queries[3].sql, metrics.countVerifiedAccounts, 'fourth query had correct SQL')
+          t.equal(queries[4].sql, metrics.countAccountsWithTwoOrMoreDevices, 'fifth query had correct SQL')
+          t.equal(queries[5].sql, metrics.countAccountsWithThreeOrMoreDevices, 'sixth query had correct SQL')
+          t.equal(queries[6].sql, metrics.countAccountsWithMobileDevice, 'seventh query had correct SQL')
+          var finalQuery = readMultiple.getCall(0).args[1]
+          t.equal(Object.keys(finalQuery).length, 1, 'final query had correct number of properties')
+          t.equal(finalQuery.sql, 'COMMIT', 'final query had correct SQL')
+
+          t.equal(mocks.fs.appendFileSync.callCount, 1, 'fs.appendFileSync was called once')
+          var args = mocks.fs.appendFileSync.getCall(0).args
+          t.equal(args.length, 2, 'fs.appendFileSync was passed two arguments')
+          t.equal(args[0], '/media/ephemeral0/fxa-admin/basic_metrics.log', 'log file path was correct')
+          var data = JSON.parse(args[1])
+          t.equal(Object.keys(data).length, 10, 'log file data had correct number of properties')
+          t.equal(data.hostname, 'fake hostname', 'log file hostname property was correct')
+          t.equal(data.pid, process.pid, 'log file pid property was correct')
+          t.equal(data.op, 'account_totals', 'log file op property was correct')
+          t.equal(data.total_accounts, 1, 'log file total_accounts property was correct')
+          t.equal(data.total_verified_accounts, 2, 'log file total_verified_accounts property was correct')
+          t.equal(data.total_accounts_with_two_or_more_devices, 3, 'log file total_accounts_with_two_or_more_devices property was correct')
+          t.equal(data.total_accounts_with_three_or_more_devices, 4, 'log file total_accounts_with_three_or_more_devices property was correct')
+          t.equal(data.total_accounts_with_mobile_device, 5, 'log file total_accounts_with_mobile_device property was correct')
+          t.equal(typeof data.time, 'string', 'log file time property was a string')
+          var time = new Date(data.time)
+          t.equal(time.getUTCFullYear(), 1977, 'log file time property had correct year')
+          t.equal(time.getUTCMonth(), 5, 'log file time property had correct month')
+          t.equal(time.getUTCDate(), 10, 'log file time property had correct date')
+          t.equal(time.getUTCHours(), 0, 'log file time property had correct hour')
+          t.equal(time.getUTCMinutes(), 0, 'log file time property had correct minute')
+          t.equal(time.getUTCSeconds(), 0, 'log file time property had correct second')
+          t.equal(time.getUTCMilliseconds(), 0, 'log file time property had correct millisecond')
+          t.equal(data.v, 0, 'log file v property was correct')
+
+          t.equal(close.callCount, 1, 'connection.close was called once')
+          t.equal(close.getCall(0).args.length, 0, 'connection.close was passed no arguments')
+        })
+      }
+    )
+
+    test(
+      'teardown',
+      function (t) {
+        return db.close()
+      }
+    )
+
+    function createAccount (uid, time, emailVerified) {
+      var email = ('' + Math.random()).substr(2) + '@foo.com'
+      return db.createAccount(uid, {
+        email: email,
+        normalizedEmail: email.toLowerCase(),
+        emailCode: zeroBuffer16,
+        emailVerified: emailVerified,
+        verifierVersion: 1,
+        verifyHash: zeroBuffer32,
+        authSalt: zeroBuffer32,
+        kA: zeroBuffer32,
+        wrapWrapKb: zeroBuffer32,
+        verifierSetAt: time,
+        createdAt: time,
+        locale: 'en_US'
+      })
+    }
+
+    function deleteAccount(uid) {
+      return db.deleteAccount(uid)
+    }
+
+    function createSessionToken (uid, uaDeviceType) {
+      return db.createSessionToken(hex(32), {
+        data: hex(32),
+        uid: uid,
+        createdAt: Date.now(),
+        uaBrowser: 'foo',
+        uaBrowserVersion: 'bar',
+        uaOS: 'baz',
+        uaOSVersion: 'qux',
+        uaDeviceType: uaDeviceType
+      })
+    }
+
+    function hex (length) {
+      return Buffer(crypto.randomBytes(length).toString('hex'), 'hex')
+    }
+
+    function getInstrumentedRequirePath (dependencyPath) {
+      if (dependencyPath[0] !== '.') {
+        return dependencyPath
+      }
+
+      return path.resolve(__dirname, '../../bin') + '/' + dependencyPath
+    }
+  })
+


### PR DESCRIPTION
Fixes #72.

This is essentially a like-for-like replacement for [`puppet-config/.../gather_basic_metrics.py`](https://github.com/mozilla-services/puppet-config/blob/master/fxa/modules/fxa_admin/files/gather_basic_metrics.py), except written for node.js and covered by tests.

Although it is part of this repo, the plan is for it to run from the same context as the Python script, hence the file paths and the [non-JSON config format](https://github.com/mozilla-services/puppet-config/blob/master/fxa/modules/fxa_admin/templates/gather_basic_metrics.conf.erb). By having it in this repo, we get the benefit of the tests running automatically against future schema changes.

I plan to commit some more tests tomorrow, but wanted to get feedback on it sooner than that because we're so close to the end of this train.

There are a few things in particular that I was unsure about:

* Am I passing the correct options to `mysql.connect`?
* Is it right or wrong to call `log.error` from this context?
* Is the `readUncommitted` parameter too hackish?

@jrgm and @rfk, feedback wanted! :smile: 