### PR TITLE
chore(coverage): exclude fxa-auth-db-server/node_modules from coverage checks

### DIFF
--- a/scripts/tap-coverage.js
+++ b/scripts/tap-coverage.js
@@ -7,7 +7,7 @@
 if (!process.env.NO_COVERAGE) {
   var ass = require('ass').enable( {
     // exclude files in /client/ and /test/ from code coverage
-    exclude: [ '/client/', '/test' ]
+    exclude: [ '/client/', '/test', '/fxa-auth-db-server/node_modules/' ]
   })
 }
 


### PR DESCRIPTION
The coverage report was impossible to read because of a bunch of long `node_modules` paths that were no longer being excluded after the repo merge.