### PR TITLE
Really use mozlog everywhere in this module

### DIFF
--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -60,10 +60,10 @@ module.exports = function (log, error) {
     function prune() {
       this.pruneTokens().done(
         function() {
-          log.info({ op: 'db.pruneTokens', msg: 'Finished' })
+          log.info('MySql.pruneTokens', { msg: 'Finished' })
         },
         function(err) {
-          log.error({ op: 'db.pruneTokens', err: err })
+          log.error('MySql.pruneTokens', { err: err })
         }
       )
 
@@ -305,7 +305,7 @@ module.exports = function (log, error) {
       ],
       function (result) {
         if (result.affectedRows === 0) {
-          log.error({ op: 'MySql.updateDevice', err: result })
+          log.error('MySql.updateDevice', { err: result })
           throw error.notFound()
         }
         return {}
@@ -532,7 +532,7 @@ module.exports = function (log, error) {
       [ uid, deviceId ],
       function (result) {
         if (result.affectedRows === 0) {
-          log.error({ op: 'MySql.deleteDevice', err: result })
+          log.error('MySql.deleteDevice', { err: result })
           throw error.notFound()
         }
         return {}
@@ -721,7 +721,7 @@ module.exports = function (log, error) {
                 )
                 .catch(
                   function (err) {
-                    log.error({ op: 'MySql.transaction', err: err })
+                    log.error('MySql.transaction', { err: err })
                     return query(connection, 'ROLLBACK')
                       .then(function () { throw err })
                   }
@@ -771,7 +771,7 @@ module.exports = function (log, error) {
     return this.singleQuery('SLAVE*', sql, params)
       .catch(
         function (err) {
-          log.error({ op: 'MySql.read', sql: sql, id: params, err: err })
+          log.error('MySql.read', { sql: sql, id: params, err: err })
           throw error.wrap(err)
         }
       )
@@ -781,7 +781,7 @@ module.exports = function (log, error) {
     return this.multipleQueries('SLAVE*', queries, finalQuery)
       .catch(
         function (err) {
-          log.error({ op: 'MySql.readMultiple', err: err })
+          log.error('MySql.readMultiple', { err: err })
           throw error.wrap(err)
         }
       )
@@ -791,14 +791,14 @@ module.exports = function (log, error) {
     return this.singleQuery('MASTER', sql, params)
       .then(
         function (result) {
-          log.trace({ op: 'MySql.write', sql: sql, result: result })
+          log.trace('MySql.write', { sql: sql, result: result })
           if (resultHandler) {
             return resultHandler(result)
           }
           return {}
         },
         function (err) {
-          log.error({ op: 'MySql.write', sql: sql, err: err })
+          log.error('MySql.write', { sql: sql, err: err })
           if (err.errno === ER_DUP_ENTRY) {
             err = error.duplicate()
           }
@@ -836,7 +836,7 @@ module.exports = function (log, error) {
     }
     function failure(err) {
       var errno = err.cause ? err.cause.errno : err.errno
-      log.error({ op: 'MySql.retryable', err: err })
+      log.error('MySql.retryable', { err: err })
       if (errnos.indexOf(errno) === -1) {
         throw err
       }
@@ -850,7 +850,7 @@ module.exports = function (log, error) {
 
   var PRUNE = 'CALL prune(?, ?)'
   MySql.prototype.pruneTokens = function () {
-    log.info({  op : 'MySql.pruneTokens' })
+    log.info('MySql.pruneTokens')
 
     var now = Date.now()
     var pruneBefore = now - this.options.pruneEvery
@@ -937,10 +937,7 @@ module.exports = function (log, error) {
                 if (err instanceof EventQueueLockedError) {
                   connection.release()
                 } else {
-                  log.error({
-                    op: 'MySql.processUnpublishedEvents',
-                    err: err
-                  })
+                  log.error('MySql.processUnpublishedEvents', { err: err })
                   connection.destroy()
                 }
                 throw err

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -43,14 +43,14 @@ module.exports = function (log, config) {
             }
           }, function(err, resp) {
             if (err) {
-              log.error({ op: 'Notifier.publishErr', err: err })
+              log.error('Notifier.publishErr', { err: err })
               return reject(err)
             }
             if (resp.statusCode >= 400) {
-              log.error({ op: 'Notifier.publishErr', err: resp })
+              log.error('Notifier.publishErr', { err: resp })
               return reject(resp)
             }
-            log.debug({ op: 'Notifier.publish' })
+            log.debug('Notifier.publish')
             resolve(events.length)
           })
         })

--- a/test/lib/log.js
+++ b/test/lib/log.js
@@ -1,7 +1,27 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
-var noop = function () {}
+const assert = require('assert');
+
+// all the promise wrapping in tests makes it unclear who actually 
+// called mozlog incorrectly. So, record this location directly.
+function getMozlogCallerLocation() {
+  var err = new Error('getMozlogCallerLocation').stack.split('\n')[3]
+  return err
+}
+
+// no-op except check that first arg is a string, etc., a la mozlog
+var noop = function () {
+  assert(arguments.length <= 2, 'mozlog takes a maximum of 2 arguments' + 
+         ', caller: ' + getMozlogCallerLocation())
+  assert.equal(typeof arguments[0], 'string',
+               'mozlog must take a String as first argument, got: ' + 
+               JSON.stringify(arguments[0]) + ', caller: ' + getMozlogCallerLocation())
+  assert.equal(arguments[0].indexOf(' '), -1,
+               'mozlog first argument must not contain spaces, got "' +
+               JSON.stringify(arguments[0]) + '"' + 
+               ', caller: ' + getMozlogCallerLocation())
+}
 
 module.exports = {
   trace: noop,

--- a/test/local/notifier.js
+++ b/test/local/notifier.js
@@ -13,7 +13,8 @@ var NOTIFICATION_SERVER = 'http://notify.me'
 
 var log = { records: [] }
 log.debug = log.error = function(msg) {
-  log.records.push(msg)
+  var args = Array.prototype.slice.call(arguments, 0)
+  log.records.push(args)
 }
 
 var config = require('../../config')
@@ -49,7 +50,7 @@ test(
     return notifier.publish(events)
       .then(function (numPublished) {
         t.equal(numPublished, 2)
-        t.equal(log.records[0].op, 'Notifier.publish')
+        t.equal(log.records[0][0], 'Notifier.publish')
         mock.done()
         t.equal(jwts.length, 2)
         var evt1 = publicKey.verifySync(jwts[0])


### PR DESCRIPTION
It turns out that not all of the logging calls in this repo had been converted to call mozlog according to mozlog calling conventions. Mostly this was on error paths, and, for example, when I had to do db upgrades, I'd get the highly informative `server.bin.[Object object]` with no error details. 

PR is in 3 parts:
1. Since most of the tests stub out the logging, I added mozlog-like assertions. This detected a fair share of the bad call sites, but not all. (Although, I had to run the tests with `node test/local/foo.js`, since within the test harness, you'd just get hard-to-grok test failures). 
2. Fix all the bad calls to `log.foo` or `logger.foo`. Please review that I don't have any typos, since there isn't complete coverage on some of these error paths.
3. Adjust the notifier tests to expect mozlog format error messages.

r? @philbooth @rfk