### PR TITLE
feat(db): implement verification state for key fetch tokens

### DIFF
--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -69,13 +69,13 @@ The following datatypes are used throughout this document:
     * deleteSessionToken        : `DEL /sessionToken/:id`
     * createSessionToken        : `PUT /sessionToken/:id`
     * updateSessionToken        : `POST /sessionToken/:id/update`
-    * verifyToken               : `POST /token/:tokenVerificationId/verify`
 * Account Reset Tokens:
     * accountResetToken         : `GET /accountResetToken/:id`
     * deleteAccountResetToken   : `DEL /accountResetToken/:id`
     * createAccountResetToken   : `PUT /accountResetToken/:id`
 * Key Fetch Tokens:
     * keyFetchToken             : `GET /keyFetchToken/:id`
+    * keyFetchTokenWithVerificationStatus : `GET /keyFetchToken/:id/verified`
     * deleteKeyFetchToken       : `DEL /keyFetchToken/:id`
     * createKeyFetchToken       : `PUT /keyFetchToken/:id`
 * Password Change Tokens:
@@ -88,6 +88,8 @@ The following datatypes are used throughout this document:
     * createPasswordForgotToken : `PUT /passwordForgotToken/:id`
     * updatePasswordForgotToken : `POST /passwordForgotToken/:id/update`
     * forgotPasswordVerified    : `POST /passwordForgotToken/:id/verified`
+* Unverified tokens:
+    * verifyTokens              : `POST /tokens/:tokenVerificationId/verify`
 
 ## Ping : `GET /`
 
@@ -608,55 +610,6 @@ Content-Length: 2
     * Conditions: if something goes wrong on the server
     * Content-Type : 'application/json'
     * Body : `{"code":"InternalError","message":"...<message related to the error>..."}`
-
-## verifyToken : `POST /token/<tokenVerificationId>/verify`
-
-This method verifies sessionTokens.
-Note that it takes the tokenVerificationId
-specified when creating the token,
-NOT the tokenId.
-
-### Example
-
-```
-curl \
-    -v \
-    -X POST \
-    -H "Content-Type: application/json" \
-    -d '{"uid":"fdea27c8188b3d980a28917bc1399e47"}' \
-    http://localhost:8000/token/8e8c27b704dbf6a5dc556453c92e7506/verify
-```
-
-### Request
-
-* Method : POST
-* Path : `/token/<tokenVerificationId>/verify`
-    * tokenVerificationId : hex128
-* Params:
-    * uid : hex128
-
-### Response
-
-```
-HTTP/1.1 200 OK
-Content-Type: application/json
-Content-Length: 2
-
-{}
-```
-
-* Status Code : 200 OK
-    * Content-Type : 'application/json'
-    * Body : {}
-* Status Code : 404 Not Found
-    * Conditions: if no unverified tokens exist for `tokenVerificationId` and `uid`
-    * Content-Type : 'application/json'
-    * Body : `{"message":"Not Found"}`
-* Status Code : 500 Internal Server Error
-    * Conditions: if something goes wrong on the server
-    * Content-Type : 'application/json'
-    * Body : {"code":"InternalError","message":"...<message related to the error>..."}
-```
 
 ## accountDevices : `GET /account/<uid>/devices`
 
@@ -1201,7 +1154,8 @@ curl \
         "uid"       : "6044486dd15b42e08b1fb9167415b9ac",
         "authKey"   : "b034061cc2886a3c3c08bd4e9bbc8afc4bc3fc9bca12d5b5d0aa7e0a7f78b9ce",
         "keyBundle" : "83333269c64eb43219f8b5807d37ac2391fc77295562685a5239674e2b0215920c45e2295c0d92fa7d69cb58d1e3c6010e1281f6d6c0df694b134815358110ae22a7b4c348a4f426bef3783b0493b3a531b649c0e2f19848d9563a61cd0f7eb8",
-        "createdAt" : 1425004396952
+        "createdAt" : 1425004396952,
+        "tokenVerificationId" : "a6062c21560edad350e6a654bdd9fd4f"
     }' \
     http://localhost:8000/keyFetchToken/4c17443c1bcf5e509bc90904905ea1974900120d3dd34e7061f182cb063f976a
 ```
@@ -1217,6 +1171,7 @@ curl \
     * authKey : hex256
     * keyBundle : hex768
     * createdAt : epoch
+    * tokenVerificationId : hex128
 
 ### Response
 
@@ -1281,6 +1236,54 @@ Content-Length: 399
     * Body : `[ ... <see example> ...]`
 * Status Code : 404 Not Found
     * Conditions: if this session `tokenId` doesn't exist
+    * Content-Type : 'application/json'
+    * Body : `{"message":"Not Found"}`
+* Status Code : 500 Internal Server Error
+    * Conditions: if something goes wrong on the server
+    * Content-Type : 'application/json'
+    * Body : `{"code":"InternalError","message":"...<message related to the error>..."}`
+
+## keyFetchTokenWithVerificationStatus : `GET /keyFetchToken/<tokenId>/verified`
+
+### Example
+
+```
+curl \
+    -v \
+    -X GET \
+    http://localhost:8000/keyFetchToken/4c17443c1bcf5e509bc90904905ea1974900120d3dd34e7061f182cb063f976a/verified
+```
+
+### Request
+
+* Method : GET
+* Path : `/keyFetchToken/<tokenId>/verified`
+    * tokenId : hex256
+* Params: none
+
+### Response
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 399
+
+{
+    "authKey":"b034061cc2886a3c3c08bd4e9bbc8afc4bc3fc9bca12d5b5d0aa7e0a7f78b9ce",
+    "uid":"6044486dd15b42e08b1fb9167415b9ac",
+    "keyBundle":"83333269c64eb43219f8b5807d37ac2391fc77295562685a5239674e2b0215920c45e2295c0d92fa7d69cb58d1e3c6010e1281f6d6c0df694b134815358110ae22a7b4c348a4f426bef3783b0493b3a531b649c0e2f19848d9563a61cd0f7eb8",
+    "createdAt":1460548810011,
+    "emailVerified":0,
+    "verifierSetAt":1460548810011,
+    "tokenVerificationId":"12c41fac80fd6149f3f695e188b5f846"
+}
+```
+
+* Status Code : 200 OK
+    * Content-Type : 'application/json'
+    * Body : `[ ... <see example> ...]`
+* Status Code : 404 Not Found
+    * Conditions: if the keyFetchToken `tokenId` doesn't exist
     * Content-Type : 'application/json'
     * Body : `{"message":"Not Found"}`
 * Status Code : 500 Internal Server Error
@@ -1704,6 +1707,55 @@ Content-Length: 2
     * Body : {}
 * Status Code : 404 Not Found
     * Conditions: if this session `tokenId` doesn't exist
+    * Content-Type : 'application/json'
+    * Body : `{"message":"Not Found"}`
+* Status Code : 500 Internal Server Error
+    * Conditions: if something goes wrong on the server
+    * Content-Type : 'application/json'
+    * Body : {"code":"InternalError","message":"...<message related to the error>..."}
+```
+
+## verifyTokens : `POST /tokens/<tokenVerificationId>/verify`
+
+This method verifies sessionTokens and keyFetchTokens.
+Note that it takes the tokenVerificationId
+specified when creating the token,
+NOT the tokenId.
+
+### Example
+
+```
+curl \
+    -v \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d '{"uid":"fdea27c8188b3d980a28917bc1399e47"}' \
+    http://localhost:8000/tokens/8e8c27b704dbf6a5dc556453c92e7506/verify
+```
+
+### Request
+
+* Method : POST
+* Path : `/tokens/<tokenVerificationId>/verify`
+    * tokenVerificationId : hex128
+* Params:
+    * uid : hex128
+
+### Response
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 2
+
+{}
+```
+
+* Status Code : 200 OK
+    * Content-Type : 'application/json'
+    * Body : {}
+* Status Code : 404 Not Found
+    * Conditions: if no unverified tokens exist for `tokenVerificationId` and `uid`
     * Content-Type : 'application/json'
     * Body : `{"message":"Not Found"}`
 * Status Code : 500 Internal Server Error

--- a/fxa-auth-db-server/index.js
+++ b/fxa-auth-db-server/index.js
@@ -102,7 +102,8 @@ function createServer(db) {
   api.put('/keyFetchToken/:id', reply(db.createKeyFetchToken))
 
   api.get('/sessionToken/:id/verified', reply(db.sessionTokenWithVerificationStatus))
-  api.post('/token/:id/verify', reply(db.verifyToken))
+  api.get('/keyFetchToken/:id/verified', reply(db.keyFetchTokenWithVerificationStatus))
+  api.post('/tokens/:id/verify', reply(db.verifyTokens))
 
   api.get('/accountResetToken/:id', reply(db.accountResetToken))
   api.del('/accountResetToken/:id', reply(db.deleteAccountResetToken))

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -195,7 +195,7 @@ module.exports = function(cfg, server) {
   test(
     'session token handling',
     function (t) {
-      t.plan(125)
+      t.plan(127)
       var user = fake.newUserDataHex()
       var verifiedUser = fake.newUserDataHex()
       delete verifiedUser.sessionToken.tokenVerificationId
@@ -392,6 +392,17 @@ module.exports = function(cfg, server) {
         .then(function(r) {
           t.equal(r.obj.tokenVerificationId, null, 'tokenVerificationId is null')
 
+          // Attempt to verify the session token again
+          return client.postThen('/tokens/' + user.sessionToken.tokenVerificationId + '/verify', {
+            uid: user.accountId
+          })
+        })
+        .then(function () {
+          t.fail('Verifying a verified token should have failed')
+        }, function (err) {
+          testNotFound(t, err)
+        })
+        .then(function () {
           // Update the newly verified session token
           return client.postThen('/sessionToken/' + user.sessionTokenId + '/update', {
             uaBrowser: 'different browser',
@@ -561,7 +572,7 @@ module.exports = function(cfg, server) {
   test(
     'key fetch token handling',
     function (t) {
-      t.plan(35)
+      t.plan(39)
       var user = fake.newUserDataHex()
       var verifiedUser = fake.newUserDataHex()
       delete verifiedUser.keyFetchToken.tokenVerificationId
@@ -661,6 +672,17 @@ module.exports = function(cfg, server) {
         .then(function(r) {
           t.equal(r.obj.tokenVerificationId, null, 'tokenVerificationId is null')
 
+          // Attempt to verify the key fetch token again
+          return client.postThen('/tokens/' + user.keyFetchToken.tokenVerificationId + '/verify', {
+            uid: user.accountId
+          })
+        })
+        .then(function () {
+          t.fail('Verifying a verified token should have failed')
+        }, function (err) {
+          testNotFound(t, err)
+        })
+        .then(function () {
           // Create a verified key fetch token
           return client.putThen('/keyFetchToken/' + verifiedUser.keyFetchTokenId, verifiedUser.keyFetchToken)
         })
@@ -677,6 +699,17 @@ module.exports = function(cfg, server) {
         .then(function(r) {
           t.equal(r.obj.tokenVerificationId, null, 'tokenVerificationId is null')
 
+          // Attempt to verify the verified key fetch token
+          return client.postThen('/tokens/' + verifiedUser.keyFetchToken.tokenVerificationId + '/verify', {
+            uid: user.accountId
+          })
+        })
+        .then(function () {
+          t.fail('Verifying a verified token should have failed')
+        }, function (err) {
+          testNotFound(t, err)
+        })
+        .then(function () {
           // Delete both key fetch tokens
           return P.all([
             client.delThen('/keyFetchToken/' + user.keyFetchTokenId),

--- a/fxa-auth-db-server/test/fake.js
+++ b/fxa-auth-db-server/test/fake.js
@@ -79,7 +79,8 @@ module.exports.newUserDataHex = function() {
     authKey : hex32(),
     uid : data.accountId,
     keyBundle : hex96(),
-    createdAt: Date.now()
+    createdAt: Date.now(),
+    tokenVerificationId: hex16()
   }
 
   // accountResetToken

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -130,6 +130,13 @@ module.exports = function (log, error) {
       createdAt: keyFetchToken.createdAt,
     }
 
+    if (keyFetchToken.tokenVerificationId) {
+      unverifiedTokens[tokenId] = {
+        tokenVerificationId: keyFetchToken.tokenVerificationId,
+        uid: keyFetchToken.uid
+      }
+    }
+
     return P.resolve({})
   }
 
@@ -297,11 +304,15 @@ module.exports = function (log, error) {
   }
 
   Memory.prototype.deleteKeyFetchToken = function (tokenId) {
-    delete keyFetchTokens[tokenId.toString('hex')]
+    tokenId = tokenId.toString('hex')
+
+    delete unverifiedTokens[tokenId]
+    delete keyFetchTokens[tokenId]
+
     return P.resolve({})
   }
 
-  Memory.prototype.verifyToken = function (tokenVerificationId, accountData) {
+  Memory.prototype.verifyTokens = function (tokenVerificationId, accountData) {
     tokenVerificationId = tokenVerificationId.toString('hex')
     var uid = accountData.uid.toString('hex')
 
@@ -562,6 +573,17 @@ module.exports = function (log, error) {
     item.verifierSetAt = account.verifierSetAt
 
     return P.resolve(item)
+  }
+
+  Memory.prototype.keyFetchTokenWithVerificationStatus = function (tokenId) {
+    tokenId = tokenId.toString('hex')
+
+    return this.keyFetchToken(tokenId)
+      .then(function (keyFetchToken) {
+        keyFetchToken.tokenVerificationId = unverifiedTokens[tokenId] ?
+          unverifiedTokens[tokenId].tokenVerificationId : null
+        return keyFetchToken
+      })
   }
 
   Memory.prototype.passwordForgotToken = function (id) {

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the schema/ directory.
-module.exports.level = 24
+module.exports.level = 25

--- a/lib/db/schema/patch-024-025.sql
+++ b/lib/db/schema/patch-024-025.sql
@@ -1,0 +1,94 @@
+-- Update createKeyFetchToken stored procedure to
+-- insert into unverifiedTokens.
+CREATE PROCEDURE `createKeyFetchToken_2` (
+  IN `tokenId` BINARY(32),
+  IN `authKey` BINARY(32),
+  IN `uid` BINARY(16),
+  IN `keyBundle` BINARY(96),
+  IN `createdAt` BIGINT UNSIGNED,
+  IN `tokenVerificationId` BINARY(16)
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  INSERT INTO keyFetchTokens(
+    tokenId,
+    authKey,
+    uid,
+    keyBundle,
+    createdAt
+  )
+  VALUES(
+    tokenId,
+    authKey,
+    uid,
+    keyBundle,
+    createdAt
+  );
+
+  IF tokenVerificationId IS NOT NULL THEN
+    INSERT INTO unverifiedTokens(
+      tokenId,
+      tokenVerificationId,
+      uid
+    )
+    VALUES(
+      tokenId,
+      tokenVerificationId,
+      uid
+    );
+  END IF;
+
+  COMMIT;
+END;
+
+-- Update deleteKeyFetchToken stored procedure to
+-- delete from unverifiedTokens.
+CREATE PROCEDURE `deleteKeyFetchToken_2` (
+  IN `tokenIdArg` BINARY(32)
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  DELETE FROM keyFetchTokens WHERE tokenId = tokenIdArg;
+  DELETE FROM unverifiedTokens WHERE tokenId = tokenIdArg;
+
+  COMMIT;
+END;
+
+-- Add stored procedure for fetching keyFetchToken
+-- with its verification status.
+CREATE PROCEDURE `keyFetchTokenWithVerificationStatus_1` (
+  IN `tokenIdArg` BINARY(32)
+)
+BEGIN
+  SELECT
+    t.authKey,
+    t.uid,
+    t.keyBundle,
+    t.createdAt,
+    a.emailVerified,
+    a.verifierSetAt,
+    ut.tokenVerificationId
+  FROM keyFetchTokens AS t
+  LEFT JOIN accounts AS a
+    ON t.uid = a.uid
+  LEFT JOIN unverifiedTokens AS ut
+    ON t.tokenId = ut.tokenId
+  WHERE t.tokenId = tokenIdArg;
+END;
+
+UPDATE dbMetadata SET value = '25' WHERE name = 'schema-patch-level';
+

--- a/lib/db/schema/patch-025-024.sql
+++ b/lib/db/schema/patch-025-024.sql
@@ -1,0 +1,5 @@
+-- DROP PROCEDURE `keyFetchTokenWithVerificationStatus_1`;
+-- DROP PROCEDURE `deleteKeyFetchToken_2`;
+-- DROP PROCEDURE `createKeyFetchToken_2`;
+
+-- UPDATE dbMetadata SET value = '24' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
This PR enables us to work round the problem of Fennec using the `/account/keys` auth server endpoint to check account status. It does so by reinstating the verification state for key fetch tokens, which is set by the presence of `tokenVerificationId` in the request payload to `PUT /keyFetchToken/:id`.

For this to work correctly with the sign-in confirmation stuff, the auth server must:

* Be updated to make requests to the plural `/tokens/:tokenVerificationId/verify`.
* Only create unverified key fetch tokens from `/account/signup` and `/account/login` (i.e. not on password change).
* Specify the same `tokenVerificationId` as it does for the equivalent session token.
* Reject requests to `/account/keys` that use an unverified token, with `errno` 104.

@vbudhram @rfk r?

/cc @shane-tomlinson 
