### PR TITLE
fix(version): print out constructor class name; adds /__version__ alias

### DIFF
--- a/fxa-auth-db-server/index.js
+++ b/fxa-auth-db-server/index.js
@@ -9,6 +9,8 @@ var errors = require('./lib/error')
 
 function createServer(db) {
 
+  var implementation = db.constructor.name || '__anonymousconstructor__'
+
   function reply(fn) {
     return function (req, res, next) {
       fn.call(db, req.params.id, req.body)
@@ -156,7 +158,15 @@ function createServer(db) {
   api.get(
     '/',
     function (req, res, next) {
-      res.send({ version: version })
+      res.send({ version: version, implementation: implementation })
+      next()
+    }
+  )
+
+  api.get(
+    '/__version__',
+    function (req, res, next) {
+      res.send({ version: version, implementation: implementation })
       next()
     }
   )

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -62,6 +62,24 @@ function captureFailureEvents(t, server) {
   server.on('failure', t.pass.bind(t, 'The server emitted the failure event'))
 }
 
+// Helper test that calls the version route and checks response that checks the version route response.
+//
+// Takes the client, and a route, either '/' or '/__version__'.
+//
+function testVersionResponse(client, route) {
+  return function (t) {
+    client.getThen(route)
+      .then(function (r) {
+        t.equal(r.res.statusCode, 200, 'version returns 200 OK')
+        t.ok(r.obj.version.match(/\d+\.\d+\.\d+/),
+             'Version has a semver version property')
+        t.ok(['Memory', 'MySql'].indexOf(r.obj.implementation) !== -1,
+             'Version has a known implementation  property')
+        t.end()
+      })
+  }
+}
+
 // To run these tests from a new backend, create a DB instance, start a test server
 // and pass the config containing the connection params to this function. The tests
 // will run against that server. Second argument is the restify server object, for
@@ -84,6 +102,9 @@ module.exports = function(cfg, server) {
         })
     }
   )
+
+  test('version', testVersionResponse(client, '/'))
+  test('version', testVersionResponse(client, '/__version__'))
 
   test(
     'account not found',


### PR DESCRIPTION
'/' and '/__version__' will how show the constructor class name, like so:
```
{"version":"0.48.0","implementation":"MySql"}
```

Not sure how I'm going to use it yet, but seems like a useful thing to be able to query.
