### PR TITLE
fix(travis): build and test on 0.10, 0.12 and 4.x, and allow failure on >= 5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
  - "0.10"
  - "0.12"
+ - "4"
  - "stable"
 
 services:
@@ -36,6 +37,5 @@ script:
 
 matrix:
   allow_failures:
-    - node_js: "0.12"
     - node_js: "stable"
   fast_finish: true


### PR DESCRIPTION
Test on 4.x, and failures no longer ok on 0.12 (or 4.x)