### PR TITLE
WIP: batch session token updates to reduce database load

### DIFF
--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -248,7 +248,8 @@ module.exports = function(cfg, server) {
             uaOS: 'different OS',
             uaOSVersion: 'different OS version',
             uaDeviceType: 'different device type',
-            lastAccessTime: 42
+            lastAccessTime: 42,
+            batchSize: 1
           })
         })
         .then(function(r) {

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -10,6 +10,7 @@ var accounts = {}
 var uidByNormalizedEmail = {}
 var uidByOpenId = {}
 var sessionTokens = {}
+var batchSessionTokenUpdates = {}
 var keyFetchTokens = {}
 var accountResetTokens = {}
 var passwordChangeTokens = {}
@@ -573,16 +574,22 @@ module.exports = function (log, error) {
   }
 
   Memory.prototype.updateSessionToken = function (id, data) {
-    var token = sessionTokens[id.toString('hex')]
-    if (!token) {
-      return P.reject(error.notFound())
+    batchSessionTokenUpdates[id.toString('hex')] = data
+
+    var tokenIds = Object.keys(batchSessionTokenUpdates)
+
+    if (tokenIds.length >= (data.batchSize || 10000)) {
+      tokenIds.forEach(function(tokenId) {
+        sessionTokens[tokenId].uaBrowser = batchSessionTokenUpdates[tokenId].uaBrowser
+        sessionTokens[tokenId].uaBrowserVersion = batchSessionTokenUpdates[tokenId].uaBrowserVersion
+        sessionTokens[tokenId].uaOS = batchSessionTokenUpdates[tokenId].uaOS
+        sessionTokens[tokenId].uaOSVersion = batchSessionTokenUpdates[tokenId].uaOSVersion
+        sessionTokens[tokenId].uaDeviceType = batchSessionTokenUpdates[tokenId].uaDeviceType
+        sessionTokens[tokenId].lastAccessTime = batchSessionTokenUpdates[tokenId].lastAccessTime
+      })
+      batchSessionTokenUpdates = {}
     }
-    token.uaBrowser = data.uaBrowser
-    token.uaBrowserVersion = data.uaBrowserVersion
-    token.uaOS = data.uaOS
-    token.uaOSVersion = data.uaOSVersion
-    token.uaDeviceType = data.uaDeviceType
-    token.lastAccessTime = data.lastAccessTime
+
     return P.resolve({})
   }
 

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -403,25 +403,27 @@ module.exports = function (log, error) {
     return this.write(UPDATE_PASSWORD_FORGOT_TOKEN, [token.tries, tokenId])
   }
 
-  // Update : sessionTokens
-  // Set    : uaBrowser = $1, uaBrowserVersion = $2, uaOS = $3, uaOSVersion = $4,
-  //          uaDeviceType = $5, lastAccessTime = $6
-  // Where  : tokenId = $7
-  var UPDATE_SESSION_TOKEN = 'CALL updateSessionToken_1(?, ?, ?, ?, ?, ?, ?)'
+  // Insert : batchSessionTokenUpdates
+  // Values : tokenId = $1, uaBrowser = $2, uaBrowserVersion = $3, uaOS = $4,
+  //          uaOSVersion = $5, uaDeviceType = $6, lastAccessTime = $7
+  var UPDATE_SESSION_TOKEN = 'CALL updateSessionToken_2(?, ?, ?, ?, ?, ?, ?)'
 
   MySql.prototype.updateSessionToken = function (tokenId, token) {
+    var self = this
     return this.write(
       UPDATE_SESSION_TOKEN,
       [
+        tokenId,
         token.uaBrowser,
         token.uaBrowserVersion,
         token.uaOS,
         token.uaOSVersion,
         token.uaDeviceType,
-        token.lastAccessTime,
-        tokenId
+        token.lastAccessTime
       ]
-    )
+    ).then(function (result) {
+      return self.write('CALL batchUpdateSessionTokens_1(?)', token.batchSize || 10000)
+    })
   }
 
   // DELETE

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the schema/ directory.
-module.exports.level = 18
+module.exports.level = 19

--- a/lib/db/schema/patch-018-019.sql
+++ b/lib/db/schema/patch-018-019.sql
@@ -1,0 +1,78 @@
+-- Create table and stored procedures for batched update of sessionTokens
+
+CREATE TABLE batchSessionTokenUpdates(
+    tokenId BINARY(32) PRIMARY KEY,
+    uaBrowser VARCHAR(255),
+    uaBrowserVersion VARCHAR(255),
+    uaOS VARCHAR(255),
+    uaOSVersion VARCHAR(255),
+    uaDeviceType VARCHAR(255),
+    lastAccessTime BIGINT UNSIGNED
+) ENGINE=MEMORY;
+
+CREATE PROCEDURE `updateSessionToken_2` (
+    IN tokenId BINARY(32),
+    IN uaBrowser VARCHAR(255),
+    IN uaBrowserVersion VARCHAR(255),
+    IN uaOS VARCHAR(255),
+    IN uaOSVersion VARCHAR(255),
+    IN uaDeviceType VARCHAR(255),
+    IN lastAccessTime BIGINT UNSIGNED
+)
+BEGIN
+    INSERT INTO batchSessionTokenUpdates(
+        tokenId,
+        uaBrowser,
+        uaBrowserVersion,
+        uaOS,
+        uaOSVersion,
+        uaDeviceType,
+        lastAccessTime
+    )
+    VALUES(
+        tokenId,
+        uaBrowser,
+        uaBrowserVersion,
+        uaOS,
+        uaOSVersion,
+        uaDeviceType,
+        lastAccessTime
+    )
+    ON DUPLICATE KEY
+    UPDATE tokenId=tokenId;
+END;
+
+CREATE PROCEDURE `batchUpdateSessionTokens_1` (
+    IN batchSize INT UNSIGNED
+)
+BEGIN
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    START TRANSACTION;
+
+    SELECT @updateCount:=COUNT(*) FROM batchSessionTokenUpdates FOR UPDATE;
+
+    IF @updateCount >= batchSize THEN
+        UPDATE sessionTokens INNER JOIN batchSessionTokenUpdates
+        ON sessionTokens.tokenId = batchSessionTokenUpdates.tokenId
+        SET
+            sessionTokens.uaBrowser = batchSessionTokenUpdates.uaBrowser,
+            sessionTokens.uaBrowserVersion = batchSessionTokenUpdates.uaBrowserVersion,
+            sessionTokens.uaOS = batchSessionTokenUpdates.uaOS,
+            sessionTokens.uaOSVersion = batchSessionTokenUpdates.uaOSVersion,
+            sessionTokens.uaDeviceType = batchSessionTokenUpdates.uaDeviceType,
+            sessionTokens.lastAccessTime = batchSessionTokenUpdates.lastAccessTime
+        ;
+
+        DELETE FROM batchSessionTokenUpdates;
+    END IF;
+
+    COMMIT;
+END;
+
+UPDATE dbMetadata SET value = '19' WHERE name = 'schema-patch-level';
+

--- a/lib/db/schema/patch-019-018.sql
+++ b/lib/db/schema/patch-019-018.sql
@@ -1,0 +1,7 @@
+-- DROP TABLE `batchSessionTokenUpdates`;
+
+-- DROP PROCEDURE `updateSessionToken_2`;
+-- DROP PROCEDURE `batchUpdateSessionTokens_1`;
+
+-- UPDATE dbMetadata SET value = '18' WHERE name = 'schema-patch-level';
+


### PR DESCRIPTION
This concerns https://github.com/mozilla/fxa-auth-server/issues/1044, which isn't actually in `waffle:now`; I started to play around with it between trains yesterday and wanted to get it in front of somebody else before parking it.

The approach I took was to preserve the existing API around `updateSessionToken` and try to implement the batching in SQL. Hence there is a new `ENGINE=MEMORY` table, `batchSessionTokenUpdates`, that receives updates.

At the moment, that table is purged to update the real `sessionTokens` table when it reaches 10,000 records. Another approach would be to do something time-based by writing a timestamp to the `dbMetadata` table. I haven't done any actual perf-testing with it yet, I just wanted to see what you guys thought of the general approach.

@jrgm & @rfk, any thoughts? (scroll to the bottom of the diff for the interesting stuff)