### PR TITLE
feat(db): implement new token verification logic

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -413,7 +413,7 @@ Parameters:
 
 Get the sessionToken
 with its verification state
-amd matching device info.
+and matching device info.
 
 Parameters:
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -351,7 +351,7 @@ Parameters.
 Returns:
 
 * resolves with:
-    * an object `{}` (whether a row was updated or not, ie. even if `tokenId` does not exist.)
+    * an object `{}` (regardless of whether a row was updated or not, ie. even if `tokenId` does not exist.)
 * rejects with:
     * any error from the underlying storage system (wrapped in `error.wrap()`)
 
@@ -368,7 +368,7 @@ Parameters.
 Returns:
 
 * resolves with:
-    * an object `{}` (whether a row was updated or not, ie. even if `tokenId` does not exist.)
+    * an object `{}` (regardless of whether a row was updated or not, ie. even if `tokenId` does not exist.)
 * rejects with:
     * any error from the underlying storage system (wrapped in `error.wrap()`)
 
@@ -383,10 +383,12 @@ with a `uid` property.
 
 Returns a promise that:
 
-* resolves with an object `{}`
-  (whether a row was updated or not,
-  i.e. even if `tokenVerificationId` does not exist).
-* rejects with any error from the underlying storage system
+* Resolves with an object `{}`
+  if a token was verified.
+* Rejects with error `{ code: 404, errno: 116 }`
+  if there was no matching token.
+* Rejects with any error
+  from the underlying storage system
   (wrapped in `error.wrap()`).
 
 ## .forgotPasswordVerified(tokenId, accountResetToken) ##
@@ -424,8 +426,11 @@ Returns:
     * `error.notFound()` if this token does not exist
     * any error from the underlying storage system (wrapped in `error.wrap()`
 
-These fields are represented as `t.*` for a field from the token `a.*` for a
-field from the corresponding account and `d.*` for a field from devices.
+These fields are represented as
+`t.*` for a field from the token,
+`a.*` for a field from the corresponding account,
+`d.*` for a field from `devices` and
+`ut.*` for a field from `unverifiedTokens`.
 
 The deviceCallbackPublicKey and deviceCallbackAuthKey fields are urlsafe-base64 strings, you can learn more about their format [here](https://developers.google.com/web/updates/2016/03/web-push-encryption).
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -27,7 +27,7 @@ There are a number of methods that a DB storage backend should implement:
     * .keyFetchTokenWithVerificationStatus(tokenId)
     * .deleteKeyFetchToken(tokenId)
 * Unverified session tokens and key fetch tokens
-    * .verifyTokens(tokenVerificationId)
+    * .verifyTokens(tokenVerificationId, accountData)
 * Password Forgot Tokens
     * .createPasswordForgotToken(tokenId, passwordForgotToken)
     * .deletePasswordForgotToken(tokenId)
@@ -377,12 +377,14 @@ Returns:
 * rejects with:
     * any error from the underlying storage system (wrapped in `error.wrap()`)
 
-## .verifyTokens(tokenVerificationId, token)
+## .verifyTokens(tokenVerificationId, accountData)
 
 Verifies sessionTokens and keyFetchTokens.
 Note that it takes the tokenVerificationId
 specified when creating the token,
 NOT the tokenId.
+`accountData` is an object
+with a `uid` property.
 
 Returns a promise that:
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -27,7 +27,7 @@ There are a number of methods that a DB storage backend should implement:
     * .keyFetchTokenVerified(tokenId)
     * .deleteKeyFetchToken(tokenId)
 * Unverified session tokens and key fetch tokens
-    * .verifyToken(tokenVerificationId)
+    * .verifyTokens(tokenVerificationId)
 * Password Forgot Tokens
     * .createPasswordForgotToken(tokenId, passwordForgotToken)
     * .deletePasswordForgotToken(tokenId)
@@ -377,7 +377,7 @@ Returns:
 * rejects with:
     * any error from the underlying storage system (wrapped in `error.wrap()`)
 
-## .verifyToken(tokenVerificationId, token)
+## .verifyTokens(tokenVerificationId, token)
 
 Verifies sessionTokens and keyFetchTokens.
 Note that it takes the tokenVerificationId

--- a/docs/API.md
+++ b/docs/API.md
@@ -18,13 +18,13 @@ There are a number of methods that a DB storage backend should implement:
     * .createSessionToken(tokenId, sessionToken)
     * .updateSessionToken(tokenId, sessionToken)
     * .sessionToken(id)
-    * .sessionTokenVerified(tokenId)
+    * .sessionTokenWithVerificationStatus(tokenId)
     * .sessionWithDevice(tokenId)
     * .deleteSessionToken(tokenId)
 * Key Fetch Tokens
     * .createKeyFetchToken(tokenId, keyFetchToken)
     * .keyFetchToken(id)
-    * .keyFetchTokenVerified(tokenId)
+    * .keyFetchTokenWithVerificationStatus(tokenId)
     * .deleteKeyFetchToken(tokenId)
 * Unverified session tokens and key fetch tokens
     * .verifyTokens(tokenVerificationId)
@@ -293,9 +293,9 @@ Note: for some tokens there should only ever be one row per `uid`. This applies 
 should do something equivalent with your storage backend.
 
 ### .sessionToken(tokenId) ###
-### .sessionTokenVerified(tokenId) ###
+### .sessionTokenWithVerificationStatus(tokenId) ###
 ### .keyFetchToken(tokenId) ###
-### .keyFetchTokenVerified(tokenId) ###
+### .keyFetchTokenWithVerificationStatus(tokenId) ###
 ### .passwordChangeToken(tokenId) ###
 ### .passwordForgotToken(tokenId) ###
 ### .accountResetToken(tokenId) ###
@@ -319,13 +319,13 @@ from the token and `a.*` for a field from the corresponding account.
                  t.uaOS, t.uaOSVersion, t.uaDeviceType, t.lastAccessTime,
                  a.emailVerified, a.email, a.emailCode, a.verifierSetAt,
                  a.createdAt AS accountCreatedAt
-* sessionTokenVerified : t.tokenData, t.uid, t.createdAt, t.uaBrowser, t.uaBrowserVersion,
-                         t.uaOS, t.uaOSVersion, t.uaDeviceType, t.lastAccessTime,
-                         a.emailVerified, a.email, a.emailCode, a.verifierSetAt,
-                         a.createdAt AS accountCreatedAt, ut.tokenVerificationId
+* sessionTokenWithVerificationStatus : t.tokenData, t.uid, t.createdAt, t.uaBrowser, t.uaBrowserVersion,
+                                       t.uaOS, t.uaOSVersion, t.uaDeviceType, t.lastAccessTime,
+                                       a.emailVerified, a.email, a.emailCode, a.verifierSetAt,
+                                       a.createdAt AS accountCreatedAt, ut.tokenVerificationId
 * keyFetchToken : t.authKey, t.uid, t.keyBundle, t.createdAt, a.emailVerified, a.verifierSetAt
-* keyFetchTokenVerified : t.authKey, t.uid, t.keyBundle, t.createdAt, a.emailVerified,
-                          a.verifierSetAt, ut.tokenVerificationId
+* keyFetchTokenWithVerificationStatus : t.authKey, t.uid, t.keyBundle, t.createdAt, a.emailVerified,
+                                        a.verifierSetAt, ut.tokenVerificationId
 * passwordChangeToken : t.tokenData, t.uid, t.createdAt, a.verifierSetAt
 * passwordForgotToken : t.tokenData, t.uid, t.createdAt, t.passCode, t.tries, a.email, a.verifierSetAt
 * accountResetToken : t.uid, t.tokenData, t.createdAt, a.verifierSetAt

--- a/docs/API.md
+++ b/docs/API.md
@@ -21,13 +21,11 @@ There are a number of methods that a DB storage backend should implement:
     * .sessionTokenWithVerificationStatus(tokenId)
     * .sessionWithDevice(tokenId)
     * .deleteSessionToken(tokenId)
+    * .verifyToken(tokenVerificationId, accountData)
 * Key Fetch Tokens
     * .createKeyFetchToken(tokenId, keyFetchToken)
     * .keyFetchToken(id)
-    * .keyFetchTokenWithVerificationStatus(tokenId)
     * .deleteKeyFetchToken(tokenId)
-* Unverified session tokens and key fetch tokens
-    * .verifyTokens(tokenVerificationId, accountData)
 * Password Forgot Tokens
     * .createPasswordForgotToken(tokenId, passwordForgotToken)
     * .deletePasswordForgotToken(tokenId)
@@ -275,7 +273,7 @@ Each token takes the following fields for it's create method respectively:
 
 * sessionToken : data, uid, createdAt, uaBrowser, uaBrowserVersion, uaOS, uaOSVersion, uaDeviceType,
                  tokenVerificationId
-* keyFetchToken : authKey, uid, keyBundle, createdAt, tokenVerificationId
+* keyFetchToken : authKey, uid, keyBundle, createdAt
 * passwordChangeToken : data, uid, createdAt
 * passwordForgotToken : data, uid, passCode, createdAt, triesxb
 * accountResetToken : data, uid, createdAt
@@ -295,7 +293,6 @@ should do something equivalent with your storage backend.
 ### .sessionToken(tokenId) ###
 ### .sessionTokenWithVerificationStatus(tokenId) ###
 ### .keyFetchToken(tokenId) ###
-### .keyFetchTokenWithVerificationStatus(tokenId) ###
 ### .passwordChangeToken(tokenId) ###
 ### .passwordForgotToken(tokenId) ###
 ### .accountResetToken(tokenId) ###
@@ -324,8 +321,6 @@ from the token and `a.*` for a field from the corresponding account.
                                        a.emailVerified, a.email, a.emailCode, a.verifierSetAt,
                                        a.createdAt AS accountCreatedAt, ut.tokenVerificationId
 * keyFetchToken : t.authKey, t.uid, t.keyBundle, t.createdAt, a.emailVerified, a.verifierSetAt
-* keyFetchTokenWithVerificationStatus : t.authKey, t.uid, t.keyBundle, t.createdAt, a.emailVerified,
-                                        a.verifierSetAt, ut.tokenVerificationId
 * passwordChangeToken : t.tokenData, t.uid, t.createdAt, a.verifierSetAt
 * passwordForgotToken : t.tokenData, t.uid, t.createdAt, t.passCode, t.tries, a.email, a.verifierSetAt
 * accountResetToken : t.uid, t.tokenData, t.createdAt, a.verifierSetAt
@@ -377,9 +372,9 @@ Returns:
 * rejects with:
     * any error from the underlying storage system (wrapped in `error.wrap()`)
 
-## .verifyTokens(tokenVerificationId, accountData)
+## .verifyToken(tokenVerificationId, accountData)
 
-Verifies sessionTokens and keyFetchTokens.
+Verifies sessionTokens.
 Note that it takes the tokenVerificationId
 specified when creating the token,
 NOT the tokenId.

--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -1754,6 +1754,10 @@ Content-Length: 2
 * Status Code : 200 OK
     * Content-Type : 'application/json'
     * Body : {}
+* Status Code : 404 Not Found
+    * Conditions: if no unverified tokens exist for `tokenVerificationId` and `uid`
+    * Content-Type : 'application/json'
+    * Body : `{"message":"Not Found"}`
 * Status Code : 500 Internal Server Error
     * Conditions: if something goes wrong on the server
     * Content-Type : 'application/json'

--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -64,7 +64,7 @@ The following datatypes are used throughout this document:
     * deleteDevice              : `DEL /account/:id/device/:deviceId`
 * Session Tokens:
     * sessionToken              : `GET /sessionToken/:id`
-    * sessionTokenVerified      : `GET /sessionToken/:id/verified`
+    * sessionTokenWithVerificationStatus : `GET /sessionToken/:id/verified`
     * sessionWithDevice         : `GET /sessionToken/:id/device`
     * deleteSessionToken        : `DEL /sessionToken/:id`
     * createSessionToken        : `PUT /sessionToken/:id`
@@ -75,7 +75,7 @@ The following datatypes are used throughout this document:
     * createAccountResetToken   : `PUT /accountResetToken/:id`
 * Key Fetch Tokens:
     * keyFetchToken             : `GET /keyFetchToken/:id`
-    * keyFetchTokenVerified     : `GET /keyFetchToken/:id/verified`
+    * keyFetchTokenWithVerificationStatus : `GET /keyFetchToken/:id/verified`
     * deleteKeyFetchToken       : `DEL /keyFetchToken/:id`
     * createKeyFetchToken       : `PUT /keyFetchToken/:id`
 * Password Change Tokens:
@@ -837,7 +837,7 @@ Content-Length: 285
     * Content-Type : 'application/json'
     * Body : `{"code":"InternalError","message":"...<message related to the error>..."}`
 
-## sessionTokenVerified : `GET /sessionToken/<tokenId>/verified`
+## sessionTokenWithVerificationStatus : `GET /sessionToken/<tokenId>/verified`
 
 ### Example
 
@@ -1243,7 +1243,7 @@ Content-Length: 399
     * Content-Type : 'application/json'
     * Body : `{"code":"InternalError","message":"...<message related to the error>..."}`
 
-## keyFetchTokenVerified : `GET /keyFetchToken/<tokenId>/verified`
+## keyFetchTokenWithVerificationStatus : `GET /keyFetchToken/<tokenId>/verified`
 
 ### Example
 

--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -64,6 +64,8 @@ The following datatypes are used throughout this document:
     * deleteDevice              : `DEL /account/:id/device/:deviceId`
 * Session Tokens:
     * sessionToken              : `GET /sessionToken/:id`
+    * sessionTokenVerified      : `GET /sessionToken/:id/verified`
+    * sessionWithDevice         : `GET /sessionToken/:id/device`
     * deleteSessionToken        : `DEL /sessionToken/:id`
     * createSessionToken        : `PUT /sessionToken/:id`
     * updateSessionToken        : `POST /sessionToken/:id/update`
@@ -73,6 +75,7 @@ The following datatypes are used throughout this document:
     * createAccountResetToken   : `PUT /accountResetToken/:id`
 * Key Fetch Tokens:
     * keyFetchToken             : `GET /keyFetchToken/:id`
+    * keyFetchTokenVerified     : `GET /keyFetchToken/:id/verified`
     * deleteKeyFetchToken       : `DEL /keyFetchToken/:id`
     * createKeyFetchToken       : `PUT /keyFetchToken/:id`
 * Password Change Tokens:
@@ -85,6 +88,8 @@ The following datatypes are used throughout this document:
     * createPasswordForgotToken : `PUT /passwordForgotToken/:id`
     * updatePasswordForgotToken : `POST /passwordForgotToken/:id/update`
     * forgotPasswordVerified    : `POST /passwordForgotToken/:id/verified`
+* Unverified tokens:
+    * verifyToken               : `POST /token/:tokenVerificationId/verify`
 
 ## Ping : `GET /`
 
@@ -500,7 +505,13 @@ curl \
     -d '{
         "uid" :  "6044486dd15b42e08b1fb9167415b9ac",
         "data" : "e2c3a8f73e826b9176e54e0f6ecb34b60b1e1979d254638f6b61d721c069d576",
-        "createdAt" : 1425004396952
+        "createdAt" : 1425004396952,
+        "uaBrowser" : Firefox,
+        "uaBrowserVersion" : 47,
+        "uaOS" : Mac OS X,
+        "uaOSVersion" : 10.10,
+        "uaDeviceType" : null,
+        "tokenVerificationId" : "5680a81ba029af7b829afb4aa6dbc23f"
     }' \
     http://localhost:8000/sessionToken/522c251a1623e1f1db1f4fe68b9594d26772d6e77e04cb68e110c58600f97a77
 ```
@@ -514,6 +525,12 @@ curl \
     * uid : hex128
     * data : hex256
     * createdAt : epoch
+    * uaBrowser : string
+    * uaBrowserVersion : string
+    * uaOS : string
+    * uaOSVersion : string
+    * uaDeviceType : string
+    * tokenVerificationId : hex128
 
 ### Response
 
@@ -820,6 +837,125 @@ Content-Length: 285
     * Content-Type : 'application/json'
     * Body : `{"code":"InternalError","message":"...<message related to the error>..."}`
 
+## sessionTokenVerified : `GET /sessionToken/<tokenId>/verified`
+
+### Example
+
+```
+curl \
+    -v \
+    -X GET \
+    http://localhost:8000/sessionToken/522c251a1623e1f1db1f4fe68b9594d26772d6e77e04cb68e110c58600f97a77/verified
+```
+
+### Request
+
+* Method : GET
+* Path : `/sessionToken/<tokenId>/verified`
+    * tokenId : hex256
+* Params: none
+
+### Response
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 285
+
+{
+    "data":"e2c3a8f73e826b9176e54e0f6ecb34b60b1e1979d254638f6b61d721c069d576",
+    "uid":"6044486dd15b42e08b1fb9167415b9ac",
+    "createdAt":1460548810011,
+    "id":"522c251a1623e1f1db1f4fe68b9594d26772d6e77e04cb68e110c58600f97a77",
+    "uaBrowser":"Firefox",
+    "uaBrowserVersion":"47",
+    "uaOS":"Mac OS X",
+    "uaOSVersion":"10.10",
+    "uaDeviceType":null,
+    "lastAccessTime":1460548810011
+    "emailVerified":0,
+    "email":"foo@example.com",
+    "verifierSetAt":1460548810011,
+    "locale":"en_US",
+    "accountCreatedAt":1460548810011,
+    "tokenVerificationId":"12c41fac80fd6149f3f695e188b5f846"
+}
+```
+
+* Status Code : 200 OK
+    * Content-Type : 'application/json'
+    * Body : `[ ... <see example> ...]`
+* Status Code : 404 Not Found
+    * Conditions: if the sessionToken `tokenId` doesn't exist
+    * Content-Type : 'application/json'
+    * Body : `{"message":"Not Found"}`
+* Status Code : 500 Internal Server Error
+    * Conditions: if something goes wrong on the server
+    * Content-Type : 'application/json'
+    * Body : `{"code":"InternalError","message":"...<message related to the error>..."}`
+
+## sessionWithDevice : `GET /sessionToken/<tokenId>/device`
+
+### Example
+
+```
+curl \
+    -v \
+    -X GET \
+    http://localhost:8000/sessionToken/522c251a1623e1f1db1f4fe68b9594d26772d6e77e04cb68e110c58600f97a77/device
+```
+
+### Request
+
+* Method : GET
+* Path : `/sessionToken/<tokenId>/device`
+    * tokenId : hex256
+* Params: none
+
+### Response
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 285
+
+{
+    "data":"e2c3a8f73e826b9176e54e0f6ecb34b60b1e1979d254638f6b61d721c069d576",
+    "uid":"6044486dd15b42e08b1fb9167415b9ac",
+    "createdAt":1460548810011,
+    "id":"522c251a1623e1f1db1f4fe68b9594d26772d6e77e04cb68e110c58600f97a77",
+    "uaBrowser":"Firefox",
+    "uaBrowserVersion":"47",
+    "uaOS":"Mac OS X",
+    "uaOSVersion":"10.10",
+    "uaDeviceType":null,
+    "lastAccessTime":1460548810011
+    "emailVerified":0,
+    "email":"foo@example.com",
+    "verifierSetAt":1460548810011,
+    "locale":"en_US",
+    "accountCreatedAt":1460548810011,
+    "deviceId":"eb87eb63c2063bf5fd35e83b535c123d073db9156e49b58bcbf543f9d35467f6",
+    "deviceName":"foo",
+    "deviceType":"mobile",
+    "deviceCreatedAt":1460548810011,
+    "deviceCallbackURL":null,
+    "deviceCallbackPublicKey":null,
+    "tokenVerificationId":"12c41fac80fd6149f3f695e188b5f846"
+}
+```
+
+* Status Code : 200 OK
+    * Content-Type : 'application/json'
+    * Body : `[ ... <see example> ...]`
+* Status Code : 404 Not Found
+    * Conditions: if the sessionToken `tokenId` doesn't exist
+    * Content-Type : 'application/json'
+    * Body : `{"message":"Not Found"}`
+* Status Code : 500 Internal Server Error
+    * Conditions: if something goes wrong on the server
+    * Content-Type : 'application/json'
+    * Body : `{"code":"InternalError","message":"...<message related to the error>..."}`
 
 ## deleteSessionToken : `DEL /sessionToken/<tokenId>`
 
@@ -916,7 +1052,7 @@ Content-Length: 2
     * Conditions: if something goes wrong on the server
     * Content-Type : 'application/json'
     * Body : {"code":"InternalError","message":"...<message related to the error>..."}
-* ``
+```
 
 
 ## accountResetToken : `GET /accountResetToken/<tokenId>`
@@ -1018,7 +1154,8 @@ curl \
         "uid"       : "6044486dd15b42e08b1fb9167415b9ac",
         "authKey"   : "b034061cc2886a3c3c08bd4e9bbc8afc4bc3fc9bca12d5b5d0aa7e0a7f78b9ce",
         "keyBundle" : "83333269c64eb43219f8b5807d37ac2391fc77295562685a5239674e2b0215920c45e2295c0d92fa7d69cb58d1e3c6010e1281f6d6c0df694b134815358110ae22a7b4c348a4f426bef3783b0493b3a531b649c0e2f19848d9563a61cd0f7eb8",
-        "createdAt" : 1425004396952
+        "createdAt" : 1425004396952,
+        "tokenVerificationId" : "a6062c21560edad350e6a654bdd9fd4f"
     }' \
     http://localhost:8000/keyFetchToken/4c17443c1bcf5e509bc90904905ea1974900120d3dd34e7061f182cb063f976a
 ```
@@ -1034,6 +1171,7 @@ curl \
     * authKey : hex256
     * keyBundle : hex768
     * createdAt : epoch
+    * tokenVerificationId : hex128
 
 ### Response
 
@@ -1056,7 +1194,7 @@ Content-Length: 2
     * Conditions: if something goes wrong on the server
     * Content-Type : 'application/json'
     * Body : {"code":"InternalError","message":"...<message related to the error>..."}
-* ``
+```
 
 ## keyFetchToken : `GET /keyFetchToken/<tokenId>`
 
@@ -1105,6 +1243,53 @@ Content-Length: 399
     * Content-Type : 'application/json'
     * Body : `{"code":"InternalError","message":"...<message related to the error>..."}`
 
+## keyFetchTokenVerified : `GET /keyFetchToken/<tokenId>/verified`
+
+### Example
+
+```
+curl \
+    -v \
+    -X GET \
+    http://localhost:8000/keyFetchToken/4c17443c1bcf5e509bc90904905ea1974900120d3dd34e7061f182cb063f976a/verified
+```
+
+### Request
+
+* Method : GET
+* Path : `/keyFetchToken/<tokenId>/verified`
+    * tokenId : hex256
+* Params: none
+
+### Response
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 399
+
+{
+    "authKey":"b034061cc2886a3c3c08bd4e9bbc8afc4bc3fc9bca12d5b5d0aa7e0a7f78b9ce",
+    "uid":"6044486dd15b42e08b1fb9167415b9ac",
+    "keyBundle":"83333269c64eb43219f8b5807d37ac2391fc77295562685a5239674e2b0215920c45e2295c0d92fa7d69cb58d1e3c6010e1281f6d6c0df694b134815358110ae22a7b4c348a4f426bef3783b0493b3a531b649c0e2f19848d9563a61cd0f7eb8",
+    "createdAt":1460548810011,
+    "emailVerified":0,
+    "verifierSetAt":1460548810011,
+    "tokenVerificationId":"12c41fac80fd6149f3f695e188b5f846"
+}
+```
+
+* Status Code : 200 OK
+    * Content-Type : 'application/json'
+    * Body : `[ ... <see example> ...]`
+* Status Code : 404 Not Found
+    * Conditions: if the keyFetchToken `tokenId` doesn't exist
+    * Content-Type : 'application/json'
+    * Body : `{"message":"Not Found"}`
+* Status Code : 500 Internal Server Error
+    * Conditions: if something goes wrong on the server
+    * Content-Type : 'application/json'
+    * Body : `{"code":"InternalError","message":"...<message related to the error>..."}`
 
 ## deleteKeyFetchToken : `DEL /keyFetchToken/<tokenId>`
 
@@ -1194,7 +1379,7 @@ Content-Length: 2
     * Conditions: if something goes wrong on the server
     * Content-Type : 'application/json'
     * Body : {"code":"InternalError","message":"...<message related to the error>..."}
-* ``
+```
 
 ## passwordChangeToken : `GET /passwordChangeToken/<tokenId>`
 
@@ -1334,7 +1519,7 @@ Content-Length: 2
     * Conditions: if something goes wrong on the server
     * Content-Type : 'application/json'
     * Body : {"code":"InternalError","message":"...<message related to the error>..."}
-* ``
+```
 
 ## passwordForgotToken : `GET /passwordForgotToken/<tokenId>`
 
@@ -1470,7 +1655,7 @@ Content-Length: 2
     * Conditions: if something goes wrong on the server
     * Content-Type : 'application/json'
     * Body : {"code":"InternalError","message":"...<message related to the error>..."}
-* ``
+```
 
 
 ## forgotPasswordVerified : `POST /passwordForgotToken/<tokenId>/verified`
@@ -1528,7 +1713,52 @@ Content-Length: 2
     * Conditions: if something goes wrong on the server
     * Content-Type : 'application/json'
     * Body : {"code":"InternalError","message":"...<message related to the error>..."}
-* ``
+```
+
+## verifyToken : `POST /token/<tokenVerificationId>/verify`
+
+This method verifies sessionTokens and keyFetchTokens.
+Note that it takes the tokenVerificationId
+specified when creating the token,
+NOT the tokenId.
+
+### Example
+
+```
+curl \
+    -v \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d '{"uid":"fdea27c8188b3d980a28917bc1399e47"}' \
+    http://localhost:8000/token/266fd690895c8b0086bb2c83e4b3b41c128746125f28b5429938765279673d62/verify
+```
+
+### Request
+
+* Method : POST
+* Path : `/token/<tokenVerificationId>/verify`
+    * tokenVerificationId : hex128
+* Params:
+    * uid : hex128
+
+### Response
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 2
+
+{}
+```
+
+* Status Code : 200 OK
+    * Content-Type : 'application/json'
+    * Body : {}
+* Status Code : 500 Internal Server Error
+    * Conditions: if something goes wrong on the server
+    * Content-Type : 'application/json'
+    * Body : {"code":"InternalError","message":"...<message related to the error>..."}
+```
 
 ## lockAccount : `POST /account/<uid>/lock` ##
 
@@ -1581,7 +1811,7 @@ Content-Length: 2
     * Conditions: if something goes wrong on the server
     * Content-Type : 'application/json'
     * Body : {"code":"InternalError","message":"...<message related to the error>..."}
-* ``
+```
 
 ## unlockCode : `GET /account/<uid>/unlockCode` ##
 
@@ -1673,6 +1903,6 @@ Content-Length: 2
     * Conditions: if something goes wrong on the server
     * Content-Type : 'application/json'
     * Body : {"code":"InternalError","message":"...<message related to the error>..."}
-* ``
+```
 
 (Ends)

--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -89,7 +89,7 @@ The following datatypes are used throughout this document:
     * updatePasswordForgotToken : `POST /passwordForgotToken/:id/update`
     * forgotPasswordVerified    : `POST /passwordForgotToken/:id/verified`
 * Unverified tokens:
-    * verifyToken               : `POST /token/:tokenVerificationId/verify`
+    * verifyTokens              : `POST /token/:tokenVerificationId/verify`
 
 ## Ping : `GET /`
 
@@ -1715,7 +1715,7 @@ Content-Length: 2
     * Body : {"code":"InternalError","message":"...<message related to the error>..."}
 ```
 
-## verifyToken : `POST /token/<tokenVerificationId>/verify`
+## verifyTokens : `POST /token/<tokenVerificationId>/verify`
 
 This method verifies sessionTokens and keyFetchTokens.
 Note that it takes the tokenVerificationId

--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -624,7 +624,7 @@ curl \
     -X POST \
     -H "Content-Type: application/json" \
     -d '{"uid":"fdea27c8188b3d980a28917bc1399e47"}' \
-    http://localhost:8000/token/266fd690895c8b0086bb2c83e4b3b41c128746125f28b5429938765279673d62/verify
+    http://localhost:8000/token/8e8c27b704dbf6a5dc556453c92e7506/verify
 ```
 
 ### Request

--- a/fxa-auth-db-server/index.js
+++ b/fxa-auth-db-server/index.js
@@ -101,6 +101,10 @@ function createServer(db) {
   api.del('/keyFetchToken/:id', reply(db.deleteKeyFetchToken))
   api.put('/keyFetchToken/:id', reply(db.createKeyFetchToken))
 
+  api.get('/sessionToken/:id/verified', reply(db.sessionTokenVerified))
+  api.get('/keyFetchToken/:id/verified', reply(db.keyFetchTokenVerified))
+  api.post('/token/:id/verify', reply(db.verifyToken))
+
   api.get('/accountResetToken/:id', reply(db.accountResetToken))
   api.del('/accountResetToken/:id', reply(db.deleteAccountResetToken))
   api.put('/accountResetToken/:id', reply(db.createAccountResetToken))

--- a/fxa-auth-db-server/index.js
+++ b/fxa-auth-db-server/index.js
@@ -103,7 +103,7 @@ function createServer(db) {
 
   api.get('/sessionToken/:id/verified', reply(db.sessionTokenVerified))
   api.get('/keyFetchToken/:id/verified', reply(db.keyFetchTokenVerified))
-  api.post('/token/:id/verify', reply(db.verifyToken))
+  api.post('/tokens/:id/verify', reply(db.verifyTokens))
 
   api.get('/accountResetToken/:id', reply(db.accountResetToken))
   api.del('/accountResetToken/:id', reply(db.deleteAccountResetToken))

--- a/fxa-auth-db-server/index.js
+++ b/fxa-auth-db-server/index.js
@@ -102,8 +102,7 @@ function createServer(db) {
   api.put('/keyFetchToken/:id', reply(db.createKeyFetchToken))
 
   api.get('/sessionToken/:id/verified', reply(db.sessionTokenWithVerificationStatus))
-  api.get('/keyFetchToken/:id/verified', reply(db.keyFetchTokenWithVerificationStatus))
-  api.post('/tokens/:id/verify', reply(db.verifyTokens))
+  api.post('/token/:id/verify', reply(db.verifyToken))
 
   api.get('/accountResetToken/:id', reply(db.accountResetToken))
   api.del('/accountResetToken/:id', reply(db.deleteAccountResetToken))

--- a/fxa-auth-db-server/index.js
+++ b/fxa-auth-db-server/index.js
@@ -101,8 +101,8 @@ function createServer(db) {
   api.del('/keyFetchToken/:id', reply(db.deleteKeyFetchToken))
   api.put('/keyFetchToken/:id', reply(db.createKeyFetchToken))
 
-  api.get('/sessionToken/:id/verified', reply(db.sessionTokenVerified))
-  api.get('/keyFetchToken/:id/verified', reply(db.keyFetchTokenVerified))
+  api.get('/sessionToken/:id/verified', reply(db.sessionTokenWithVerificationStatus))
+  api.get('/keyFetchToken/:id/verified', reply(db.keyFetchTokenWithVerificationStatus))
   api.post('/tokens/:id/verify', reply(db.verifyTokens))
 
   api.get('/accountResetToken/:id', reply(db.accountResetToken))

--- a/fxa-auth-db-server/test/backend/db_tests.js
+++ b/fxa-auth-db-server/test/backend/db_tests.js
@@ -68,8 +68,7 @@ var KEY_FETCH_TOKEN = {
   authKey : hex32(),
   uid : ACCOUNT.uid,
   keyBundle : hex96(),
-  createdAt : now + 2,
-  tokenVerificationId : hex16()
+  createdAt : now + 2
 }
 
 var PASSWORD_FORGOT_TOKEN_ID = hex32()
@@ -354,7 +353,7 @@ module.exports = function(config, DB) {
                 t.deepEqual(token.tokenVerificationId, SESSION_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
 
                 // Attempt to verify session token with invalid tokenVerificationId
-                return db.verifyTokens(hex16(), { uid: ACCOUNT.uid })
+                return db.verifyToken(hex16(), { uid: ACCOUNT.uid })
               })
               .then(function () {
                 t.fail('Verifying session token with invalid tokenVerificationId should have failed')
@@ -370,7 +369,7 @@ module.exports = function(config, DB) {
                 t.deepEqual(token.tokenVerificationId, SESSION_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
 
                 // Attempt to verify session token with invalid uid
-                return db.verifyTokens(SESSION_TOKEN.tokenVerificationId, { uid: hex16() })
+                return db.verifyToken(SESSION_TOKEN.tokenVerificationId, { uid: hex16() })
               })
               .then(function () {
                 t.fail('Verifying session token with invalid uid should have failed')
@@ -385,7 +384,7 @@ module.exports = function(config, DB) {
                 t.deepEqual(token.tokenVerificationId, SESSION_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
 
                 // Verify the session token
-                return db.verifyTokens(SESSION_TOKEN.tokenVerificationId, { uid: ACCOUNT.uid })
+                return db.verifyToken(SESSION_TOKEN.tokenVerificationId, { uid: ACCOUNT.uid })
               })
               .then(function() {
                 // Fetch the session token
@@ -426,24 +425,10 @@ module.exports = function(config, DB) {
         test(
           'key fetch token handling',
           function (t) {
-            t.plan(22)
+            t.plan(8)
 
-            // Attempt to create a key fetch token with no tokenVerificationId
-            return db.createKeyFetchToken(KEY_FETCH_TOKEN_ID, {
-              authKey: hex32(),
-              uid: ACCOUNT.uid,
-              keyBundle: hex96(),
-              createdAt: Date.now()
-            })
-              .then(function () {
-                t.fail('Should have failed to create key fetch token with no tokenVerificationId')
-              }, function (err) {
-                t.pass('Correctly failed to create key fetch token with no tokenVerificationId')
-              })
-              .then(function () {
-                // Create a key fetch token
-                return db.createKeyFetchToken(KEY_FETCH_TOKEN_ID, KEY_FETCH_TOKEN)
-              })
+            // Create a key fetch token
+            return db.createKeyFetchToken(KEY_FETCH_TOKEN_ID, KEY_FETCH_TOKEN)
               .then(function(result) {
                 t.deepEqual(result, {}, 'Returned an empty object on key fetch token creation')
 
@@ -459,64 +444,6 @@ module.exports = function(config, DB) {
                 // email is not returned
                 // emailCode is not returned
                 t.equal(token.verifierSetAt, ACCOUNT.verifierSetAt, 'verifierSetAt is correct')
-                t.equal(token.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
-
-                // Fetch the key fetch token with its verification state
-                return db.keyFetchTokenWithVerificationStatus(KEY_FETCH_TOKEN_ID)
-              })
-              .then(function(token) {
-                t.deepEqual(token.authKey, KEY_FETCH_TOKEN.authKey, 'authKey matches')
-                t.deepEqual(token.uid, ACCOUNT.uid, 'token belongs to this account')
-                t.equal(token.createdAt, KEY_FETCH_TOKEN.createdAt, 'createdAt is ok')
-                t.equal(!!token.emailVerified, ACCOUNT.emailVerified, 'emailVerified is correct')
-                t.equal(token.verifierSetAt, ACCOUNT.verifierSetAt, 'verifierSetAt is correct')
-                t.deepEqual(token.tokenVerificationId, KEY_FETCH_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
-
-                // Attempt to verify key fetch token with invalid tokenVerificationId
-                return db.verifyTokens(hex16(), { uid: KEY_FETCH_TOKEN.uid })
-              })
-              .then(function () {
-                t.fail('Verifying key fetch token with invalid tokenVerificationId should have failed')
-              }, function () {
-                t.pass('Verifying key fetch token with invalid tokenVerificationId failed as expected')
-              })
-              .then(function() {
-                // Fetch the key fetch token with its verification state
-                return db.keyFetchTokenWithVerificationStatus(KEY_FETCH_TOKEN_ID)
-              })
-              .then(function (token) {
-                t.deepEqual(token.tokenVerificationId, KEY_FETCH_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
-
-                // Attempt to verify key fetch token with invalid uid
-                return db.verifyTokens(KEY_FETCH_TOKEN.tokenVerificationId, { uid: hex16() })
-              })
-              .then(function () {
-                t.fail('Verifying key fetch token with invalid uid should have failed')
-              }, function () {
-                t.pass('Verifying key fetch token with invalid uid failed as expected')
-              })
-              .then(function() {
-                // Fetch the key fetch token with its verification state
-                return db.keyFetchTokenWithVerificationStatus(KEY_FETCH_TOKEN_ID)
-              })
-              .then(function (token) {
-                t.deepEqual(token.tokenVerificationId, KEY_FETCH_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
-
-                // Verify the key fetch token
-                return db.verifyTokens(KEY_FETCH_TOKEN.tokenVerificationId, { uid: SESSION_TOKEN.uid })
-              })
-              .then(function() {
-                // Fetch the key fetch token
-                return db.keyFetchToken(KEY_FETCH_TOKEN_ID)
-              })
-              .then(function(token) {
-                t.equal(token.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
-
-                // Fetch the key fetch token with its verification state
-                return db.keyFetchTokenWithVerificationStatus(KEY_FETCH_TOKEN_ID)
-              })
-              .then(function(token) {
-                t.equal(token.tokenVerificationId, null, 'tokenVerificationId is null')
 
                 // Delete the key fetch token
                 return db.deleteKeyFetchToken(KEY_FETCH_TOKEN_ID)
@@ -1095,7 +1022,7 @@ module.exports = function(config, DB) {
               })
               .then(function () {
                 // Verify the session token
-                return db.verifyTokens(SESSION_TOKEN.tokenVerificationId, { uid: SESSION_TOKEN.uid })
+                return db.verifyToken(SESSION_TOKEN.tokenVerificationId, { uid: SESSION_TOKEN.uid })
               })
               .then(function () {
                 // Fetch the session token with its verification state and device info

--- a/fxa-auth-db-server/test/backend/db_tests.js
+++ b/fxa-auth-db-server/test/backend/db_tests.js
@@ -217,7 +217,7 @@ module.exports = function(config, DB) {
         test(
           'session token handling',
           function (t) {
-            t.plan(98)
+            t.plan(100)
 
             var VERIFIED_SESSION_TOKEN_ID = hex32()
 
@@ -392,8 +392,9 @@ module.exports = function(config, DB) {
               })
               .then(function () {
                 t.fail('Verifying session token with invalid tokenVerificationId should have failed')
-              }, function () {
-                t.pass('Verifying session token with invalid tokenVerificationId failed as expected')
+              }, function (err) {
+                t.equal(err.errno, 116, 'err.errno is correct')
+                t.equal(err.code, 404, 'err.code is correct')
               })
               .then(function() {
                 // Fetch the unverified session token with its verification state
@@ -407,8 +408,9 @@ module.exports = function(config, DB) {
               })
               .then(function () {
                 t.fail('Verifying session token with invalid uid should have failed')
-              }, function () {
-                t.pass('Verifying session token with invalid uid failed as expected')
+              }, function (err) {
+                t.equal(err.errno, 116, 'err.errno is correct')
+                t.equal(err.code, 404, 'err.code is correct')
               })
               .then(function() {
                 // Fetch the unverified session token with its verification state

--- a/fxa-auth-db-server/test/backend/db_tests.js
+++ b/fxa-auth-db-server/test/backend/db_tests.js
@@ -217,7 +217,7 @@ module.exports = function(config, DB) {
         test(
           'session token handling',
           function (t) {
-            t.plan(77)
+            t.plan(79)
 
             // Fetch all of the sessions tokens for the account
             return db.sessions(ACCOUNT.uid)
@@ -356,6 +356,11 @@ module.exports = function(config, DB) {
                 // Attempt to verify session token with invalid tokenVerificationId
                 return db.verifyToken(hex16(), { uid: ACCOUNT.uid })
               })
+              .then(function () {
+                t.fail('Verifying session token with invalid tokenVerificationId should have failed')
+              }, function () {
+                t.pass('Verifying session token with invalid tokenVerificationId failed as expected')
+              })
               .then(function() {
 
                 // Fetch the session token with its verification state
@@ -366,6 +371,11 @@ module.exports = function(config, DB) {
 
                 // Attempt to verify session token with invalid uid
                 return db.verifyToken(SESSION_TOKEN.tokenVerificationId, { uid: hex16() })
+              })
+              .then(function () {
+                t.fail('Verifying session token with invalid uid should have failed')
+              }, function () {
+                t.pass('Verifying session token with invalid uid failed as expected')
               })
               .then(function() {
                 // Fetch the session token with its verification state
@@ -416,7 +426,7 @@ module.exports = function(config, DB) {
         test(
           'key fetch token handling',
           function (t) {
-            t.plan(20)
+            t.plan(22)
 
             // Attempt to create a key fetch token with no tokenVerificationId
             return db.createKeyFetchToken(KEY_FETCH_TOKEN_ID, {
@@ -465,6 +475,11 @@ module.exports = function(config, DB) {
                 // Attempt to verify key fetch token with invalid tokenVerificationId
                 return db.verifyToken(hex16(), { uid: KEY_FETCH_TOKEN.uid })
               })
+              .then(function () {
+                t.fail('Verifying key fetch token with invalid tokenVerificationId should have failed')
+              }, function () {
+                t.pass('Verifying key fetch token with invalid tokenVerificationId failed as expected')
+              })
               .then(function() {
                 // Fetch the key fetch token with its verification state
                 return db.keyFetchTokenVerified(KEY_FETCH_TOKEN_ID)
@@ -474,6 +489,11 @@ module.exports = function(config, DB) {
 
                 // Attempt to verify key fetch token with invalid uid
                 return db.verifyToken(KEY_FETCH_TOKEN.tokenVerificationId, { uid: hex16() })
+              })
+              .then(function () {
+                t.fail('Verifying key fetch token with invalid uid should have failed')
+              }, function () {
+                t.pass('Verifying key fetch token with invalid uid failed as expected')
               })
               .then(function() {
                 // Fetch the key fetch token with its verification state

--- a/fxa-auth-db-server/test/backend/db_tests.js
+++ b/fxa-auth-db-server/test/backend/db_tests.js
@@ -354,7 +354,7 @@ module.exports = function(config, DB) {
                 t.deepEqual(token.tokenVerificationId, SESSION_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
 
                 // Attempt to verify session token with invalid tokenVerificationId
-                return db.verifyToken(hex16(), { uid: ACCOUNT.uid })
+                return db.verifyTokens(hex16(), { uid: ACCOUNT.uid })
               })
               .then(function () {
                 t.fail('Verifying session token with invalid tokenVerificationId should have failed')
@@ -370,7 +370,7 @@ module.exports = function(config, DB) {
                 t.deepEqual(token.tokenVerificationId, SESSION_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
 
                 // Attempt to verify session token with invalid uid
-                return db.verifyToken(SESSION_TOKEN.tokenVerificationId, { uid: hex16() })
+                return db.verifyTokens(SESSION_TOKEN.tokenVerificationId, { uid: hex16() })
               })
               .then(function () {
                 t.fail('Verifying session token with invalid uid should have failed')
@@ -385,7 +385,7 @@ module.exports = function(config, DB) {
                 t.deepEqual(token.tokenVerificationId, SESSION_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
 
                 // Verify the session token
-                return db.verifyToken(SESSION_TOKEN.tokenVerificationId, { uid: ACCOUNT.uid })
+                return db.verifyTokens(SESSION_TOKEN.tokenVerificationId, { uid: ACCOUNT.uid })
               })
               .then(function() {
                 // Fetch the session token
@@ -473,7 +473,7 @@ module.exports = function(config, DB) {
                 t.deepEqual(token.tokenVerificationId, KEY_FETCH_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
 
                 // Attempt to verify key fetch token with invalid tokenVerificationId
-                return db.verifyToken(hex16(), { uid: KEY_FETCH_TOKEN.uid })
+                return db.verifyTokens(hex16(), { uid: KEY_FETCH_TOKEN.uid })
               })
               .then(function () {
                 t.fail('Verifying key fetch token with invalid tokenVerificationId should have failed')
@@ -488,7 +488,7 @@ module.exports = function(config, DB) {
                 t.deepEqual(token.tokenVerificationId, KEY_FETCH_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
 
                 // Attempt to verify key fetch token with invalid uid
-                return db.verifyToken(KEY_FETCH_TOKEN.tokenVerificationId, { uid: hex16() })
+                return db.verifyTokens(KEY_FETCH_TOKEN.tokenVerificationId, { uid: hex16() })
               })
               .then(function () {
                 t.fail('Verifying key fetch token with invalid uid should have failed')
@@ -503,7 +503,7 @@ module.exports = function(config, DB) {
                 t.deepEqual(token.tokenVerificationId, KEY_FETCH_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
 
                 // Verify the key fetch token
-                return db.verifyToken(KEY_FETCH_TOKEN.tokenVerificationId, { uid: SESSION_TOKEN.uid })
+                return db.verifyTokens(KEY_FETCH_TOKEN.tokenVerificationId, { uid: SESSION_TOKEN.uid })
               })
               .then(function() {
                 // Fetch the key fetch token
@@ -1095,7 +1095,7 @@ module.exports = function(config, DB) {
               })
               .then(function () {
                 // Verify the session token
-                return db.verifyToken(SESSION_TOKEN.tokenVerificationId, { uid: SESSION_TOKEN.uid })
+                return db.verifyTokens(SESSION_TOKEN.tokenVerificationId, { uid: SESSION_TOKEN.uid })
               })
               .then(function () {
                 // Fetch the session token with its verification state and device info

--- a/fxa-auth-db-server/test/backend/db_tests.js
+++ b/fxa-auth-db-server/test/backend/db_tests.js
@@ -334,7 +334,7 @@ module.exports = function(config, DB) {
                 t.equal(token.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
 
                 // Fetch the session token with its verification state
-                return db.sessionTokenVerified(SESSION_TOKEN_ID)
+                return db.sessionTokenWithVerificationStatus(SESSION_TOKEN_ID)
               })
               .then(function (token) {
                 t.deepEqual(token.tokenData, SESSION_TOKEN.data, 'token data matches')
@@ -364,7 +364,7 @@ module.exports = function(config, DB) {
               .then(function() {
 
                 // Fetch the session token with its verification state
-                return db.sessionTokenVerified(SESSION_TOKEN_ID)
+                return db.sessionTokenWithVerificationStatus(SESSION_TOKEN_ID)
               })
               .then(function (token) {
                 t.deepEqual(token.tokenVerificationId, SESSION_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
@@ -379,7 +379,7 @@ module.exports = function(config, DB) {
               })
               .then(function() {
                 // Fetch the session token with its verification state
-                return db.sessionTokenVerified(SESSION_TOKEN_ID)
+                return db.sessionTokenWithVerificationStatus(SESSION_TOKEN_ID)
               })
               .then(function (token) {
                 t.deepEqual(token.tokenVerificationId, SESSION_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
@@ -395,7 +395,7 @@ module.exports = function(config, DB) {
                 t.equal(token.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
 
                 // Fetch the session token with its verification state
-                return db.sessionTokenVerified(SESSION_TOKEN_ID)
+                return db.sessionTokenWithVerificationStatus(SESSION_TOKEN_ID)
               })
               .then(function (token) {
                 t.equal(token.tokenVerificationId, null, 'tokenVerificationId is null')
@@ -462,7 +462,7 @@ module.exports = function(config, DB) {
                 t.equal(token.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
 
                 // Fetch the key fetch token with its verification state
-                return db.keyFetchTokenVerified(KEY_FETCH_TOKEN_ID)
+                return db.keyFetchTokenWithVerificationStatus(KEY_FETCH_TOKEN_ID)
               })
               .then(function(token) {
                 t.deepEqual(token.authKey, KEY_FETCH_TOKEN.authKey, 'authKey matches')
@@ -482,7 +482,7 @@ module.exports = function(config, DB) {
               })
               .then(function() {
                 // Fetch the key fetch token with its verification state
-                return db.keyFetchTokenVerified(KEY_FETCH_TOKEN_ID)
+                return db.keyFetchTokenWithVerificationStatus(KEY_FETCH_TOKEN_ID)
               })
               .then(function (token) {
                 t.deepEqual(token.tokenVerificationId, KEY_FETCH_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
@@ -497,7 +497,7 @@ module.exports = function(config, DB) {
               })
               .then(function() {
                 // Fetch the key fetch token with its verification state
-                return db.keyFetchTokenVerified(KEY_FETCH_TOKEN_ID)
+                return db.keyFetchTokenWithVerificationStatus(KEY_FETCH_TOKEN_ID)
               })
               .then(function (token) {
                 t.deepEqual(token.tokenVerificationId, KEY_FETCH_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
@@ -513,7 +513,7 @@ module.exports = function(config, DB) {
                 t.equal(token.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
 
                 // Fetch the key fetch token with its verification state
-                return db.keyFetchTokenVerified(KEY_FETCH_TOKEN_ID)
+                return db.keyFetchTokenWithVerificationStatus(KEY_FETCH_TOKEN_ID)
               })
               .then(function(token) {
                 t.equal(token.tokenVerificationId, null, 'tokenVerificationId is null')

--- a/fxa-auth-db-server/test/backend/db_tests.js
+++ b/fxa-auth-db-server/test/backend/db_tests.js
@@ -4,6 +4,7 @@
 var test = require('tap').test
 var crypto = require('crypto')
 var base64url = require('base64url')
+var P = require('bluebird')
 
 var zeroBuffer16 = Buffer('00000000000000000000000000000000', 'hex')
 var zeroBuffer32 = Buffer('0000000000000000000000000000000000000000000000000000000000000000', 'hex')
@@ -433,7 +434,7 @@ module.exports = function(config, DB) {
                 t.equal(token.tokenVerificationId, null, 'tokenVerificationId is null')
 
                 // Delete both session tokens
-                return Promise.all([
+                return P.all([
                   db.deleteSessionToken(SESSION_TOKEN_ID),
                   db.deleteSessionToken(VERIFIED_SESSION_TOKEN_ID)
                 ])

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -208,7 +208,7 @@ module.exports = function(cfg, server) {
           t.equal(r.obj.length, 0, 'sessions is empty')
 
           // Create accounts
-          return Promise.all([
+          return P.all([
             client.putThen('/account/' + user.accountId, user.account),
             client.putThen('/account/' + verifiedUser.accountId, verifiedUser.account)
           ])
@@ -439,7 +439,7 @@ module.exports = function(cfg, server) {
           t.equal(token.lastAccessTime, 42, 'lastAccessTime was updated')
 
           // Delete both session tokens
-          return Promise.all([
+          return P.all([
             client.delThen('/sessionToken/' + user.sessionTokenId),
             client.delThen('/sessionToken/' + verifiedUser.sessionTokenId)
           ])

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -312,7 +312,7 @@ module.exports = function(cfg, server) {
           t.equal(token.tokenVerificationId, user.sessionToken.tokenVerificationId, 'tokenVerificationId is correct')
 
           // Attempt to verify a non-existent session token
-          return client.postThen('/token/' + crypto.randomBytes(16).toString('hex') + '/verify', {
+          return client.postThen('/tokens/' + crypto.randomBytes(16).toString('hex') + '/verify', {
             uid: user.accountId
           })
         })
@@ -322,7 +322,7 @@ module.exports = function(cfg, server) {
           testNotFound(t, err)
 
           // Attempt to verify a session token with the wrong uid
-          return client.postThen('/token/' + user.sessionToken.tokenVerificationId + '/verify', {
+          return client.postThen('/tokens/' + user.sessionToken.tokenVerificationId + '/verify', {
             uid: crypto.randomBytes(16).toString('hex')
           })
         })
@@ -332,7 +332,7 @@ module.exports = function(cfg, server) {
           testNotFound(t, err)
 
           // Verify the session token
-          return client.postThen('/token/' + user.sessionToken.tokenVerificationId + '/verify', {
+          return client.postThen('/tokens/' + user.sessionToken.tokenVerificationId + '/verify', {
             uid: user.accountId
           })
         })
@@ -582,7 +582,7 @@ module.exports = function(cfg, server) {
           t.equal(token.tokenVerificationId, user.keyFetchToken.tokenVerificationId, 'tokenVerificationId is correct')
 
           // Attempt to verify a non-existent key fetch token
-          return client.postThen('/token/' + crypto.randomBytes(16).toString('hex') + '/verify', {
+          return client.postThen('/tokens/' + crypto.randomBytes(16).toString('hex') + '/verify', {
             uid: user.accountId
           })
         })
@@ -592,7 +592,7 @@ module.exports = function(cfg, server) {
           testNotFound(t, err)
 
           // Attempt to verify a key fetch token with the wrong uid
-          return client.postThen('/token/' + user.keyFetchToken.tokenVerificationId + '/verify', {
+          return client.postThen('/tokens/' + user.keyFetchToken.tokenVerificationId + '/verify', {
             uid: crypto.randomBytes(16).toString('hex')
           })
         })
@@ -602,7 +602,7 @@ module.exports = function(cfg, server) {
           testNotFound(t, err)
 
           // Verify the key fetch token
-          return client.postThen('/token/' + user.keyFetchToken.tokenVerificationId + '/verify', {
+          return client.postThen('/tokens/' + user.keyFetchToken.tokenVerificationId + '/verify', {
             uid: user.accountId
           })
         })

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -195,10 +195,10 @@ module.exports = function(cfg, server) {
   test(
     'session token handling',
     function (t) {
-      t.plan(91)
+      t.plan(125)
       var user = fake.newUserDataHex()
-      var badUser = fake.newUserDataHex()
-      delete badUser.sessionToken.tokenVerificationId
+      var verifiedUser = fake.newUserDataHex()
+      delete verifiedUser.sessionToken.tokenVerificationId
 
       // Fetch all of the session tokens for the account
       return client.getThen('/account/' + user.accountId + '/sessions')
@@ -207,8 +207,11 @@ module.exports = function(cfg, server) {
           t.ok(Array.isArray(r.obj), 'sessions is array')
           t.equal(r.obj.length, 0, 'sessions is empty')
 
-          // Create an account
-          return client.putThen('/account/' + user.accountId, user.account)
+          // Create accounts
+          return Promise.all([
+            client.putThen('/account/' + user.accountId, user.account),
+            client.putThen('/account/' + verifiedUser.accountId, verifiedUser.account)
+          ])
         })
         .then(function() {
           // Fetch all of the session tokens for the account
@@ -233,15 +236,6 @@ module.exports = function(cfg, server) {
         }, function(err) {
           testNotFound(t, err)
 
-          // Attempt to create a session token with no tokenVerificationId
-          return client.putThen('/sessionToken/' + badUser.sessionTokenId, badUser.sessionToken)
-        })
-        .then(function () {
-          t.fail('Should have failed to create a session token with no tokenVerificationId')
-        }, function (err) {
-          t.pass('Correctly failed to create a session token with no tokenVerificationId')
-        })
-        .then(function () {
           // Create a session token
           return client.putThen('/sessionToken/' + user.sessionTokenId, user.sessionToken)
         })
@@ -272,7 +266,6 @@ module.exports = function(cfg, server) {
         .then(function(r) {
           var token = r.obj
 
-          // tokenId is not returned from db.sessionToken()
           t.deepEqual(token.tokenData, user.sessionToken.data, 'token data matches')
           t.deepEqual(token.uid, user.accountId, 'token belongs to this account')
           t.equal(token.createdAt, user.sessionToken.createdAt, 'createdAt matches')
@@ -311,6 +304,56 @@ module.exports = function(cfg, server) {
           t.ok(token.accountCreatedAt > 0, 'accountCreatedAt is positive number')
           t.equal(token.tokenVerificationId, user.sessionToken.tokenVerificationId, 'tokenVerificationId is correct')
 
+          // Create a verified session token
+          return client.putThen('/sessionToken/' + verifiedUser.sessionTokenId, verifiedUser.sessionToken)
+        })
+        .then(function (r) {
+          respOk(t, r)
+
+          // Fetch the verified session token
+          return client.getThen('/sessionToken/' + verifiedUser.sessionTokenId)
+        })
+        .then(function(r) {
+          var token = r.obj
+
+          t.deepEqual(token.tokenData, verifiedUser.sessionToken.data, 'token data matches')
+          t.deepEqual(token.uid, verifiedUser.accountId, 'token belongs to this account')
+          t.equal(token.createdAt, verifiedUser.sessionToken.createdAt, 'createdAt matches')
+          t.equal(token.uaBrowser, verifiedUser.sessionToken.uaBrowser, 'uaBrowser matches')
+          t.equal(token.uaBrowserVersion, verifiedUser.sessionToken.uaBrowserVersion, 'uaBrowserVersion matches')
+          t.equal(token.uaOS, verifiedUser.sessionToken.uaOS, 'uaOS matches')
+          t.equal(token.uaOSVersion, verifiedUser.sessionToken.uaOSVersion, 'uaOSVersion matches')
+          t.equal(token.uaDeviceType, verifiedUser.sessionToken.uaDeviceType, 'uaDeviceType matches')
+          t.equal(token.lastAccessTime, token.createdAt, 'lastAccessTime was set')
+          t.equal(!!token.emailVerified, verifiedUser.account.emailVerified, 'emailVerified same as account emailVerified')
+          t.equal(token.email, verifiedUser.account.email, 'token.email same as account email')
+          t.deepEqual(token.emailCode, verifiedUser.account.emailCode, 'token emailCode same as account emailCode')
+          t.ok(token.verifierSetAt, 'verifierSetAt is set to a truthy value')
+          t.ok(token.accountCreatedAt > 0, 'accountCreatedAt is positive number')
+          t.equal(token.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
+
+          // Fetch the verified session token with its verification state
+          return client.getThen('/sessionToken/' + verifiedUser.sessionTokenId + '/verified')
+        })
+        .then(function(r) {
+          var token = r.obj
+
+          t.deepEqual(token.tokenData, verifiedUser.sessionToken.data, 'token data matches')
+          t.deepEqual(token.uid, verifiedUser.accountId, 'token belongs to this account')
+          t.equal(token.createdAt, verifiedUser.sessionToken.createdAt, 'createdAt matches')
+          t.equal(token.uaBrowser, verifiedUser.sessionToken.uaBrowser, 'uaBrowser matches')
+          t.equal(token.uaBrowserVersion, verifiedUser.sessionToken.uaBrowserVersion, 'uaBrowserVersion matches')
+          t.equal(token.uaOS, verifiedUser.sessionToken.uaOS, 'uaOS matches')
+          t.equal(token.uaOSVersion, verifiedUser.sessionToken.uaOSVersion, 'uaOSVersion matches')
+          t.equal(token.uaDeviceType, verifiedUser.sessionToken.uaDeviceType, 'uaDeviceType matches')
+          t.equal(token.lastAccessTime, token.createdAt, 'lastAccessTime was set')
+          t.equal(!!token.emailVerified, verifiedUser.account.emailVerified, 'emailVerified same as account emailVerified')
+          t.equal(token.email, verifiedUser.account.email, 'token.email same as account email')
+          t.deepEqual(token.emailCode, verifiedUser.account.emailCode, 'token emailCode same as account emailCode')
+          t.ok(token.verifierSetAt, 'verifierSetAt is set to a truthy value')
+          t.ok(token.accountCreatedAt > 0, 'accountCreatedAt is positive number')
+          t.equal(token.tokenVerificationId, null, 'tokenVerificationId is null')
+
           // Attempt to verify a non-existent session token
           return client.postThen('/token/' + crypto.randomBytes(16).toString('hex') + '/verify', {
             uid: user.accountId
@@ -331,25 +374,25 @@ module.exports = function(cfg, server) {
         }, function(err) {
           testNotFound(t, err)
 
-          // Verify the session token
+          // Verify the unverified session token
           return client.postThen('/token/' + user.sessionToken.tokenVerificationId + '/verify', {
             uid: user.accountId
           })
         })
         .then(function() {
-          // Fetch the session token
+          // Fetch the newly verified session token
           return client.getThen('/sessionToken/' + user.sessionTokenId)
         })
         .then(function(r) {
           t.equal(r.obj.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
 
-          // Fetch the session token with its verification state
+          // Fetch the newly verified session token with its verification state
           return client.getThen('/sessionToken/' + user.sessionTokenId + '/verified')
         })
         .then(function(r) {
           t.equal(r.obj.tokenVerificationId, null, 'tokenVerificationId is null')
 
-          // Update the session token
+          // Update the newly verified session token
           return client.postThen('/sessionToken/' + user.sessionTokenId + '/update', {
             uaBrowser: 'different browser',
             uaBrowserVersion: 'different browser version',
@@ -379,13 +422,12 @@ module.exports = function(cfg, server) {
           t.equal(sessions[0].uaDeviceType, 'different device type', 'uaDeviceType is correct')
           t.equal(sessions[0].lastAccessTime, 42, 'lastAccessTime is correct')
 
-          // Fetch the session token
+          // Fetch the newly verified session token
           return client.getThen('/sessionToken/' + user.sessionTokenId)
         })
         .then(function(r) {
           var token = r.obj
 
-          // tokenId is not returned from db.sessionToken()
           t.deepEqual(token.tokenData, user.sessionToken.data, 'token data matches')
           t.deepEqual(token.uid, user.accountId, 'token belongs to this account')
           t.equal(token.createdAt, user.sessionToken.createdAt, 'createdAt was not updated')
@@ -396,11 +438,17 @@ module.exports = function(cfg, server) {
           t.equal(token.uaDeviceType, 'different device type', 'uaDeviceType was updated')
           t.equal(token.lastAccessTime, 42, 'lastAccessTime was updated')
 
-          // Delete the session token
-          return client.delThen('/sessionToken/' + user.sessionTokenId)
+          // Delete both session tokens
+          return Promise.all([
+            client.delThen('/sessionToken/' + user.sessionTokenId),
+            client.delThen('/sessionToken/' + verifiedUser.sessionTokenId)
+          ])
         })
-        .then(function(r) {
-          respOk(t, r)
+        .then(function(results) {
+          t.equal(results.length, 2)
+          results.forEach(function (result) {
+            respOk(t, result)
+          })
 
           // Fetch all of the session tokens for the account
           return client.getThen('/account/' + user.accountId + '/sessions')
@@ -409,7 +457,7 @@ module.exports = function(cfg, server) {
           respOk(t, r)
           t.equal(r.obj.length, 0, 'sessions is empty')
 
-          // Attempt to fetch the deleted session token
+          // Attempt to fetch a deleted session token
           return client.getThen('/sessionToken/' + user.sessionTokenId)
         })
         .then(function(r) {

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -195,7 +195,7 @@ module.exports = function(cfg, server) {
   test(
     'session token handling',
     function (t) {
-      t.plan(87)
+      t.plan(91)
       var user = fake.newUserDataHex()
       var badUser = fake.newUserDataHex()
       delete badUser.sessionToken.tokenVerificationId
@@ -310,6 +310,26 @@ module.exports = function(cfg, server) {
           t.ok(token.verifierSetAt, 'verifierSetAt is set to a truthy value')
           t.ok(token.accountCreatedAt > 0, 'accountCreatedAt is positive number')
           t.equal(token.tokenVerificationId, user.sessionToken.tokenVerificationId, 'tokenVerificationId is correct')
+
+          // Attempt to verify a non-existent session token
+          return client.postThen('/token/' + crypto.randomBytes(16).toString('hex') + '/verify', {
+            uid: user.accountId
+          })
+        })
+        .then(function(r) {
+          t.fail('Verifying a non-existent token should fail')
+        }, function(err) {
+          testNotFound(t, err)
+
+          // Attempt to verify a session token with the wrong uid
+          return client.postThen('/token/' + user.sessionToken.tokenVerificationId + '/verify', {
+            uid: crypto.randomBytes(16).toString('hex')
+          })
+        })
+        .then(function(r) {
+          t.fail('Verifying a non-existent token should fail')
+        }, function(err) {
+          testNotFound(t, err)
 
           // Verify the session token
           return client.postThen('/token/' + user.sessionToken.tokenVerificationId + '/verify', {
@@ -493,7 +513,7 @@ module.exports = function(cfg, server) {
   test(
     'key fetch token handling',
     function (t) {
-      t.plan(27)
+      t.plan(31)
       var user = fake.newUserDataHex()
       var badUser = fake.newUserDataHex()
       delete badUser.keyFetchToken.tokenVerificationId
@@ -560,6 +580,26 @@ module.exports = function(cfg, server) {
           t.equal(!!token.emailVerified, user.account.emailVerified)
           t.ok(token.verifierSetAt, 'verifierSetAt is set to a truthy value')
           t.equal(token.tokenVerificationId, user.keyFetchToken.tokenVerificationId, 'tokenVerificationId is correct')
+
+          // Attempt to verify a non-existent key fetch token
+          return client.postThen('/token/' + crypto.randomBytes(16).toString('hex') + '/verify', {
+            uid: user.accountId
+          })
+        })
+        .then(function(r) {
+          t.fail('Verifying a non-existent token should fail')
+        }, function(err) {
+          testNotFound(t, err)
+
+          // Attempt to verify a key fetch token with the wrong uid
+          return client.postThen('/token/' + user.keyFetchToken.tokenVerificationId + '/verify', {
+            uid: crypto.randomBytes(16).toString('hex')
+          })
+        })
+        .then(function(r) {
+          t.fail('Verifying a non-existent token should fail')
+        }, function(err) {
+          testNotFound(t, err)
 
           // Verify the key fetch token
           return client.postThen('/token/' + user.keyFetchToken.tokenVerificationId + '/verify', {

--- a/fxa-auth-db-server/test/fake.js
+++ b/fxa-auth-db-server/test/fake.js
@@ -79,8 +79,7 @@ module.exports.newUserDataHex = function() {
     authKey : hex32(),
     uid : data.accountId,
     keyBundle : hex96(),
-    createdAt: Date.now(),
-    tokenVerificationId: hex16()
+    createdAt: Date.now()
   }
 
   // accountResetToken

--- a/fxa-auth-db-server/test/fake.js
+++ b/fxa-auth-db-server/test/fake.js
@@ -56,7 +56,8 @@ module.exports.newUserDataHex = function() {
     uaBrowserVersion: 'fake browser version',
     uaOS: 'fake OS',
     uaOSVersion: 'fake OS version',
-    uaDeviceType: 'fake device type'
+    uaDeviceType: 'fake device type',
+    tokenVerificationId: hex16()
   }
 
   // device
@@ -78,7 +79,8 @@ module.exports.newUserDataHex = function() {
     authKey : hex32(),
     uid : data.accountId,
     keyBundle : hex96(),
-    createdAt: Date.now()
+    createdAt: Date.now(),
+    tokenVerificationId: hex16()
   }
 
   // accountResetToken

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -322,7 +322,7 @@ module.exports = function (log, error) {
     return P.resolve({})
   }
 
-  Memory.prototype.verifyToken = function (tokenVerificationId, tokenData) {
+  Memory.prototype.verifyTokens = function (tokenVerificationId, tokenData) {
     tokenVerificationId = tokenVerificationId.toString('hex')
     var uid = tokenData.uid.toString('hex')
 

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -348,11 +348,11 @@ module.exports = function (log, error) {
           if (! account.devices[deviceKey]) {
             throw error.notFound()
           }
+
           var device = account.devices[deviceKey]
-          var sessionKey = (device.sessionTokenId || '').toString('hex')
-          delete sessionTokens[sessionKey]
           delete account.devices[deviceKey]
-          return {}
+
+          return Memory.prototype.deleteSessionToken(device.sessionTokenId)
         }
       )
   }
@@ -665,6 +665,7 @@ module.exports = function (log, error) {
           deleteByUid(uid, passwordChangeTokens)
           deleteByUid(uid, passwordForgotTokens)
           deleteByUid(uid, accountUnlockCodes)
+          deleteByUid(uid, unverifiedTokens)
 
           account.verifyHash = data.verifyHash
           account.authSalt = data.authSalt
@@ -688,6 +689,7 @@ module.exports = function (log, error) {
           deleteByUid(uid, passwordChangeTokens)
           deleteByUid(uid, passwordForgotTokens)
           deleteByUid(uid, accountUnlockCodes)
+          deleteByUid(uid, unverifiedTokens)
 
           delete uidByNormalizedEmail[account.normalizedEmail]
           delete uidByOpenId[account.openId]

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -115,7 +115,7 @@ module.exports = function (log, error) {
 
     unverifiedTokens[tokenId] = {
       tokenVerificationId: sessionToken.tokenVerificationId,
-      uid: sessionToken.uid.toString('hex')
+      uid: sessionToken.uid
     }
 
     return P.resolve({})
@@ -144,7 +144,7 @@ module.exports = function (log, error) {
 
     unverifiedTokens[tokenId] = {
       tokenVerificationId: keyFetchToken.tokenVerificationId,
-      uid: keyFetchToken.uid.toString('hex')
+      uid: keyFetchToken.uid
     }
 
     return P.resolve({})
@@ -328,7 +328,10 @@ module.exports = function (log, error) {
 
     var tokenCount = Object.keys(unverifiedTokens).reduce(function (count, tokenId) {
       var t = unverifiedTokens[tokenId]
-      if (t.tokenVerificationId.toString('hex') !== tokenVerificationId || t.uid !== uid) {
+      if (
+        t.tokenVerificationId.toString('hex') !== tokenVerificationId ||
+        t.uid.toString('hex') !== uid
+      ) {
         return count
       }
 

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -128,23 +128,11 @@ module.exports = function (log, error) {
       return P.reject(error.duplicate())
     }
 
-    if (! keyFetchToken.tokenVerificationId) {
-      var err = new Error()
-      err.code = 'ER_BAD_NULL_ERROR'
-      err.errno = 1048
-      return P.reject(error.wrap(err))
-    }
-
     keyFetchTokens[tokenId] = {
       authKey: keyFetchToken.authKey,
       uid: keyFetchToken.uid,
       keyBundle: keyFetchToken.keyBundle,
       createdAt: keyFetchToken.createdAt,
-    }
-
-    unverifiedTokens[tokenId] = {
-      tokenVerificationId: keyFetchToken.tokenVerificationId,
-      uid: keyFetchToken.uid
     }
 
     return P.resolve({})
@@ -314,15 +302,11 @@ module.exports = function (log, error) {
   }
 
   Memory.prototype.deleteKeyFetchToken = function (tokenId) {
-    tokenId = tokenId.toString('hex')
-
-    delete unverifiedTokens[tokenId]
-    delete keyFetchTokens[tokenId]
-
+    delete keyFetchTokens[tokenId.toString('hex')]
     return P.resolve({})
   }
 
-  Memory.prototype.verifyTokens = function (tokenVerificationId, accountData) {
+  Memory.prototype.verifyToken = function (tokenVerificationId, accountData) {
     tokenVerificationId = tokenVerificationId.toString('hex')
     var uid = accountData.uid.toString('hex')
 
@@ -583,17 +567,6 @@ module.exports = function (log, error) {
     item.verifierSetAt = account.verifierSetAt
 
     return P.resolve(item)
-  }
-
-  Memory.prototype.keyFetchTokenWithVerificationStatus = function (tokenId) {
-    tokenId = tokenId.toString('hex')
-
-    return this.keyFetchToken(tokenId)
-      .then(function (keyFetchToken) {
-        keyFetchToken.tokenVerificationId = unverifiedTokens[tokenId] ?
-          unverifiedTokens[tokenId].tokenVerificationId : null
-        return keyFetchToken
-      })
   }
 
   Memory.prototype.passwordForgotToken = function (id) {

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -425,7 +425,7 @@ module.exports = function (log, error) {
   }
 
   Memory.prototype.sessionWithDevice = function (id) {
-    return this.sessionTokenVerified(id)
+    return this.sessionTokenWithVerificationStatus(id)
       .then(
         function (session) {
           return this.accountDevices(session.uid)
@@ -548,7 +548,7 @@ module.exports = function (log, error) {
     return P.resolve(item)
   }
 
-  Memory.prototype.sessionTokenVerified = function (tokenId) {
+  Memory.prototype.sessionTokenWithVerificationStatus = function (tokenId) {
     tokenId = tokenId.toString('hex')
 
     return this.sessionToken(tokenId)
@@ -582,7 +582,7 @@ module.exports = function (log, error) {
     return P.resolve(item)
   }
 
-  Memory.prototype.keyFetchTokenVerified = function (tokenId) {
+  Memory.prototype.keyFetchTokenWithVerificationStatus = function (tokenId) {
     tokenId = tokenId.toString('hex')
 
     return this.keyFetchToken(tokenId)

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -322,16 +322,23 @@ module.exports = function (log, error) {
     return P.resolve({})
   }
 
-  Memory.prototype.verifyToken = function (tokenVerificationId, token) {
+  Memory.prototype.verifyToken = function (tokenVerificationId, tokenData) {
     tokenVerificationId = tokenVerificationId.toString('hex')
-    var uid = token.uid.toString('hex')
+    var uid = tokenData.uid.toString('hex')
 
-    Object.keys(unverifiedTokens).forEach(function (tokenId) {
+    var tokenCount = Object.keys(unverifiedTokens).reduce(function (count, tokenId) {
       var t = unverifiedTokens[tokenId]
-      if (t.tokenVerificationId.toString('hex') === tokenVerificationId && t.uid === uid) {
-        delete unverifiedTokens[tokenId]
+      if (t.tokenVerificationId.toString('hex') !== tokenVerificationId || t.uid !== uid) {
+        return count
       }
-    })
+
+      delete unverifiedTokens[tokenId]
+      return count + 1
+    }, 0)
+
+    if (tokenCount === 0) {
+      return P.reject(error.notFound())
+    }
 
     return P.resolve({})
   }

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -94,13 +94,6 @@ module.exports = function (log, error) {
       return P.reject(error.duplicate())
     }
 
-    if (! sessionToken.tokenVerificationId) {
-      var err = new Error()
-      err.code = 'ER_BAD_NULL_ERROR'
-      err.errno = 1048
-      return P.reject(error.wrap(err))
-    }
-
     sessionTokens[tokenId] = {
       data: sessionToken.data,
       uid: sessionToken.uid,
@@ -113,9 +106,11 @@ module.exports = function (log, error) {
       lastAccessTime: sessionToken.createdAt
     }
 
-    unverifiedTokens[tokenId] = {
-      tokenVerificationId: sessionToken.tokenVerificationId,
-      uid: sessionToken.uid
+    if (sessionToken.tokenVerificationId) {
+      unverifiedTokens[tokenId] = {
+        tokenVerificationId: sessionToken.tokenVerificationId,
+        uid: sessionToken.uid
+      }
     }
 
     return P.resolve({})

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -322,9 +322,9 @@ module.exports = function (log, error) {
     return P.resolve({})
   }
 
-  Memory.prototype.verifyTokens = function (tokenVerificationId, tokenData) {
+  Memory.prototype.verifyTokens = function (tokenVerificationId, accountData) {
     tokenVerificationId = tokenVerificationId.toString('hex')
-    var uid = tokenData.uid.toString('hex')
+    var uid = accountData.uid.toString('hex')
 
     var tokenCount = Object.keys(unverifiedTokens).reduce(function (count, tokenId) {
       var t = unverifiedTokens[tokenId]

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -501,9 +501,10 @@ module.exports = function (log, error) {
 
   // DELETE
 
-  // Delete : sessionTokens, keyFetchTokens, accountResetTokens, passwordChangeTokens, passwordForgotTokens, accountUnlockCodes, accounts
+  // Delete : sessionTokens, keyFetchTokens, accountResetTokens, passwordChangeTokens,
+  //          passwordForgotTokens, accountUnlockCodes, accounts, devices, unverifiedTokens
   // Where  : uid = $1
-  var DELETE_ACCOUNT = 'CALL deleteAccount_6(?)'
+  var DELETE_ACCOUNT = 'CALL deleteAccount_7(?)'
 
   MySql.prototype.deleteAccount = function (uid) {
     return this.write(DELETE_ACCOUNT, [uid])
@@ -562,7 +563,9 @@ module.exports = function (log, error) {
     return this.write(DELETE_PASSWORD_CHANGE_TOKEN, [tokenId])
   }
 
-  var DELETE_DEVICE = 'CALL deleteDevice_1(?, ?)'
+  // Delete : devices, sessionTokens, unverifiedTokens
+  // Where  : uid = $1
+  var DELETE_DEVICE = 'CALL deleteDevice_2(?, ?)'
 
   MySql.prototype.deleteDevice = function (uid, deviceId) {
     return this.write(
@@ -581,14 +584,15 @@ module.exports = function (log, error) {
   // BATCH
 
   // Step   : 1
-  // Delete : sessionTokens, keyFetchTokens, accountResetTokens, passwordChangeTokens, passwordForgotTokens, accountUnlockCodes
+  // Delete : sessionTokens, keyFetchTokens, accountResetTokens, passwordChangeTokens,
+  //          passwordForgotTokens, accountUnlockCodes, devices, unverifiedTokens
   // Where  : uid = $1
   //
   // Step   : 2
   // Update : accounts
   // Set    : verifyHash = $2, authSalt = $3, wrapWrapKb = $4, verifierSetAt = $5, verifierVersion = $6
   // Where  : uid = $1
-  var RESET_ACCOUNT = 'CALL resetAccount_5(?, ?, ?, ?, ?, ?)'
+  var RESET_ACCOUNT = 'CALL resetAccount_6(?, ?, ?, ?, ?, ?)'
 
   MySql.prototype.resetAccount = function (uid, data) {
     return this.write(

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -541,8 +541,8 @@ module.exports = function (log, error) {
   // Where  : tokenVerificationId = $1, uid = $2
   var VERIFY_TOKEN = 'CALL verifyTokens_1(?, ?)'
 
-  MySql.prototype.verifyTokens = function (tokenVerificationId, tokenData) {
-    return this.read(VERIFY_TOKEN, [tokenVerificationId, tokenData.uid])
+  MySql.prototype.verifyTokens = function (tokenVerificationId, accountData) {
+    return this.read(VERIFY_TOKEN, [tokenVerificationId, accountData.uid])
       .then(function (result) {
         if (result.affectedRows === 0) {
           throw error.notFound()

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -541,8 +541,13 @@ module.exports = function (log, error) {
   // Where  : tokenVerificationId = $1, uid = $2
   var VERIFY_TOKEN = 'CALL verifyToken_1(?, ?)'
 
-  MySql.prototype.verifyToken = function (tokenVerificationId, token) {
-    return this.write(VERIFY_TOKEN, [tokenVerificationId, token.uid])
+  MySql.prototype.verifyToken = function (tokenVerificationId, tokenData) {
+    return this.read(VERIFY_TOKEN, [tokenVerificationId, tokenData.uid])
+      .then(function (result) {
+        if (result.affectedRows === 0) {
+          throw error.notFound()
+        }
+      })
   }
 
   // Delete : accountResetTokens

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -539,9 +539,9 @@ module.exports = function (log, error) {
 
   // Delete : unverifiedTokens
   // Where  : tokenVerificationId = $1, uid = $2
-  var VERIFY_TOKEN = 'CALL verifyToken_1(?, ?)'
+  var VERIFY_TOKEN = 'CALL verifyTokens_1(?, ?)'
 
-  MySql.prototype.verifyToken = function (tokenVerificationId, tokenData) {
+  MySql.prototype.verifyTokens = function (tokenVerificationId, tokenData) {
     return this.read(VERIFY_TOKEN, [tokenVerificationId, tokenData.uid])
       .then(function (result) {
         if (result.affectedRows === 0) {

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -206,9 +206,8 @@ module.exports = function (log, error) {
   }
 
   // Insert : keyFetchTokens
-  // Values : tokenId = $1, authKey = $2, uid = $3, keyBundle = $4, createdAt = $5,
-  //          tokenVerificationId = $6
-  var CREATE_KEY_FETCH_TOKEN = 'CALL createKeyFetchToken_2(?, ?, ?, ?, ?, ?)'
+  // Values : tokenId = $1, authKey = $2, uid = $3, keyBundle = $4, createdAt = $5
+  var CREATE_KEY_FETCH_TOKEN = 'CALL createKeyFetchToken_1(?, ?, ?, ?, ?)'
 
   MySql.prototype.createKeyFetchToken = function (tokenId, keyFetchToken) {
     return this.write(
@@ -218,8 +217,7 @@ module.exports = function (log, error) {
         keyFetchToken.authKey,
         keyFetchToken.uid,
         keyFetchToken.keyBundle,
-        keyFetchToken.createdAt,
-        keyFetchToken.tokenVerificationId
+        keyFetchToken.createdAt
       ]
     )
   }
@@ -418,16 +416,6 @@ module.exports = function (log, error) {
     return this.readFirstResult(KEY_FETCH_TOKEN, [id])
   }
 
-  // Select : keyFetchTokens t, accounts a, unverifiedTokens ut
-  // Fields : t.authKey, t.uid, t.keyBundle, t.createdAt, a.emailVerified, a.verifierSetAt,
-  //          ut.tokenVerificationId
-  // Where  : t.tokenId = $1 AND t.uid = a.uid AND t.tokenId = u.tokenId
-  var KEY_FETCH_TOKEN_VERIFIED = 'CALL keyFetchTokenWithVerificationStatus_1(?)'
-
-  MySql.prototype.keyFetchTokenWithVerificationStatus = function (tokenId) {
-    return this.readFirstResult(KEY_FETCH_TOKEN_VERIFIED, [tokenId])
-  }
-
   // Select : accountResetTokens t, accounts a
   // Fields : t.uid, t.tokenData, t.createdAt, a.verifierSetAt
   // Where  : t.tokenId = $1 AND t.uid = a.uid
@@ -529,9 +517,9 @@ module.exports = function (log, error) {
     return this.write(DELETE_SESSION_TOKEN, [tokenId])
   }
 
-  // Delete : keyFetchTokens, unverifiedTokens
+  // Delete : keyFetchTokens
   // Where  : tokenId = $1
-  var DELETE_KEY_FETCH_TOKEN = 'CALL deleteKeyFetchToken_2(?)'
+  var DELETE_KEY_FETCH_TOKEN = 'CALL deleteKeyFetchToken_1(?)'
 
   MySql.prototype.deleteKeyFetchToken = function (tokenId) {
     return this.write(DELETE_KEY_FETCH_TOKEN, [tokenId])
@@ -539,9 +527,9 @@ module.exports = function (log, error) {
 
   // Delete : unverifiedTokens
   // Where  : tokenVerificationId = $1, uid = $2
-  var VERIFY_TOKEN = 'CALL verifyTokens_1(?, ?)'
+  var VERIFY_TOKEN = 'CALL verifyToken_1(?, ?)'
 
-  MySql.prototype.verifyTokens = function (tokenVerificationId, accountData) {
+  MySql.prototype.verifyToken = function (tokenVerificationId, accountData) {
     return this.read(VERIFY_TOKEN, [tokenVerificationId, accountData.uid])
       .then(function (result) {
         if (result.affectedRows === 0) {

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -403,9 +403,9 @@ module.exports = function (log, error) {
   //          a.emailVerified, a.email, a.emailCode, a.verifierSetAt, a.locale,
   //          a.createdAt AS accountCreatedAt, ut.tokenVerificationId
   // Where  : t.tokenId = $1 AND t.uid = a.uid AND t.tokenId = u.tokenId
-  var SESSION_TOKEN_VERIFIED = 'CALL sessionTokenVerified_1(?)'
+  var SESSION_TOKEN_VERIFIED = 'CALL sessionTokenWithVerificationStatus_1(?)'
 
-  MySql.prototype.sessionTokenVerified = function (tokenId) {
+  MySql.prototype.sessionTokenWithVerificationStatus = function (tokenId) {
     return this.readFirstResult(SESSION_TOKEN_VERIFIED, [tokenId])
   }
 
@@ -422,9 +422,9 @@ module.exports = function (log, error) {
   // Fields : t.authKey, t.uid, t.keyBundle, t.createdAt, a.emailVerified, a.verifierSetAt,
   //          ut.tokenVerificationId
   // Where  : t.tokenId = $1 AND t.uid = a.uid AND t.tokenId = u.tokenId
-  var KEY_FETCH_TOKEN_VERIFIED = 'CALL keyFetchTokenVerified_1(?)'
+  var KEY_FETCH_TOKEN_VERIFIED = 'CALL keyFetchTokenWithVerificationStatus_1(?)'
 
-  MySql.prototype.keyFetchTokenVerified = function (tokenId) {
+  MySql.prototype.keyFetchTokenWithVerificationStatus = function (tokenId) {
     return this.readFirstResult(KEY_FETCH_TOKEN_VERIFIED, [tokenId])
   }
 

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the schema/ directory.
-module.exports.level = 23
+module.exports.level = 24

--- a/lib/db/schema/patch-023-024.sql
+++ b/lib/db/schema/patch-023-024.sql
@@ -53,16 +53,18 @@ BEGIN
     createdAt
   );
 
-  INSERT INTO unverifiedTokens(
-    tokenId,
-    tokenVerificationId,
-    uid
-  )
-  VALUES(
-    tokenId,
-    tokenVerificationId,
-    uid
-  );
+  IF tokenVerificationId IS NOT NULL THEN
+    INSERT INTO unverifiedTokens(
+      tokenId,
+      tokenVerificationId,
+      uid
+    )
+    VALUES(
+      tokenId,
+      tokenVerificationId,
+      uid
+    );
+  END IF;
 
   COMMIT;
 END;

--- a/lib/db/schema/patch-023-024.sql
+++ b/lib/db/schema/patch-023-024.sql
@@ -157,8 +157,8 @@ BEGIN
 END;
 
 -- Add stored procedure for fetching sessionToken
--- with its verified state.
-CREATE PROCEDURE `sessionTokenVerified_1` (
+-- with its verification status.
+CREATE PROCEDURE `sessionTokenWithVerificationStatus_1` (
   IN tokenIdArg BINARY(32)
 )
 BEGIN
@@ -188,7 +188,7 @@ BEGIN
 END;
 
 -- Update sessionWithDevice stored procedure to
--- fetch sessionToken verification state.
+-- fetch sessionToken verification status.
 CREATE PROCEDURE `sessionWithDevice_3` (
   IN tokenIdArg BINARY(32)
 )
@@ -228,8 +228,8 @@ BEGIN
 END;
 
 -- Add stored procedure for fetching keyFetchToken
--- with its verified state.
-CREATE PROCEDURE `keyFetchTokenVerified_1` (
+-- with its verification status.
+CREATE PROCEDURE `keyFetchTokenWithVerificationStatus_1` (
   IN tokenIdArg BINARY(32)
 )
 BEGIN

--- a/lib/db/schema/patch-023-024.sql
+++ b/lib/db/schema/patch-023-024.sql
@@ -1,0 +1,264 @@
+-- Add table for storing unverified sessionTokens
+-- and keyFetchTokens.
+CREATE TABLE `unverifiedTokens` (
+  tokenId BINARY(32) NOT NULL PRIMARY KEY,
+  tokenVerificationId BINARY(16) NOT NULL,
+  uid BINARY(16) NOT NULL
+) ENGINE=InnoDB;
+
+-- Update createSessionToken stored procedure to
+-- insert into unverifiedTokens.
+CREATE PROCEDURE `createSessionToken_3` (
+  IN tokenId BINARY(32),
+  IN tokenData BINARY(32),
+  IN uid BINARY(16),
+  IN createdAt BIGINT UNSIGNED,
+  IN uaBrowser VARCHAR(255),
+  IN uaBrowserVersion VARCHAR(255),
+  IN uaOS VARCHAR(255),
+  IN uaOSVersion VARCHAR(255),
+  IN uaDeviceType VARCHAR(255),
+  IN tokenVerificationId BINARY(16)
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  INSERT INTO sessionTokens(
+    tokenId,
+    tokenData,
+    uid,
+    createdAt,
+    uaBrowser,
+    uaBrowserVersion,
+    uaOS,
+    uaOSVersion,
+    uaDeviceType,
+    lastAccessTime
+  )
+  VALUES(
+    tokenId,
+    tokenData,
+    uid,
+    createdAt,
+    uaBrowser,
+    uaBrowserVersion,
+    uaOS,
+    uaOSVersion,
+    uaDeviceType,
+    createdAt
+  );
+
+  INSERT INTO unverifiedTokens(
+    tokenId,
+    tokenVerificationId,
+    uid
+  )
+  VALUES(
+    tokenId,
+    tokenVerificationId,
+    uid
+  );
+
+  COMMIT;
+END;
+
+-- Update createKeyFetchToken stored procedure to
+-- insert into unverifiedTokens.
+CREATE PROCEDURE `createKeyFetchToken_2` (
+  IN tokenId BINARY(32),
+  IN authKey BINARY(32),
+  IN uid BINARY(16),
+  IN keyBundle BINARY(96),
+  IN createdAt BIGINT UNSIGNED,
+  IN tokenVerificationId BINARY(16)
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  INSERT INTO keyFetchTokens(
+    tokenId,
+    authKey,
+    uid,
+    keyBundle,
+    createdAt
+  )
+  VALUES(
+    tokenId,
+    authKey,
+    uid,
+    keyBundle,
+    createdAt
+  );
+
+  INSERT INTO unverifiedTokens(
+    tokenId,
+    tokenVerificationId,
+    uid
+  )
+  VALUES(
+    tokenId,
+    tokenVerificationId,
+    uid
+  );
+
+  COMMIT;
+END;
+
+-- Update deleteSessionToken stored procedure to
+-- delete from unverifiedTokens.
+CREATE PROCEDURE `deleteSessionToken_2` (
+  IN tokenIdArg BINARY(32)
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  DELETE FROM sessionTokens WHERE tokenId = tokenIdArg;
+  DELETE FROM unverifiedTokens WHERE tokenId = tokenIdArg;
+
+  COMMIT;
+END;
+
+-- Update deleteKeyFetchToken stored procedure to
+-- delete from unverifiedTokens.
+CREATE PROCEDURE `deleteKeyFetchToken_2` (
+  IN tokenIdArg BINARY(32)
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  DELETE FROM keyFetchTokens WHERE tokenId = tokenIdArg;
+  DELETE FROM unverifiedTokens WHERE tokenId = tokenIdArg;
+
+  COMMIT;
+END;
+
+-- Add stored procedure for fetching sessionToken
+-- with its verified state.
+CREATE PROCEDURE `sessionTokenVerified_1` (
+  IN tokenIdArg BINARY(32)
+)
+BEGIN
+  SELECT
+    t.tokenData,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.lastAccessTime,
+    a.emailVerified,
+    a.email,
+    a.emailCode,
+    a.verifierSetAt,
+    a.locale,
+    a.createdAt AS accountCreatedAt,
+    ut.tokenVerificationId
+  FROM sessionTokens AS t
+  LEFT JOIN accounts AS a
+    ON t.uid = a.uid
+  LEFT JOIN unverifiedTokens AS ut
+    ON t.tokenId = ut.tokenId
+  WHERE t.tokenId = tokenIdArg;
+END;
+
+-- Update sessionWithDevice stored procedure to
+-- fetch sessionToken verification state.
+CREATE PROCEDURE `sessionWithDevice_3` (
+  IN tokenIdArg BINARY(32)
+)
+BEGIN
+  SELECT
+    t.tokenData,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.lastAccessTime,
+    a.emailVerified,
+    a.email,
+    a.emailCode,
+    a.verifierSetAt,
+    a.locale,
+    a.createdAt AS accountCreatedAt,
+    d.id AS deviceId,
+    d.name AS deviceName,
+    d.type AS deviceType,
+    d.createdAt AS deviceCreatedAt,
+    d.callbackURL AS deviceCallbackURL,
+    d.callbackPublicKey AS deviceCallbackPublicKey,
+    d.callbackAuthKey AS deviceCallbackAuthKey,
+    ut.tokenVerificationId
+  FROM sessionTokens AS t
+  LEFT JOIN accounts AS a
+    ON t.uid = a.uid
+  LEFT JOIN devices AS d
+    ON (t.tokenId = d.sessionTokenId AND t.uid = d.uid)
+  LEFT JOIN unverifiedTokens AS ut
+    ON t.tokenId = ut.tokenId
+  WHERE t.tokenId = tokenIdArg;
+END;
+
+-- Add stored procedure for fetching keyFetchToken
+-- with its verified state.
+CREATE PROCEDURE `keyFetchTokenVerified_1` (
+  IN tokenIdArg BINARY(32)
+)
+BEGIN
+  SELECT
+    t.authKey,
+    t.uid,
+    t.keyBundle,
+    t.createdAt,
+    a.emailVerified,
+    a.verifierSetAt,
+    ut.tokenVerificationId
+  FROM keyFetchTokens AS t
+  LEFT JOIN accounts AS a
+    ON t.uid = a.uid
+  LEFT JOIN unverifiedTokens AS ut
+    ON t.tokenId = ut.tokenId
+  WHERE t.tokenId = tokenIdArg;
+END;
+
+-- Add stored procedure for deleting unverifiedTokens.
+CREATE PROCEDURE `verifyToken_1` (
+  IN tokenVerificationIdArg BINARY(16),
+  IN uidArg BINARY(16)
+)
+BEGIN
+  DELETE FROM unverifiedTokens
+  WHERE tokenVerificationId = tokenVerificationIdArg
+  AND uid = uidArg;
+END;
+
+UPDATE dbMetadata SET value = '24' WHERE name = 'schema-patch-level';
+

--- a/lib/db/schema/patch-023-024.sql
+++ b/lib/db/schema/patch-023-024.sql
@@ -250,7 +250,7 @@ BEGIN
 END;
 
 -- Add stored procedure for deleting unverifiedTokens.
-CREATE PROCEDURE `verifyToken_1` (
+CREATE PROCEDURE `verifyTokens_1` (
   IN tokenVerificationIdArg BINARY(16),
   IN uidArg BINARY(16)
 )

--- a/lib/db/schema/patch-024-023.sql
+++ b/lib/db/schema/patch-024-023.sql
@@ -1,0 +1,12 @@
+-- DROP PROCEDURE `verifyToken_1`;
+-- DROP PROCEDURE `keyFetchTokenVerified_1`;
+-- DROP PROCEDURE `sessionWithDevice_3`;
+-- DROP PROCEDURE `sessionTokenVerified_1`;
+-- DROP PROCEDURE `deleteKeyFetchToken_2`;
+-- DROP PROCEDURE `deleteSessionToken_2`;
+-- DROP PROCEDURE `createKeyFetchToken_2`;
+-- DROP PROCEDURE `createSessionToken_3`;
+
+-- DROP TABLE `unverifiedTokens`;
+
+-- UPDATE dbMetadata SET value = '23' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-024-023.sql
+++ b/lib/db/schema/patch-024-023.sql
@@ -1,4 +1,4 @@
--- DROP PROCEDURE `verifyToken_1`;
+-- DROP PROCEDURE `verifyTokens_1`;
 -- DROP PROCEDURE `keyFetchTokenVerified_1`;
 -- DROP PROCEDURE `sessionWithDevice_3`;
 -- DROP PROCEDURE `sessionTokenVerified_1`;

--- a/lib/db/schema/patch-024-023.sql
+++ b/lib/db/schema/patch-024-023.sql
@@ -1,6 +1,9 @@
 -- DROP PROCEDURE `verifyToken_1`;
 -- DROP PROCEDURE `sessionWithDevice_3`;
--- DROP PROCEDURE `sessionTokenVerified_1`;
+-- DROP PROCEDURE `sessionTokenWithVerificationStatus_1`;
+-- DROP PROCEDURE `resetAccount_6`;
+-- DROP PROCEDURE `deleteAccount_7`;
+-- DROP PROCEDURE `deleteDevice_2`;
 -- DROP PROCEDURE `deleteSessionToken_2`;
 -- DROP PROCEDURE `createSessionToken_3`;
 

--- a/lib/db/schema/patch-024-023.sql
+++ b/lib/db/schema/patch-024-023.sql
@@ -1,10 +1,7 @@
--- DROP PROCEDURE `verifyTokens_1`;
--- DROP PROCEDURE `keyFetchTokenVerified_1`;
+-- DROP PROCEDURE `verifyToken_1`;
 -- DROP PROCEDURE `sessionWithDevice_3`;
 -- DROP PROCEDURE `sessionTokenVerified_1`;
--- DROP PROCEDURE `deleteKeyFetchToken_2`;
 -- DROP PROCEDURE `deleteSessionToken_2`;
--- DROP PROCEDURE `createKeyFetchToken_2`;
 -- DROP PROCEDURE `createSessionToken_3`;
 
 -- DROP TABLE `unverifiedTokens`;

--- a/test/local/metrics_tests.js
+++ b/test/local/metrics_tests.js
@@ -344,7 +344,8 @@ DB.connect(config)
         uaBrowserVersion: 'bar',
         uaOS: 'baz',
         uaOSVersion: 'qux',
-        uaDeviceType: uaDeviceType
+        uaDeviceType: uaDeviceType,
+        tokenVerificationId: hex(16)
       })
     }
 


### PR DESCRIPTION
This covers all of the database changes for FxA-83, sign-in confirmation. I realise the feature document isn't actually finished yet but, as I'd already made a start on this, I wanted to get it into review so that nobody is blocked from working on other parts of the feature.

The approach taken is based on (my understanding of) @dannycoates' recommendation from the Google Doc:

* A new table is added, `unverifiedTokens`, and the create/delete stored procedures for `sessionTokens` and `keyFetchTokens` maintain it appropriately. ~~Fwiw, as things stand, the first cut of the auth server changes may not utilise the `keyFetchTokens` part of this, but a second version that does so should follow pretty rapidly.~~

* New endpoints, `GET /sessionToken/:id/verified` and `GET keyFetchToken/:id/verified`, are added for checking a token's verification state, which is returned in a field called `tokenVerified`. This has changed from `isVerified` in the original document, to better disambiguate it from the `emailVerified` field.

* A third new endpoint, `POST /token/:tokenVerificationId/verify` is added for verifying tokens. I briefly toyed with the idea of implementing this as `DELETE /unverifiedToken/:tokenVerificationId`, in an effort to fit what actually happens in the database. But I figured the extra table is just an implementation detail and naming the stored procedure `verifyToken` better reflects what is happening from the caller's point of view.

@vbudhram @dannycoates @rfk, feedback appreciated.

/cc @shane-tomlinson