### PR TITLE
fix(device): remove storage of push key data on device records.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -400,15 +400,11 @@ Returns:
 These fields are represented as `t.*` for a field from the token `a.*` for a
 field from the corresponding account and `d.*` for a field from devices.
 
-The deviceCallbackPublicKey and deviceCallbackAuthKey fields are urlsafe-base64 strings, you can learn more about their format [here](https://developers.google.com/web/updates/2016/03/web-push-encryption).
-
 * sessionToken : t.tokenData, t.uid, t.createdAt, t.uaBrowser, t.uaBrowserVersion,
                  t.uaOS, t.uaOSVersion, t.uaDeviceType, t.lastAccessTime,
                  a.emailVerified, a.email, a.emailCode, a.verifierSetAt,
                  a.createdAt AS accountCreatedAt, d.id AS deviceId,
                  d.name AS deviceName, d.type AS deviceType,
-                 d.createdAt AS deviceCreatedAt, d.callbackURL AS deviceCallbackURL,
-                 d.callbackPublicKey AS deviceCallbackPublicKey,
-                 d.callbackAuthKey AS deviceCallbackAuthKey
+                 d.createdAt AS deviceCreatedAt, d.callbackURL AS deviceCallbackURL
 
 (Ends)

--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -614,8 +614,6 @@ curl \
 
 ### Response
 
-Note: The deviceCallbackPublicKey and deviceCallbackAuthKey fields are urlsafe-base64 strings, you can learn more about their format [here](https://developers.google.com/web/updates/2016/03/web-push-encryption).
-
 ```
 HTTP/1.1 200 OK
 Content-Type: application/json
@@ -629,8 +627,6 @@ Content-Type: application/json
         "type": "mobile"
         "createdAt": 1437992394186,
         "callbackURL": "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef",
-        "callbackPublicKey": "BCp93zru09_hab2Bg37LpTNG__Pw6eMPEP2hrQpwuytoj3h4chXpGc-3qqdKyqjuvAiEupsnOd_RLyc7erJHWgA",
-        "callbackAuthKey": "w3b14Zjc-Afj2SDOLOyong",
         "uaBrowser": "Firefox",
         "uaBrowserVersion": "42",
         "uaOS": "Android",
@@ -669,9 +665,7 @@ curl \
       "name": "My Phone",
       "type": "mobile"
       "createdAt": 1437992394186,
-      "callbackURL": "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef",
-      "callbackPublicKey": "BCp93zru09_hab2Bg37LpTNG__Pw6eMPEP2hrQpwuytoj3h4chXpGc-3qqdKyqjuvAiEupsnOd_RLyc7erJHWgA",
-      "callbackAuthKey": "w3b14Zjc-Afj2SDOLOyong"
+      "callbackURL": "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef"
     }'
 ```
 
@@ -712,9 +706,7 @@ curl \
       "name": "My Phone",
       "type": "mobile"
       "createdAt": 1437992394186,
-      "callbackURL": "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef",
-      "callbackPublicKey": "BCp93zru09_hab2Bg37LpTNG__Pw6eMPEP2hrQpwuytoj3h4chXpGc-3qqdKyqjuvAiEupsnOd_RLyc7erJHWgA",
-      "callbackAuthKey": "w3b14Zjc-Afj2SDOLOyong"
+      "callbackURL": "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef"
     }'
 ```
 

--- a/fxa-auth-db-server/test/backend/db_tests.js
+++ b/fxa-auth-db-server/test/backend/db_tests.js
@@ -3,7 +3,6 @@
 
 var test = require('tap').test
 var crypto = require('crypto')
-var base64url = require('base64url')
 
 var zeroBuffer16 = Buffer('00000000000000000000000000000000', 'hex')
 var zeroBuffer32 = Buffer('0000000000000000000000000000000000000000000000000000000000000000', 'hex')
@@ -42,13 +41,6 @@ function hex16() { return hex(16) }
 function hex32() { return hex(32) }
 // function hex64() { return hex(64) }
 function hex96() { return hex(96) }
-
-function base64(len) {
-  return base64url(crypto.randomBytes(len))
-}
-
-function base64_16() { return base64(16) }
-function base64_65() { return base64(65) }
 
 var SESSION_TOKEN_ID = hex32()
 var SESSION_TOKEN = {
@@ -820,16 +812,14 @@ module.exports = function(config, DB) {
         test(
           'db.accountDevices',
           function (t) {
-            t.plan(63)
+            t.plan(53)
             var deviceId = newUuid()
             var sessionTokenId = hex32()
             var createdAt = Date.now()
             var deviceInfo = {
               name: 'test device',
               type: 'mobile',
-              callbackURL: 'https://foo/bar',
-              callbackPublicKey: base64_65(),
-              callbackAuthKey: base64_16()
+              callbackURL: 'https://foo/bar'
             }
             var newDeviceId = newUuid()
             var newSessionTokenId = hex32()
@@ -881,8 +871,6 @@ module.exports = function(config, DB) {
                 t.equal(device.createdAt, createdAt, 'createdAt')
                 t.equal(device.type, null, 'type')
                 t.equal(device.callbackURL, null, 'callbackURL')
-                t.equal(device.callbackPublicKey, null, 'callbackPublicKey')
-                t.equal(device.callbackAuthKey, null, 'callbackAuthKey')
                 t.ok(device.lastAccessTime > 0, 'has a lastAccessTime')
                 return db.sessionWithDevice(sessionTokenId)
                   .then(
@@ -893,8 +881,6 @@ module.exports = function(config, DB) {
                       t.equal(s.deviceType, device.type, 'type')
                       t.equal(s.deviceCreatedAt, device.createdAt, 'createdAt')
                       t.equal(s.deviceCallbackURL, device.callbackURL, 'callbackURL')
-                      t.equal(s.deviceCallbackPublicKey, device.callbackPublicKey, 'callbackPublicKey')
-                      t.equal(s.deviceCallbackAuthKey, device.callbackAuthKey, 'callbackAuthKey')
                     },
                     function (e) {
                       t.fail('getting the sessionWithDevice should not have failed')
@@ -922,8 +908,6 @@ module.exports = function(config, DB) {
                 t.equal(device.createdAt, createdAt, 'createdAt')
                 t.equal(device.type, deviceInfo.type, 'type')
                 t.equal(device.callbackURL, deviceInfo.callbackURL, 'callbackURL')
-                t.equal(device.callbackPublicKey, deviceInfo.callbackPublicKey, 'callbackPublicKey')
-                t.equal(device.callbackAuthKey, deviceInfo.callbackAuthKey, 'callbackAuthKey')
                 t.ok(device.lastAccessTime > 0, 'has a lastAccessTime')
                 return db.createSessionToken(newSessionTokenId, SESSION_TOKEN)
               })
@@ -949,13 +933,9 @@ module.exports = function(config, DB) {
                 t.equal(device.name, 'updated name', 'name updated')
                 t.equal(device.type, deviceInfo.type, 'type unchanged')
                 t.equal(device.callbackURL, deviceInfo.callbackURL, 'callbackURL unchanged')
-                t.equal(device.callbackPublicKey, deviceInfo.callbackPublicKey, 'callbackPublicKey unchanged')
-                t.equal(device.callbackAuthKey, deviceInfo.callbackAuthKey, 'callbackAuthKey unchanged')
                 return db.updateDevice(ACCOUNT.uid, deviceId, {
                   type: 'desktop',
-                  callbackURL: '',
-                  callbackPublicKey: '',
-                  callbackAuthKey: ''
+                  callbackURL: ''
                 })
                 .catch(function () {
                   t.fail('updating an existing device should not have failed')
@@ -973,16 +953,12 @@ module.exports = function(config, DB) {
                 t.equal(device.name, 'updated name', 'name unchanged')
                 t.equal(device.type, 'desktop', 'type updated')
                 t.equal(device.callbackURL, '', 'callbackURL updated')
-                t.equal(device.callbackPublicKey, '', 'callbackPublicKey updated')
-                t.equal(device.callbackAuthKey, '', 'callbackAuthKey updated')
                 return db.createDevice(ACCOUNT.uid, newUuid(), {
                   sessionTokenId: newSessionTokenId,
                   name: 'second device',
                   createdAt: Date.now(),
                   type: 'desktop',
-                  callbackURL: 'https://foo/bar',
-                  callbackPublicKey: base64_65(),
-                  callbackAuthKey: base64_16()
+                  callbackURL: 'https://foo/bar'
                 })
                 .then(function () {
                   t.fail('adding a second device should have failed when the session token is already registered')
@@ -1002,9 +978,7 @@ module.exports = function(config, DB) {
                   name: 'second device',
                   createdAt: Date.now(),
                   type: 'desktop',
-                  callbackURL: 'https://foo/bar',
-                  callbackPublicKey: base64_65(),
-                  callbackAuthKey: base64_16()
+                  callbackURL: 'https://foo/bar'
                 })
                 .then(function () {
                   t.pass('adding a second device did not fail when the session token is not registered')

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -323,7 +323,7 @@ module.exports = function(cfg, server) {
   test(
     'device handling',
     function (t) {
-      t.plan(51)
+      t.plan(47)
       var user = fake.newUserDataHex()
       return client.getThen('/account/' + user.accountId + '/devices')
         .then(function(r) {
@@ -350,7 +350,7 @@ module.exports = function(cfg, server) {
           respOk(t, r)
           var devices = r.obj
           t.equal(devices.length, 1, 'devices contains one item')
-          t.equal(Object.keys(devices[0]).length, 15, 'device has fourteen properties')
+          t.equal(Object.keys(devices[0]).length, 13, 'device has thirteen properties')
           t.equal(devices[0].uid, user.accountId, 'uid is correct')
           t.equal(devices[0].id, user.deviceId, 'id is correct')
           t.equal(devices[0].sessionTokenId, user.sessionTokenId, 'sessionTokenId is correct')
@@ -358,8 +358,6 @@ module.exports = function(cfg, server) {
           t.equal(devices[0].name, user.device.name, 'name is correct')
           t.equal(devices[0].type, user.device.type, 'type is correct')
           t.equal(devices[0].callbackURL, user.device.callbackURL, 'callbackURL is correct')
-          t.equal(devices[0].callbackPublicKey, user.device.callbackPublicKey, 'callbackPublicKey is correct')
-          t.equal(devices[0].callbackAuthKey, user.device.callbackAuthKey, 'callbackAuthKey is correct')
           t.equal(devices[0].uaBrowser, user.sessionToken.uaBrowser, 'uaBrowser is correct')
           t.equal(devices[0].uaBrowserVersion, user.sessionToken.uaBrowserVersion, 'uaBrowserVersion is correct')
           t.equal(devices[0].uaOS, user.sessionToken.uaOS, 'uaOS is correct')
@@ -369,9 +367,7 @@ module.exports = function(cfg, server) {
           return client.postThen('/account/' + user.accountId + '/device/' + user.deviceId + '/update', {
             name: 'wibble',
             type: 'mobile',
-            callbackURL: '',
-            callbackPublicKey: null,
-            callbackAuthKey: null
+            callbackURL: ''
           })
         })
         .then(function(r) {
@@ -389,8 +385,6 @@ module.exports = function(cfg, server) {
           t.equal(devices[0].name, 'wibble', 'name is correct')
           t.equal(devices[0].type, 'mobile', 'type is correct')
           t.equal(devices[0].callbackURL, '', 'callbackURL is correct')
-          t.equal(devices[0].callbackPublicKey, user.device.callbackPublicKey, 'callbackPublicKey is correct')
-          t.equal(devices[0].callbackAuthKey, user.device.callbackAuthKey, 'callbackAuthKey is correct')
           t.equal(devices[0].uaBrowser, user.sessionToken.uaBrowser, 'uaBrowser is correct')
           t.equal(devices[0].uaBrowserVersion, user.sessionToken.uaBrowserVersion, 'uaBrowserVersion is correct')
           t.equal(devices[0].uaOS, user.sessionToken.uaOS, 'uaOS is correct')

--- a/fxa-auth-db-server/test/fake.js
+++ b/fxa-auth-db-server/test/fake.js
@@ -2,7 +2,6 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 var crypto = require('crypto')
-var base64url = require('base64url')
 
 function hex(len) {
   return crypto.randomBytes(len).toString('hex')
@@ -11,13 +10,6 @@ function hex16() { return hex(16) }
 function hex32() { return hex(32) }
 // function hex64() { return hex(64) }
 function hex96() { return hex(96) }
-
-function base64(len) {
-  return base64url(crypto.randomBytes(len))
-}
-
-function base64_16() { return base64(16) }
-function base64_65() { return base64(65) }
 
 function buf(len) {
   return Buffer(crypto.randomBytes(len))
@@ -67,9 +59,7 @@ module.exports.newUserDataHex = function() {
     createdAt: Date.now(),
     name: 'fake device name',
     type: 'fake device type',
-    callbackURL: 'fake callback URL',
-    callbackPublicKey: base64_65(),
-    callbackAuthKey: base64_16()
+    callbackURL: 'fake callback URL'
   }
 
   // keyFetchToken

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -21,9 +21,7 @@ var DEVICE_FIELDS = [
   'name',
   'type',
   'createdAt',
-  'callbackURL',
-  'callbackPublicKey',
-  'callbackAuthKey'
+  'callbackURL'
 ]
 
 var SESSION_FIELDS = [
@@ -395,8 +393,6 @@ module.exports = function (log, error) {
                   session.deviceType = device.type
                   session.deviceCreatedAt = device.createdAt
                   session.deviceCallbackURL = device.callbackURL
-                  session.deviceCallbackPublicKey = device.callbackPublicKey
-                  session.deviceCallbackAuthKey = device.callbackAuthKey
                 }
                 return session
               }

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -271,7 +271,7 @@ module.exports = function (log, error) {
     )
   }
 
-  var CREATE_DEVICE = 'CALL createDevice_2(?, ?, ?, ?, ?, ?, ?, ?, ?)'
+  var CREATE_DEVICE = 'CALL createDevice_3(?, ?, ?, ?, ?, ?, ?)'
 
   MySql.prototype.createDevice = function (uid, deviceId, deviceInfo) {
     return this.write(
@@ -283,14 +283,12 @@ module.exports = function (log, error) {
         deviceInfo.name,
         deviceInfo.type,
         deviceInfo.createdAt,
-        deviceInfo.callbackURL,
-        deviceInfo.callbackPublicKey,
-        deviceInfo.callbackAuthKey
+        deviceInfo.callbackURL
       ]
     )
   }
 
-  var UPDATE_DEVICE = 'CALL updateDevice_2(?, ?, ?, ?, ?, ?, ?, ?)'
+  var UPDATE_DEVICE = 'CALL updateDevice_3(?, ?, ?, ?, ?, ?)'
 
   MySql.prototype.updateDevice = function (uid, deviceId, deviceInfo) {
     return this.write(
@@ -301,9 +299,7 @@ module.exports = function (log, error) {
         deviceInfo.sessionTokenId,
         deviceInfo.name,
         deviceInfo.type,
-        deviceInfo.callbackURL,
-        deviceInfo.callbackPublicKey,
-        deviceInfo.callbackAuthKey
+        deviceInfo.callbackURL
       ],
       function (result) {
         if (result.affectedRows === 0) {
@@ -347,16 +343,16 @@ module.exports = function (log, error) {
 
   // Select : devices d, sessionTokens s
   // Fields : d.uid, d.id, d.sessionTokenId, d.name, d.type, d.createdAt, d.callbackURL,
-  //          d.callbackPublicKey, d.callbackAuthKey, s.uaBrowser, s.uaBrowserVersion,
-  //          s.uaOS, s.uaOSVersion, s.uaDeviceType, s.lastAccessTime
+  //          s.uaBrowser, s.uaBrowserVersion, s.uaOS, s.uaOSVersion,
+  //          s.uaDeviceType, s.lastAccessTime
   // Where  : d.uid = $1
-  var ACCOUNT_DEVICES = 'CALL accountDevices_4(?)'
+  var ACCOUNT_DEVICES = 'CALL accountDevices_5(?)'
 
   MySql.prototype.accountDevices = function (uid) {
     return this.readOneFromFirstResult(ACCOUNT_DEVICES, [uid])
   }
 
-  var SESSION_DEVICE = 'CALL sessionWithDevice_2(?)'
+  var SESSION_DEVICE = 'CALL sessionWithDevice_3(?)'
 
   MySql.prototype.sessionWithDevice = function (id) {
     return this.readFirstResult(SESSION_DEVICE, [id])

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the schema/ directory.
-module.exports.level = 23
+module.exports.level = 25

--- a/lib/db/schema/patch-023-024.sql
+++ b/lib/db/schema/patch-023-024.sql
@@ -1,0 +1,16 @@
+--
+-- This patch reverts the table changes from previous patch #23,
+-- which turned out to be difficult to deploy to production.
+--
+-- It's here as a separate patch to ensure a smooth update path
+-- for dev servers that already had patch #23 applied,
+-- but should *not* be deployed to production.
+--
+
+-- Drop new column and restore callbackPublicKey column type
+ALTER TABLE devices
+DROP COLUMN callbackAuthKey,
+MODIFY COLUMN callbackPublicKey BINARY(32);
+
+-- -- Decrement the schema version
+UPDATE dbMetadata SET value = '24' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-024-023.sql
+++ b/lib/db/schema/patch-024-023.sql
@@ -1,0 +1,7 @@
+-- -- Restore new column and modified column type
+-- ALTER TABLE devices
+-- MODIFY COLUMN callbackPublicKey CHAR(88),
+-- ADD COLUMN callbackAuthKey CHAR(24);
+
+-- -- Decrement the schema version
+-- UPDATE dbMetadata SET value = '23' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-024-025.sql
+++ b/lib/db/schema/patch-024-025.sql
@@ -1,0 +1,112 @@
+-- This migration updates stored procedures
+-- to avoid referencing the devices.callbackPublicKey column.
+--
+
+CREATE PROCEDURE `accountDevices_5` (
+  IN `inUid` BINARY(16)
+)
+BEGIN
+  SELECT
+    d.uid,
+    d.id,
+    d.sessionTokenId,
+    d.name,
+    d.type,
+    d.createdAt,
+    d.callbackURL,
+    s.uaBrowser,
+    s.uaBrowserVersion,
+    s.uaOS,
+    s.uaOSVersion,
+    s.uaDeviceType,
+    s.lastAccessTime
+  FROM
+    devices d LEFT JOIN sessionTokens s
+  ON
+    d.sessionTokenId = s.tokenId
+  WHERE
+    d.uid = inUid;
+END;
+
+CREATE PROCEDURE `createDevice_3` (
+  IN `inUid` BINARY(16),
+  IN `inId` BINARY(16),
+  IN `inSessionTokenId` BINARY(32),
+  IN `inName` VARCHAR(255),
+  IN `inType` VARCHAR(16),
+  IN `inCreatedAt` BIGINT UNSIGNED,
+  IN `inCallbackURL` VARCHAR(255)
+)
+BEGIN
+  INSERT INTO devices(
+    uid,
+    id,
+    sessionTokenId,
+    name,
+    type,
+    createdAt,
+    callbackURL
+  )
+  VALUES (
+    inUid,
+    inId,
+    inSessionTokenId,
+    inName,
+    inType,
+    inCreatedAt,
+    inCallbackURL
+  );
+END;
+
+CREATE PROCEDURE `updateDevice_3` (
+  IN `inUid` BINARY(16),
+  IN `inId` BINARY(16),
+  IN `inSessionTokenId` BINARY(32),
+  IN `inName` VARCHAR(255),
+  IN `inType` VARCHAR(16),
+  IN `inCallbackURL` VARCHAR(255)
+)
+BEGIN
+  UPDATE devices
+  SET sessionTokenId = COALESCE(inSessionTokenId, sessionTokenId),
+    name = COALESCE(inName, name),
+    type = COALESCE(inType, type),
+    callbackURL = COALESCE(inCallbackURL, callbackURL)
+  WHERE uid = inUid AND id = inId;
+END;
+
+CREATE PROCEDURE `sessionWithDevice_3` (
+  IN `inTokenId` BINARY(32)
+)
+BEGIN
+  SELECT
+    t.tokenData,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.lastAccessTime,
+    a.emailVerified,
+    a.email,
+    a.emailCode,
+    a.verifierSetAt,
+    a.locale,
+    a.createdAt AS accountCreatedAt,
+    d.id AS deviceId,
+    d.name AS deviceName,
+    d.type AS deviceType,
+    d.createdAt AS deviceCreatedAt,
+    d.callbackURL AS deviceCallbackURL
+  FROM
+    sessionTokens t
+    LEFT JOIN accounts a ON t.uid = a.uid
+    LEFT JOIN devices d ON (t.tokenId = d.sessionTokenId AND t.uid = d.uid)
+  WHERE
+    t.tokenId = inTokenId;
+END;
+
+UPDATE dbMetadata SET value = '25' WHERE name = 'schema-patch-level';
+

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "ass": {
       "version": "1.0.0",
-      "from": "git://github.com/jrgm/ass.git#5be99ee",
+      "from": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
       "resolved": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
       "dependencies": {
         "async": {
@@ -86,9 +86,9 @@
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                 },
                 "readable-stream": {
-                  "version": "1.1.14",
+                  "version": "1.1.13",
                   "from": "readable-stream@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -159,117 +159,6 @@
               "version": "2.2.8",
               "from": "rimraf@>=2.2.6 <2.3.0",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-            }
-          }
-        }
-      }
-    },
-    "base64url": {
-      "version": "1.0.6",
-      "from": "base64url@1.0.6",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
-      "dependencies": {
-        "concat-stream": {
-          "version": "1.4.10",
-          "from": "concat-stream@>=1.4.7 <1.5.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "typedarray": {
-              "version": "0.0.6",
-              "from": "typedarray@>=0.0.5 <0.1.0",
-              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-            },
-            "readable-stream": {
-              "version": "1.1.14",
-              "from": "readable-stream@>=1.1.9 <1.2.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                }
-              }
-            }
-          }
-        },
-        "meow": {
-          "version": "2.0.0",
-          "from": "meow@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
-          "dependencies": {
-            "camelcase-keys": {
-              "version": "1.0.0",
-              "from": "camelcase-keys@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-              "dependencies": {
-                "camelcase": {
-                  "version": "1.2.1",
-                  "from": "camelcase@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                },
-                "map-obj": {
-                  "version": "1.0.1",
-                  "from": "map-obj@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-                }
-              }
-            },
-            "indent-string": {
-              "version": "1.2.2",
-              "from": "indent-string@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
-              "dependencies": {
-                "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                },
-                "repeating": {
-                  "version": "1.1.3",
-                  "from": "repeating@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                  "dependencies": {
-                    "is-finite": {
-                      "version": "1.0.1",
-                      "from": "is-finite@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "from": "minimist@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-            },
-            "object-assign": {
-              "version": "1.0.0",
-              "from": "object-assign@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
             }
           }
         }
@@ -392,7 +281,7 @@
               "dependencies": {
                 "esprima": {
                   "version": "1.0.4",
-                  "from": "esprima@>=1.0.4 <1.1.0",
+                  "from": "esprima@>=1.0.2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                 }
               }
@@ -508,7 +397,7 @@
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
@@ -704,23 +593,23 @@
       "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-14.0.0.tgz",
       "dependencies": {
         "chalk": {
-          "version": "1.1.3",
+          "version": "1.1.1",
           "from": "chalk@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.2.1",
-              "from": "ansi-styles@>=2.2.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+              "version": "2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
-              "version": "1.0.5",
+              "version": "1.0.4",
               "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "from": "has-ansi@2.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
@@ -731,9 +620,9 @@
               }
             },
             "strip-ansi": {
-              "version": "3.0.1",
+              "version": "3.0.0",
               "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
@@ -756,7 +645,7 @@
           "dependencies": {
             "concat-stream": {
               "version": "1.5.1",
-              "from": "concat-stream@>=1.4.6 <2.0.0",
+              "from": "concat-stream@1.5.1",
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
               "dependencies": {
                 "inherits": {
@@ -770,9 +659,9 @@
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 },
                 "readable-stream": {
-                  "version": "2.0.6",
+                  "version": "2.0.5",
                   "from": "readable-stream@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -780,9 +669,9 @@
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
-                      "version": "1.0.0",
-                      "from": "isarray@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
@@ -805,7 +694,7 @@
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@>=2.1.1 <3.0.0",
+              "from": "debug@2.2.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
@@ -833,14 +722,14 @@
               }
             },
             "escape-string-regexp": {
-              "version": "1.0.5",
+              "version": "1.0.4",
               "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
             },
             "escope": {
-              "version": "3.6.0",
+              "version": "3.4.0",
               "from": "escope@>=3.1.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/escope/-/escope-3.4.0.tgz",
               "dependencies": {
                 "es6-map": {
                   "version": "0.1.3",
@@ -907,26 +796,21 @@
                   }
                 },
                 "esrecurse": {
-                  "version": "4.1.0",
-                  "from": "esrecurse@>=4.1.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
+                  "version": "3.1.1",
+                  "from": "esrecurse@>=3.1.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
                   "dependencies": {
                     "estraverse": {
-                      "version": "4.1.1",
-                      "from": "estraverse@>=4.1.0 <4.2.0",
-                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
-                    },
-                    "object-assign": {
-                      "version": "4.0.1",
-                      "from": "object-assign@>=4.0.1 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+                      "version": "3.1.0",
+                      "from": "estraverse@>=3.1.0 <3.2.0",
+                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
                     }
                   }
                 },
                 "estraverse": {
-                  "version": "4.2.0",
+                  "version": "4.1.1",
                   "from": "estraverse@>=4.1.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
                 }
               }
             },
@@ -966,9 +850,9 @@
                   "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz"
                 },
                 "figures": {
-                  "version": "1.5.0",
+                  "version": "1.4.0",
                   "from": "figures@>=1.3.5 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/figures/-/figures-1.5.0.tgz"
+                  "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
                 },
                 "lodash": {
                   "version": "3.10.1",
@@ -1005,9 +889,9 @@
               }
             },
             "is-my-json-valid": {
-              "version": "2.13.1",
+              "version": "2.12.4",
               "from": "is-my-json-valid@>=2.10.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
@@ -1039,14 +923,14 @@
               }
             },
             "js-yaml": {
-              "version": "3.6.0",
+              "version": "3.5.3",
               "from": "js-yaml@>=3.2.5 <4.0.0",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.3.tgz",
               "dependencies": {
                 "argparse": {
-                  "version": "1.0.7",
-                  "from": "argparse@>=1.0.7 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
+                  "version": "1.0.6",
+                  "from": "argparse@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.6.tgz",
                   "dependencies": {
                     "sprintf-js": {
                       "version": "1.0.3",
@@ -1142,7 +1026,7 @@
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "from": "path-is-absolute@1.0.0",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "strip-json-comments": {
@@ -1255,7 +1139,7 @@
             },
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "asn1": {
@@ -1265,7 +1149,7 @@
             },
             "assert-plus": {
               "version": "0.1.5",
-              "from": "assert-plus@0.1.5",
+              "from": "assert-plus@>=0.1.5 <0.2.0",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "async": {
@@ -1408,15 +1292,15 @@
               "from": "generate-function@2.0.0",
               "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
             },
+            "glob": {
+              "version": "5.0.15",
+              "from": "glob@>=5.0.15 <6.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
+            },
             "generate-object-property": {
               "version": "1.2.0",
               "from": "generate-object-property@1.2.0",
               "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
-            },
-            "glob": {
-              "version": "5.0.15",
-              "from": "glob@5.0.15",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
             },
             "graceful-fs": {
               "version": "3.0.8",
@@ -1428,25 +1312,25 @@
               "from": "graceful-readlink@1.0.1",
               "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
             },
-            "har-validator": {
-              "version": "2.0.2",
-              "from": "har-validator@2.0.2",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz"
-            },
             "has-ansi": {
               "version": "2.0.0",
               "from": "has-ansi@2.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
             },
-            "has-unicode": {
-              "version": "1.0.1",
-              "from": "has-unicode@1.0.1",
-              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
+            "har-validator": {
+              "version": "2.0.2",
+              "from": "har-validator@2.0.2",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz"
             },
             "hawk": {
               "version": "3.1.0",
               "from": "hawk@3.1.0",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz"
+            },
+            "has-unicode": {
+              "version": "1.0.1",
+              "from": "has-unicode@1.0.1",
+              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
             },
             "hoek": {
               "version": "2.16.3",
@@ -1460,7 +1344,7 @@
             },
             "http-signature": {
               "version": "0.11.0",
-              "from": "http-signature@0.11.0",
+              "from": "http-signature@>=0.11.0 <0.12.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz"
             },
             "inflight": {
@@ -1470,7 +1354,7 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "inherits@2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "ini": {
@@ -1505,12 +1389,12 @@
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "isstream@0.1.2",
+              "from": "isstream@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@5.0.1",
+              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "jsonpointer": {
@@ -1570,7 +1454,7 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@0.5.1",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
             },
             "moment": {
@@ -1700,12 +1584,12 @@
             },
             "stringstream": {
               "version": "0.0.5",
-              "from": "stringstream@0.0.5",
+              "from": "stringstream@>=0.0.4 <0.1.0",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
             },
             "strip-json-comments": {
@@ -1715,7 +1599,7 @@
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             },
             "topo": {
@@ -1735,7 +1619,7 @@
             },
             "typedarray": {
               "version": "0.0.6",
-              "from": "typedarray@>=0.0.5 <0.1.0",
+              "from": "typedarray@0.0.6",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "util-deprecate": {
@@ -1755,7 +1639,7 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@4.0.1",
+              "from": "xtend@>=4.0.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             },
             "are-we-there-yet": {
@@ -1803,7 +1687,7 @@
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
@@ -1886,19 +1770,19 @@
           "resolved": "https://registry.npmjs.org/intel/-/intel-1.1.0.tgz",
           "dependencies": {
             "chalk": {
-              "version": "1.1.3",
+              "version": "1.1.1",
               "from": "chalk@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
-                  "version": "2.2.1",
-                  "from": "ansi-styles@>=2.2.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                  "version": "2.1.0",
+                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
-                  "version": "1.0.5",
+                  "version": "1.0.4",
                   "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
@@ -1913,9 +1797,9 @@
                   }
                 },
                 "strip-ansi": {
-                  "version": "3.0.1",
+                  "version": "3.0.0",
                   "from": "strip-ansi@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
@@ -1976,9 +1860,9 @@
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.1.2.tgz"
         },
         "readable-stream": {
-          "version": "1.1.14",
+          "version": "1.1.13",
           "from": "readable-stream@>=1.1.13 <1.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
@@ -2036,14 +1920,14 @@
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "wrappy@1.0.1",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "inherits@2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
@@ -2077,7 +1961,7 @@
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "wrappy@1.0.1",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -2101,35 +1985,6 @@
       "from": "nock@1.2.0",
       "resolved": "https://registry.npmjs.org/nock/-/nock-1.2.0.tgz",
       "dependencies": {
-        "lodash": {
-          "version": "2.4.1",
-          "from": "lodash@2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            }
-          }
-        },
-        "debug": {
-          "version": "1.0.4",
-          "from": "debug@>=1.0.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
-          "dependencies": {
-            "ms": {
-              "version": "0.6.2",
-              "from": "ms@0.6.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-            }
-          }
-        },
         "chai": {
           "version": "1.10.0",
           "from": "chai@>=1.9.2 <2.0.0",
@@ -2151,6 +2006,35 @@
                   "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
                 }
               }
+            }
+          }
+        },
+        "debug": {
+          "version": "1.0.4",
+          "from": "debug@>=1.0.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.6.2",
+              "from": "ms@0.6.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "2.4.1",
+          "from": "lodash@2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
@@ -2201,13 +2085,13 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
           "dependencies": {
             "readable-stream": {
-              "version": "1.0.34",
+              "version": "1.0.33",
               "from": "readable-stream@>=1.0.26 <1.1.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "core-util-is@1.0.2",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
@@ -2217,12 +2101,12 @@
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "string_decoder@0.10.31",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -2284,9 +2168,9 @@
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
         },
         "tough-cookie": {
-          "version": "2.2.2",
+          "version": "2.2.1",
           "from": "tough-cookie@>=0.12.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
         },
         "http-signature": {
           "version": "0.10.1",
@@ -2382,9 +2266,9 @@
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
         },
         "backoff": {
-          "version": "2.5.0",
+          "version": "2.4.1",
           "from": "backoff@>=2.4.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
           "dependencies": {
             "precond": {
               "version": "0.2.3",
@@ -2394,9 +2278,9 @@
           }
         },
         "bunyan": {
-          "version": "1.8.0",
+          "version": "1.6.0",
           "from": "bunyan@>=1.4.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.6.0.tgz",
           "dependencies": {
             "mv": {
               "version": "2.1.1",
@@ -2488,9 +2372,9 @@
               "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz"
             },
             "moment": {
-              "version": "2.13.0",
+              "version": "2.11.2",
               "from": "moment@>=2.10.6 <3.0.0",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
+              "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz"
             }
           }
         },
@@ -2505,9 +2389,9 @@
               "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-0.0.6.tgz"
             },
             "csv-parse": {
-              "version": "1.0.4",
+              "version": "1.0.1",
               "from": "csv-parse@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-1.0.4.tgz"
+              "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-1.0.1.tgz"
             },
             "stream-transform": {
               "version": "0.1.1",
@@ -2570,7 +2454,7 @@
         },
         "node-uuid": {
           "version": "1.4.7",
-          "from": "node-uuid@>=1.4.1 <2.0.0",
+          "from": "node-uuid@>=1.4.0 <1.5.0",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
         },
         "once": {
@@ -2580,7 +2464,7 @@
           "dependencies": {
             "wrappy": {
               "version": "1.0.1",
-              "from": "wrappy@>=1.0.0 <2.0.0",
+              "from": "wrappy@1.0.1",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
             }
           }
@@ -2647,9 +2531,9 @@
           "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz",
           "dependencies": {
             "nan": {
-              "version": "2.2.1",
+              "version": "2.2.0",
               "from": "nan@>=2.0.8 <3.0.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.1.tgz"
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
             }
           }
         }
@@ -2710,9 +2594,9 @@
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "1.0.34",
+                      "version": "1.0.33",
                       "from": "readable-stream@>=1.0.26 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
@@ -2774,9 +2658,9 @@
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
                 },
                 "tough-cookie": {
-                  "version": "2.2.2",
+                  "version": "2.2.1",
                   "from": "tough-cookie@>=0.12.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
                 },
                 "form-data": {
                   "version": "0.1.4",
@@ -2937,9 +2821,9 @@
           }
         },
         "coveralls": {
-          "version": "2.11.9",
+          "version": "2.11.6",
           "from": "coveralls@>=2.11.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.11.9.tgz",
+          "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.11.6.tgz",
           "dependencies": {
             "js-yaml": {
               "version": "3.0.1",
@@ -2988,46 +2872,7 @@
                 "bl": {
                   "version": "1.0.3",
                   "from": "bl@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "2.0.6",
-                      "from": "readable-stream@>=2.0.5 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "1.0.0",
-                          "from": "isarray@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.6",
-                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz"
                 },
                 "caseless": {
                   "version": "0.11.0",
@@ -3045,13 +2890,13 @@
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                 },
                 "form-data": {
-                  "version": "1.0.0-rc4",
+                  "version": "1.0.0-rc3",
                   "from": "form-data@>=1.0.0-rc3 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
                   "dependencies": {
                     "async": {
                       "version": "1.5.2",
-                      "from": "async@>=1.5.2 <2.0.0",
+                      "from": "async@>=1.4.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                     }
                   }
@@ -3062,14 +2907,14 @@
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
-                  "version": "2.1.10",
+                  "version": "2.1.9",
                   "from": "mime-types@>=2.1.7 <2.2.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.22.0",
-                      "from": "mime-db@>=1.22.0 <1.23.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
+                      "version": "1.21.0",
+                      "from": "mime-db@>=1.21.0 <1.22.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
                     }
                   }
                 },
@@ -3089,9 +2934,9 @@
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
                 },
                 "tough-cookie": {
-                  "version": "2.2.2",
+                  "version": "2.2.1",
                   "from": "tough-cookie@>=2.2.0 <2.3.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
                 },
                 "http-signature": {
                   "version": "1.1.1",
@@ -3153,9 +2998,9 @@
                           "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                         },
                         "tweetnacl": {
-                          "version": "0.14.3",
+                          "version": "0.13.3",
                           "from": "tweetnacl@>=0.13.0 <1.0.0",
-                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
                         },
                         "jodid25519": {
                           "version": "1.0.2",
@@ -3241,19 +3086,19 @@
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
                   "dependencies": {
                     "chalk": {
-                      "version": "1.1.3",
+                      "version": "1.1.1",
                       "from": "chalk@>=1.1.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                       "dependencies": {
                         "ansi-styles": {
-                          "version": "2.2.1",
-                          "from": "ansi-styles@>=2.2.1 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                          "version": "2.1.0",
+                          "from": "ansi-styles@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                         },
                         "escape-string-regexp": {
-                          "version": "1.0.5",
+                          "version": "1.0.4",
                           "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                         },
                         "has-ansi": {
                           "version": "2.0.0",
@@ -3268,9 +3113,9 @@
                           }
                         },
                         "strip-ansi": {
-                          "version": "3.0.1",
+                          "version": "3.0.0",
                           "from": "strip-ansi@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
@@ -3299,9 +3144,9 @@
                       }
                     },
                     "is-my-json-valid": {
-                      "version": "2.13.1",
+                      "version": "2.12.4",
                       "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz",
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
@@ -3333,9 +3178,9 @@
                       }
                     },
                     "pinkie-promise": {
-                      "version": "2.0.1",
+                      "version": "2.0.0",
                       "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
@@ -3361,19 +3206,19 @@
           "resolved": "https://registry.npmjs.org/deeper/-/deeper-2.1.0.tgz"
         },
         "foreground-child": {
-          "version": "1.4.0",
+          "version": "1.3.5",
           "from": "foreground-child@>=1.2.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.3.5.tgz",
           "dependencies": {
             "cross-spawn-async": {
-              "version": "2.2.2",
+              "version": "2.1.8",
               "from": "cross-spawn-async@>=2.1.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.1.8.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "4.0.1",
+                  "version": "4.0.0",
                   "from": "lru-cache@>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.0.tgz",
                   "dependencies": {
                     "pseudomap": {
                       "version": "1.0.2",
@@ -3422,19 +3267,19 @@
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
+              "from": "inflight@1.0.4",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "wrappy@1.0.1",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "inherits@2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
@@ -3468,7 +3313,7 @@
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "wrappy@1.0.1",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -3481,14 +3326,14 @@
           }
         },
         "js-yaml": {
-          "version": "3.6.0",
+          "version": "3.5.3",
           "from": "js-yaml@>=3.3.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.3.tgz",
           "dependencies": {
             "argparse": {
-              "version": "1.0.7",
-              "from": "argparse@>=1.0.7 <2.0.0",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
+              "version": "1.0.6",
+              "from": "argparse@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.6.tgz",
               "dependencies": {
                 "sprintf-js": {
                   "version": "1.0.3",
@@ -3690,9 +3535,9 @@
                       }
                     },
                     "uglify-js": {
-                      "version": "2.6.2",
+                      "version": "2.6.1",
                       "from": "uglify-js@>=2.6.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
+                      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
                       "dependencies": {
                         "async": {
                           "version": "0.2.10",
@@ -3731,7 +3576,7 @@
                                   "dependencies": {
                                     "align-text": {
                                       "version": "0.1.4",
-                                      "from": "align-text@>=0.1.1 <0.2.0",
+                                      "from": "align-text@>=0.1.3 <0.2.0",
                                       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                       "dependencies": {
                                         "kind-of": {
@@ -3740,9 +3585,9 @@
                                           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                           "dependencies": {
                                             "is-buffer": {
-                                              "version": "1.1.3",
+                                              "version": "1.1.2",
                                               "from": "is-buffer@>=1.0.2 <2.0.0",
-                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
                                             }
                                           }
                                         },
@@ -3752,9 +3597,9 @@
                                           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                         },
                                         "repeat-string": {
-                                          "version": "1.5.4",
+                                          "version": "1.5.2",
                                           "from": "repeat-string@>=1.5.2 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                         }
                                       }
                                     },
@@ -3772,7 +3617,7 @@
                                   "dependencies": {
                                     "align-text": {
                                       "version": "0.1.4",
-                                      "from": "align-text@>=0.1.1 <0.2.0",
+                                      "from": "align-text@>=0.1.3 <0.2.0",
                                       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                       "dependencies": {
                                         "kind-of": {
@@ -3781,9 +3626,9 @@
                                           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                           "dependencies": {
                                             "is-buffer": {
-                                              "version": "1.1.3",
+                                              "version": "1.1.2",
                                               "from": "is-buffer@>=1.0.2 <2.0.0",
-                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
                                             }
                                           }
                                         },
@@ -3793,9 +3638,9 @@
                                           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                         },
                                         "repeat-string": {
-                                          "version": "1.5.4",
+                                          "version": "1.5.2",
                                           "from": "repeat-string@>=1.5.2 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                         }
                                       }
                                     }
@@ -3809,9 +3654,16 @@
                               }
                             },
                             "decamelize": {
-                              "version": "1.2.0",
+                              "version": "1.1.2",
                               "from": "decamelize@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
+                              "dependencies": {
+                                "escape-string-regexp": {
+                                  "version": "1.0.4",
+                                  "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                                }
+                              }
                             },
                             "window-size": {
                               "version": "0.1.0",
@@ -3900,9 +3752,9 @@
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
               "dependencies": {
                 "glob": {
-                  "version": "7.0.3",
+                  "version": "7.0.0",
                   "from": "glob@>=7.0.0 <8.0.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
@@ -3918,7 +3770,7 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
@@ -3996,19 +3848,19 @@
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
               "dependencies": {
                 "camelcase": {
-                  "version": "2.1.1",
+                  "version": "2.1.0",
                   "from": "camelcase@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
                 },
                 "cliui": {
-                  "version": "3.2.0",
+                  "version": "3.1.0",
                   "from": "cliui@>=3.0.3 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.1.0.tgz",
                   "dependencies": {
                     "strip-ansi": {
-                      "version": "3.0.1",
-                      "from": "strip-ansi@>=3.0.1 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "version": "3.0.0",
+                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
@@ -4018,16 +3870,23 @@
                       }
                     },
                     "wrap-ansi": {
-                      "version": "2.0.0",
-                      "from": "wrap-ansi@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz"
+                      "version": "1.0.0",
+                      "from": "wrap-ansi@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-1.0.0.tgz"
                     }
                   }
                 },
                 "decamelize": {
-                  "version": "1.2.0",
+                  "version": "1.1.2",
                   "from": "decamelize@>=1.1.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
+                  "dependencies": {
+                    "escape-string-regexp": {
+                      "version": "1.0.4",
+                      "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                    }
+                  }
                 },
                 "os-locale": {
                   "version": "1.4.0",
@@ -4078,9 +3937,9 @@
                       }
                     },
                     "strip-ansi": {
-                      "version": "3.0.1",
+                      "version": "3.0.0",
                       "from": "strip-ansi@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
@@ -4097,9 +3956,9 @@
                   "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
                 },
                 "y18n": {
-                  "version": "3.2.1",
+                  "version": "3.2.0",
                   "from": "y18n@>=3.2.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
+                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
                 }
               }
             }
@@ -4116,82 +3975,24 @@
           "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.1.tgz"
         },
         "readable-stream": {
-          "version": "2.1.0",
+          "version": "2.0.5",
           "from": "readable-stream@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "from": "core-util-is@1.0.2",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "inherits@2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
-            "inline-process-browser": {
-              "version": "2.0.1",
-              "from": "inline-process-browser@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-2.0.1.tgz",
-              "dependencies": {
-                "falafel": {
-                  "version": "1.2.0",
-                  "from": "falafel@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
-                  "dependencies": {
-                    "acorn": {
-                      "version": "1.2.2",
-                      "from": "acorn@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
-                    },
-                    "foreach": {
-                      "version": "2.0.5",
-                      "from": "foreach@>=2.0.5 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "object-keys": {
-                      "version": "1.0.9",
-                      "from": "object-keys@>=1.0.6 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
-                    }
-                  }
-                },
-                "through2": {
-                  "version": "0.6.5",
-                  "from": "through2@>=0.6.5 <0.7.0",
-                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.0.34",
-                      "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                      "dependencies": {
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        }
-                      }
-                    },
-                    "xtend": {
-                      "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <4.1.0-0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
             "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "process-nextick-args": {
               "version": "1.0.6",
@@ -4200,51 +4001,12 @@
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@>=0.10.0 <0.11.0",
+              "from": "string_decoder@0.10.31",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-            },
-            "unreachable-branch-transform": {
-              "version": "0.5.1",
-              "from": "unreachable-branch-transform@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz",
-              "dependencies": {
-                "esmangle-evaluator": {
-                  "version": "1.0.0",
-                  "from": "esmangle-evaluator@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz"
-                },
-                "recast": {
-                  "version": "0.11.5",
-                  "from": "recast@>=0.11.4 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.5.tgz",
-                  "dependencies": {
-                    "ast-types": {
-                      "version": "0.8.16",
-                      "from": "ast-types@0.8.16",
-                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz"
-                    },
-                    "esprima": {
-                      "version": "2.7.2",
-                      "from": "esprima@>=2.7.1 <2.8.0",
-                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
-                    },
-                    "private": {
-                      "version": "0.1.6",
-                      "from": "private@>=0.1.5 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
-                    },
-                    "source-map": {
-                      "version": "0.5.3",
-                      "from": "source-map@>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-                    }
-                  }
-                }
-              }
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "from": "util-deprecate@>=1.0.1 <1.1.0",
+              "from": "util-deprecate@1.0.2",
               "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
             }
           }
@@ -4282,9 +4044,9 @@
               "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
             },
             "escape-string-regexp": {
-              "version": "1.0.5",
+              "version": "1.0.4",
               "from": "escape-string-regexp@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
             },
             "glob": {
               "version": "6.0.4",
@@ -4357,14 +4119,14 @@
               "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.0.tgz",
               "dependencies": {
                 "chalk": {
-                  "version": "1.1.3",
+                  "version": "1.1.1",
                   "from": "chalk@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                   "dependencies": {
                     "ansi-styles": {
-                      "version": "2.2.1",
-                      "from": "ansi-styles@>=2.2.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                      "version": "2.1.0",
+                      "from": "ansi-styles@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                     },
                     "has-ansi": {
                       "version": "2.0.0",
@@ -4379,9 +4141,9 @@
                       }
                     },
                     "strip-ansi": {
-                      "version": "3.0.1",
+                      "version": "3.0.0",
                       "from": "strip-ansi@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
@@ -4399,20 +4161,20 @@
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.7.0 <4.0.0",
+                  "from": "lodash@>=3.3.1 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "punycode": {
-                  "version": "1.4.1",
+                  "version": "1.4.0",
                   "from": "punycode@>=1.3.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.0.tgz"
                 }
               }
             },
             "readable-stream": {
-              "version": "1.1.14",
+              "version": "1.1.13",
               "from": "readable-stream@>=1.1.13 <2.0.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
@@ -4450,7 +4212,7 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "inherits@2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "base64url": "1.0.6",
     "bluebird": "2.1.3",
     "clone": "0.2.0",
     "convict": "1.0.1",


### PR DESCRIPTION
Connects to #135, although not a complete fix.

This reverts most of commit b1261bcf11a81a94ea93ed2f913b6c1e83cff21d, and replaces it with an explicit refusal to store any push key data on the device record.  The idea is as follows:

* Patch number 24 reverts the schema changes introduced previously, and is intended to clean up on dev boxes that may already have patch number 23 applied.  It's not necessary in production.
* Patch number 25 creates new device-related stored procedures that do not handle key data.  This is the patch we'd apply in production.
* After this is deployed, we're no longer touching the `callbackPublicKey` column at all, so we should be safe to drop/modify it in the next deployment.

@jrgm/@jbuck does this seem like a good approach?

@vladikoff r?