### PR TITLE
feat(db): return accountCreatedAt from sessionToken stored procedure

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -309,7 +309,8 @@ from the token and `a.*` for a field from the corresponding account.
 
 * sessionToken : t.tokenData, t.uid, t.createdAt, t.uaBrowser, t.uaBrowserVersion,
                  t.uaOS, t.uaOSVersion, t.uaDeviceType, t.lastAccessTime,
-                 a.emailVerified, a.email, a.emailCode, a.verifierSetAt
+                 a.emailVerified, a.email, a.emailCode, a.verifierSetAt,
+                 a.createdAt AS accountCreatedAt
 * keyFetchToken : t.authKey, t.uid, t.keyBundle, t.createdAt, a.emailVerified, a.verifierSetAt
 * passwordChangeToken : t.tokenData, t.uid, t.createdAt, a.verifierSetAt
 * passwordForgotToken : t.tokenData, t.uid, t.createdAt, t.passCode, t.tries, a.email, a.verifierSetAt

--- a/fxa-auth-db-server/test/backend/db_tests.js
+++ b/fxa-auth-db-server/test/backend/db_tests.js
@@ -207,7 +207,7 @@ module.exports = function(config, DB) {
         test(
           'session token handling',
           function (t) {
-            t.plan(54)
+            t.plan(56)
             return db.sessions(ACCOUNT.uid)
               .then(function(sessions) {
                 t.ok(Array.isArray(sessions), 'sessions is an array')
@@ -247,6 +247,7 @@ module.exports = function(config, DB) {
                 t.equal(token.email, ACCOUNT.email, 'token email same as account email')
                 t.deepEqual(token.emailCode, ACCOUNT.emailCode, 'token emailCode same as account emailCode')
                 t.equal(token.verifierSetAt, ACCOUNT.verifierSetAt, 'verifierSetAt is correct')
+                t.equal(token.accountCreatedAt, ACCOUNT.createdAt, 'accountCreatedAt is correct')
               })
               .then(function() {
                 return db.updateSessionToken(SESSION_TOKEN_ID, {
@@ -289,6 +290,7 @@ module.exports = function(config, DB) {
                 t.equal(token.email, ACCOUNT.email, 'token email same as account email')
                 t.deepEqual(token.emailCode, ACCOUNT.emailCode, 'token emailCode same as account emailCode')
                 t.equal(token.verifierSetAt, ACCOUNT.verifierSetAt, 'verifierSetAt is correct')
+                t.equal(token.accountCreatedAt, ACCOUNT.createdAt, 'accountCreatedAt is correct')
               })
               .then(function() {
                 return db.deleteSessionToken(SESSION_TOKEN_ID)

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -180,7 +180,7 @@ module.exports = function(cfg, server) {
   test(
     'session token handling',
     function (t) {
-      t.plan(59)
+      t.plan(60)
       var user = fake.newUserDataHex()
       client.getThen('/account/' + user.accountId + '/sessions')
         .then(function(r) {
@@ -239,6 +239,7 @@ module.exports = function(cfg, server) {
           t.equal(token.email, user.account.email, 'token.email same as account email')
           t.deepEqual(token.emailCode, user.account.emailCode, 'token emailCode same as account emailCode')
           t.ok(token.verifierSetAt, 'verifierSetAt is set to a truthy value')
+          t.ok(token.accountCreatedAt > 0, 'accountCreatedAt is positive number')
 
           // update the session token
           return client.postThen('/sessionToken/' + user.sessionTokenId + '/update', {

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -352,6 +352,7 @@ module.exports = function (log, error) {
     item.emailCode = account.emailCode
     item.verifierSetAt = account.verifierSetAt
     item.locale = account.locale
+    item.accountCreatedAt = account.createdAt
 
     return P.resolve(item)
   }

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -323,9 +323,10 @@ module.exports = function (log, error) {
   // Select : sessionTokens t, accounts a
   // Fields : t.tokenData, t.uid, t.createdAt, t.uaBrowser, t.uaBrowserVersion,
   //          t.uaOS, t.uaOSVersion, t.uaDeviceType, t.lastAccessTime,
-  //          a.emailVerified, a.email, a.emailCode, a.verifierSetAt, a.locale
+  //          a.emailVerified, a.email, a.emailCode, a.verifierSetAt, a.locale,
+  //          a.createdAt AS accountCreatedAt
   // Where  : t.tokenId = $1 AND t.uid = a.uid
-  var SESSION_TOKEN = 'CALL sessionToken_2(?)'
+  var SESSION_TOKEN = 'CALL sessionToken_3(?)'
 
   MySql.prototype.sessionToken = function (id) {
     return this.readFirstResult(SESSION_TOKEN, [id])

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the schema/ directory.
-module.exports.level = 17
+module.exports.level = 18

--- a/lib/db/schema/patch-017-018.sql
+++ b/lib/db/schema/patch-017-018.sql
@@ -1,0 +1,35 @@
+-- return accountCreatedAt from the sessionToken stored procedure
+
+CREATE PROCEDURE `sessionToken_3` (
+    IN `inTokenId` BINARY(32)
+)
+BEGIN
+    SELECT
+        t.tokenData,
+        t.uid,
+        t.createdAt,
+        t.uaBrowser,
+        t.uaBrowserVersion,
+        t.uaOS,
+        t.uaOSVersion,
+        t.uaDeviceType,
+        t.lastAccessTime,
+        a.emailVerified,
+        a.email,
+        a.emailCode,
+        a.verifierSetAt,
+        a.locale,
+        a.createdAt AS accountCreatedAt
+    FROM
+        sessionTokens t,
+        accounts a
+    WHERE
+        t.tokenId = inTokenId
+    AND
+        t.uid = a.uid
+    ;
+END;
+
+-- Schema patch-level increment.
+UPDATE dbMetadata SET value = '18' WHERE name = 'schema-patch-level';
+

--- a/lib/db/schema/patch-018-017.sql
+++ b/lib/db/schema/patch-018-017.sql
@@ -1,0 +1,4 @@
+-- DROP PROCEDURE `sessionToken_3`;
+
+-- UPDATE dbMetadata SET value = '17' WHERE name = 'schema-patch-level';
+


### PR DESCRIPTION
This change enables https://github.com/mozilla/fxa-auth-server/pull/1056 to work without making an extra query against the `accounts` table to get the value of `createdAt`.

There is already a migration ([016-017](https://github.com/mozilla/fxa-auth-db-mysql/pull/102)) in this train, but I figured it was probably too late in the day to mess about adding to it here. So I've added an 017-018 migration too, but let me know if you'd rather fold this into that first one.