### PR TITLE
feat(db): update devices to match new requirements

### DIFF
--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -59,7 +59,8 @@ The following datatypes are used throughout this document:
     * sessions                  : `GET /account/:id/sessions`
     * devices                   : `GET /account/:id/devices`
 * Devices:
-    * upsertDevice              : `PUT /account/:id/device/:deviceId`
+    * createDevice              : `PUT /account/:id/device/:deviceId`
+    * updateDevice              : `POST /account/:id/device/:deviceId/update`
     * deleteDevice              : `DEL /account/:id/device/:deviceId`
 * Session Tokens:
     * sessionToken              : `GET /sessionToken/:id`
@@ -625,7 +626,8 @@ Content-Type: application/json
         "name": "My Phone",
         "type": "mobile"
         "createdAt": 1437992394186,
-        "callbackURL": "",
+        "callbackURL": "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef",
+        "callbackPublicKey": "468601214f60f4828b6cd5d51d9d99d212e7c73657978955f0f5a5b7e2fa1370",
         "uaBrowser": "Firefox",
         "uaBrowserVersion": "42",
         "uaOS": "Android",
@@ -648,7 +650,7 @@ Content-Type: application/json
     * Content-Type : 'application/json'
     * Body : `{"code":"InternalError","message":"...<message related to the error>..."}`
 
-## upsertDevice : `PUT /account/<uid>/device/<deviceId>`
+## createDevice : `PUT /account/<uid>/device/<deviceId>`
 
 ### Example
 
@@ -664,7 +666,8 @@ curl \
       "name": "My Phone",
       "type": "mobile"
       "createdAt": 1437992394186,
-      "callbackURL": ""
+      "callbackURL": "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef",
+      "callbackPublicKey": "468601214f60f4828b6cd5d51d9d99d212e7c73657978955f0f5a5b7e2fa1370"
     }'
 ```
 
@@ -680,6 +683,56 @@ Content-Type: application/json
 * Status Code : 200 OK
     * Content-Type : 'application/json'
     * Body : `[ ... <see example> ...]`
+* Status Code : 409 Conflict
+    * Conditions: if id already exists or sessionTokenId is already used by a different device
+    * Content-Type : 'application/json'
+    * Body : `{"errno":101",message":"Record already exists"}`
+* Status Code : 500 Internal Server Error
+    * Conditions: if something goes wrong on the server
+    * Content-Type : 'application/json'
+    * Body : `{"code":"InternalError","message":"...<message related to the error>..."}`
+
+## updateDevice : `POST /account/<uid>/device/<deviceId>/update`
+
+### Example
+
+```
+curl \
+    -v \
+    -X POST \
+    http://localhost:8000/account/6044486dd15b42e08b1fb9167415b9ac/device/154c86dde08bfbb47415b9a216044916/update \
+    -d '{
+      "id": "154c86dde08bfbb47415b9a216044916",
+      "uid": "6044486dd15b42e08b1fb9167415b9ac",
+      "sessionTokenId": "9a15b9ad6044ce08bfbb4744b1604491686dd15b42e2154c86d08b1fb9167415",
+      "name": "My Phone",
+      "type": "mobile"
+      "createdAt": 1437992394186,
+      "callbackURL": "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef",
+      "callbackPublicKey": "468601214f60f4828b6cd5d51d9d99d212e7c73657978955f0f5a5b7e2fa1370"
+    }'
+```
+
+### Response
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{}
+```
+
+* Status Code : 200 OK
+    * Content-Type : 'application/json'
+    * Body : `[ ... <see example> ...]`
+* Status Code : 409 Conflict
+    * Conditions: if sessionTokenId is already used by a different device
+    * Content-Type : 'application/json'
+    * Body : `{"errno":101",message":"Record already exists"}`
+* Status Code : 404 Not Found
+    * Conditions: if device(uid,id) is not found in the database
+    * Content-Type : 'application/json'
+    * Body : `{"errno":116,"message":"Not found"}`
 * Status Code : 500 Internal Server Error
     * Conditions: if something goes wrong on the server
     * Content-Type : 'application/json'
@@ -708,6 +761,10 @@ Content-Type: application/json
 * Status Code : 200 OK
     * Content-Type : 'application/json'
     * Body : `[ ... <see example> ...]`
+* Status Code : 404 Not Found
+    * Conditions: if device(uid,id) is not found in the database
+    * Content-Type : 'application/json'
+    * Body : `{"errno":116,"message":"Not found"}`
 * Status Code : 500 Internal Server Error
     * Conditions: if something goes wrong on the server
     * Content-Type : 'application/json'

--- a/fxa-auth-db-server/index.js
+++ b/fxa-auth-db-server/index.js
@@ -122,7 +122,18 @@ function createServer(db) {
   api.put(
     '/account/:uid/device/:deviceId',
     function (req, res, next) {
-      db.upsertDevice(req.params.uid, req.params.deviceId, req.body)
+      db.createDevice(req.params.uid, req.params.deviceId, req.body)
+        .then(
+          handleSuccess.bind(null, req, res),
+          handleError.bind(null, req, res)
+        )
+        .done(next, next)
+    }
+  )
+  api.post(
+    '/account/:uid/device/:deviceId/update',
+    function (req, res, next) {
+      db.updateDevice(req.params.uid, req.params.deviceId, req.body)
         .then(
           handleSuccess.bind(null, req, res),
           handleError.bind(null, req, res)

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -310,7 +310,7 @@ module.exports = function(cfg, server) {
   test(
     'device handling',
     function (t) {
-      t.plan(47)
+      t.plan(49)
       var user = fake.newUserDataHex()
       client.getThen('/account/' + user.accountId + '/devices')
         .then(function(r) {
@@ -337,7 +337,7 @@ module.exports = function(cfg, server) {
           respOk(t, r)
           var devices = r.obj
           t.equal(devices.length, 1, 'devices contains one item')
-          t.equal(Object.keys(devices[0]).length, 13, 'device has thirteen properties')
+          t.equal(Object.keys(devices[0]).length, 14, 'device has fourteen properties')
           t.equal(devices[0].uid, user.accountId, 'uid is correct')
           t.equal(devices[0].id, user.deviceId, 'id is correct')
           t.equal(devices[0].sessionTokenId, user.sessionTokenId, 'sessionTokenId is correct')
@@ -345,16 +345,18 @@ module.exports = function(cfg, server) {
           t.equal(devices[0].name, user.device.name, 'name is correct')
           t.equal(devices[0].type, user.device.type, 'type is correct')
           t.equal(devices[0].callbackURL, user.device.callbackURL, 'callbackURL is correct')
+          t.equal(devices[0].callbackPublicKey, user.device.callbackPublicKey, 'callbackPublicKey is correct')
           t.equal(devices[0].uaBrowser, user.sessionToken.uaBrowser, 'uaBrowser is correct')
           t.equal(devices[0].uaBrowserVersion, user.sessionToken.uaBrowserVersion, 'uaBrowserVersion is correct')
           t.equal(devices[0].uaOS, user.sessionToken.uaOS, 'uaOS is correct')
           t.equal(devices[0].uaOSVersion, user.sessionToken.uaOSVersion, 'uaOSVersion is correct')
           t.equal(devices[0].uaDeviceType, user.sessionToken.uaDeviceType, 'uaDeviceType is correct')
           t.equal(devices[0].lastAccessTime, user.sessionToken.createdAt, 'lastAccessTime is correct')
-          return client.putThen('/account/' + user.accountId + '/device/' + user.deviceId, {
+          return client.postThen('/account/' + user.accountId + '/device/' + user.deviceId + '/update', {
             name: 'wibble',
             type: 'mobile',
-            callbackURL: ''
+            callbackURL: '',
+            callbackPublicKey: null
           })
         })
         .then(function(r) {
@@ -372,6 +374,7 @@ module.exports = function(cfg, server) {
           t.equal(devices[0].name, 'wibble', 'name is correct')
           t.equal(devices[0].type, 'mobile', 'type is correct')
           t.equal(devices[0].callbackURL, '', 'callbackURL is correct')
+          t.equal(devices[0].callbackPublicKey, user.device.callbackPublicKey, 'callbackPublicKey is correct')
           t.equal(devices[0].uaBrowser, user.sessionToken.uaBrowser, 'uaBrowser is correct')
           t.equal(devices[0].uaBrowserVersion, user.sessionToken.uaBrowserVersion, 'uaBrowserVersion is correct')
           t.equal(devices[0].uaOS, user.sessionToken.uaOS, 'uaOS is correct')

--- a/fxa-auth-db-server/test/fake.js
+++ b/fxa-auth-db-server/test/fake.js
@@ -59,7 +59,8 @@ module.exports.newUserDataHex = function() {
     createdAt: Date.now(),
     name: 'fake device name',
     type: 'fake device type',
-    callbackURL: 'fake callback URL'
+    callbackURL: 'fake callback URL',
+    callbackPublicKey: hex32()
   }
 
   // keyFetchToken

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the schema/ directory.
-module.exports.level = 19
+module.exports.level = 20

--- a/lib/db/schema/patch-019-020.sql
+++ b/lib/db/schema/patch-019-020.sql
@@ -1,0 +1,92 @@
+-- This migration:
+--
+-- * Adds a column, devices.callbackPublicKey
+-- * Updates the accountDevices stored procedure with the new column
+-- * Adds a unique constraint on devices.uid, devices.sessionTokenId
+-- * Adds two stored procedures, createDevice and updateDevice
+
+ALTER TABLE devices
+ADD COLUMN callbackPublicKey BINARY(32),
+ADD CONSTRAINT UQ_devices_sessionTokenId UNIQUE (uid, sessionTokenId);
+
+CREATE PROCEDURE `accountDevices_3` (
+  IN `inUid` BINARY(16)
+)
+BEGIN
+  SELECT
+    d.uid,
+    d.id,
+    d.sessionTokenId,
+    d.name,
+    d.type,
+    d.createdAt,
+    d.callbackURL,
+    d.callbackPublicKey,
+    s.uaBrowser,
+    s.uaBrowserVersion,
+    s.uaOS,
+    s.uaOSVersion,
+    s.uaDeviceType,
+    s.lastAccessTime
+  FROM
+    devices d LEFT JOIN sessionTokens s
+  ON
+    d.sessionTokenId = s.tokenId
+  WHERE
+    d.uid = inUid;
+END;
+
+CREATE PROCEDURE `createDevice_1` (
+  IN `inUid` BINARY(16),
+  IN `inId` BINARY(16),
+  IN `inSessionTokenId` BINARY(32),
+  IN `inName` VARCHAR(255),
+  IN `inType` VARCHAR(16),
+  IN `inCreatedAt` BIGINT UNSIGNED,
+  IN `inCallbackURL` VARCHAR(255),
+  IN `inCallbackPublicKey` BINARY(32)
+)
+BEGIN
+  INSERT INTO devices(
+    uid,
+    id,
+    sessionTokenId,
+    name,
+    type,
+    createdAt,
+    callbackURL,
+    callbackPublicKey
+  )
+  VALUES (
+    inUid,
+    inId,
+    inSessionTokenId,
+    inName,
+    inType,
+    inCreatedAt,
+    inCallbackURL,
+    inCallbackPublicKey
+  );
+END;
+
+CREATE PROCEDURE `updateDevice_1` (
+  IN `inUid` BINARY(16),
+  IN `inId` BINARY(16),
+  IN `inSessionTokenId` BINARY(32),
+  IN `inName` VARCHAR(255),
+  IN `inType` VARCHAR(16),
+  IN `inCallbackURL` VARCHAR(255),
+  IN `inCallbackPublicKey` BINARY(32)
+)
+BEGIN
+  UPDATE devices
+  SET sessionTokenId = COALESCE(inSessionTokenId, sessionTokenId),
+    name = COALESCE(inName, name),
+    type = COALESCE(inType, type),
+    callbackURL = COALESCE(inCallbackURL, callbackURL),
+    callbackPublicKey = COALESCE(inCallbackPublicKey, callbackPublicKey)
+  WHERE uid = inUid AND id = inId;
+END;
+
+UPDATE dbMetadata SET value = '20' WHERE name = 'schema-patch-level';
+

--- a/lib/db/schema/patch-020-019.sql
+++ b/lib/db/schema/patch-020-019.sql
@@ -1,0 +1,13 @@
+-- -- Drop new column and new constraint
+-- ALTER TABLE devices
+-- DROP COLUMN callbackPublicKey,
+-- DROP INDEX UQ_devices_sessionTokenId;
+
+-- -- Drop new stored procedures
+-- DROP PROCEDURE `accountDevices_3`;
+-- DROP PROCEDURE `createDevice_1`;
+-- DROP PROCEDURE `updateDevice_1`;
+
+-- -- Decrement the schema version
+-- UPDATE dbMetadata SET value = '19' WHERE name = 'schema-patch-level';
+


### PR DESCRIPTION
There are ~~two~~ three changes here:

1. Fixes #114, adding a column for the push callback public key.

2. [Return an error if a device attempts to register a session token that is already registered to another device](https://github.com/mozilla/fxa/tree/master/features/FxA-45-device-registration-api#registered-device-1).

3. [Return an error from the `POST` and `DELETE` endpoints if an unrecognised device id is received](https://github.com/mozilla/fxa/issues/78).

I put them ~~both~~ all into the same commit because I wanted to limit database changes to a single migration and I figured one migration should always be one atomic commit.

~~My approach to `2`, especially, may be (is probably?) wrong. It performs two extra queries in the worst case and then aborts the stored procedure using `SIGNAL SQLSTATE`~~. I look forward to the next stage of my on-the-job databases education in your comments. :grin:

@dannycoates && @rfk, r?