### PR TITLE
fix(db): expunge devices in resetAccount sproc

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -153,7 +153,7 @@ Returns:
 ## .resetAccount(uid, data) ##
 
 Resets the account specified by `uid` using the fields provided in `data`. Deletes all tokens
-related to this account.
+and devices related to this account.
 
 Parameters:
 

--- a/fxa-auth-db-server/test/backend/db_tests.js
+++ b/fxa-auth-db-server/test/backend/db_tests.js
@@ -1036,7 +1036,7 @@ module.exports = function(config, DB) {
         test(
           'db.resetAccount',
           function (t) {
-            t.plan(9)
+            t.plan(10)
             var uid = ACCOUNT.uid
             var lockedAt = Date.now()
             var unlockCode = hex16()
@@ -1044,6 +1044,13 @@ module.exports = function(config, DB) {
             return db.createSessionToken(SESSION_TOKEN_ID, SESSION_TOKEN)
               .then(function(sessionToken) {
                 t.pass('.createSessionToken() did not error')
+                return db.createDevice(ACCOUNT.uid, newUuid(), {
+                  sessionTokenId: SESSION_TOKEN_ID,
+                  createdAt: lockedAt
+                })
+              })
+              .then(function() {
+                t.pass('.createDevice() did not error')
                 return db.createAccountResetToken(ACCOUNT_RESET_TOKEN_ID, ACCOUNT_RESET_TOKEN)
               })
               .then(function() {

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -550,7 +550,7 @@ module.exports = function (log, error) {
   // Update : accounts
   // Set    : verifyHash = $2, authSalt = $3, wrapWrapKb = $4, verifierSetAt = $5, verifierVersion = $6
   // Where  : uid = $1
-  var RESET_ACCOUNT = 'CALL resetAccount_4(?, ?, ?, ?, ?, ?)'
+  var RESET_ACCOUNT = 'CALL resetAccount_5(?, ?, ?, ?, ?, ?)'
 
   MySql.prototype.resetAccount = function (uid, data) {
     return this.write(

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the schema/ directory.
-module.exports.level = 21
+module.exports.level = 22

--- a/lib/db/schema/patch-021-022.sql
+++ b/lib/db/schema/patch-021-022.sql
@@ -1,0 +1,57 @@
+-- Previous versions of the resetAccount stored procedure
+-- do not expunge devices. This one does.
+CREATE PROCEDURE `resetAccount_5` (
+    IN `inUid` BINARY(16),
+    IN `inVerifyHash` BINARY(32),
+    IN `inAuthSalt` BINARY(32),
+    IN `inWrapWrapKb` BINARY(32),
+    IN `inVerifierSetAt` BIGINT UNSIGNED,
+    IN `inVerifierVersion` TINYINT UNSIGNED
+)
+BEGIN
+
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    START TRANSACTION;
+
+    DELETE FROM sessionTokens WHERE uid = inUid;
+    DELETE FROM keyFetchTokens WHERE uid = inUid;
+    DELETE FROM accountResetTokens WHERE uid = inUid;
+    DELETE FROM passwordChangeTokens WHERE uid = inUid;
+    DELETE FROM passwordForgotTokens WHERE uid = inUid;
+    DELETE FROM accountUnlockCodes WHERE uid = inUid;
+    DELETE FROM devices WHERE uid = inUid;
+
+    UPDATE
+        accounts
+    SET
+        verifyHash = inVerifyHash,
+        authSalt = inAuthSalt,
+        wrapWrapKb = inWrapWrapKb,
+        verifierSetAt = inVerifierSetAt,
+        verifierVersion = inVerifierVersion
+    WHERE
+        uid = inUid
+    ;
+
+    INSERT INTO eventLog(
+        uid,
+        typ,
+        iat
+    )
+    VALUES(
+        inUid,
+        "reset",
+        UNIX_TIMESTAMP()
+    );
+
+    COMMIT;
+END;
+
+
+-- Schema patch-level increment.
+UPDATE dbMetadata SET value = '22' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-022-021.sql
+++ b/lib/db/schema/patch-022-021.sql
@@ -1,0 +1,5 @@
+-- -- Drop new stored procedures
+-- DROP PROCEDURE `resetAccount_5`;
+
+-- -- Decrement the schema version
+-- UPDATE dbMetadata SET value = '21' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
Fixes the root cause of the recent 500 errors that have been occurring on the `/devices` endpoint by ensuring that device records are expunged during account reset. They are already expunged during account delete.

The existing `resetAccount` test was already asserting there are no devices after the reset, it just needed tweaking to actually create a device first.

@jrgm, @rfk r?