### PR TITLE
fix(db): remove createAccountResetToken stored procedure and endpoint

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -39,7 +39,6 @@ There are a number of methods that a DB storage backend should implement:
     * .passwordChangeToken(id)
     * .deletePasswordChangeToken(tokenId)
 * Account Reset Tokens
-    * .createAccountResetToken(tokenId, accountResetToken)
     * .accountResetToken(id)
     * .deleteAccountResetToken(tokenId)
 * Verification Reminders
@@ -268,7 +267,6 @@ functions which all work similarly. For example, the `sessionTokens` have:
 ### .createKeyFetchToken(tokenId, token) ###
 ### .createPasswordChangeToken(tokenId, token) ###
 ### .createPasswordForgotToken(tokenId, token) ###
-### .createAccountResetToken(tokenId, token) ###
 
 Parameters.
 
@@ -282,7 +280,6 @@ Each token takes the following fields for it's create method respectively:
 * keyFetchToken : authKey, uid, keyBundle, createdAt, tokenVerificationId
 * passwordChangeToken : data, uid, createdAt
 * passwordForgotToken : data, uid, passCode, createdAt, triesxb
-* accountResetToken : data, uid, createdAt
 
 Returns:
 
@@ -418,7 +415,7 @@ Parameters:
     * tokenId
     * data
     * uid
-    * createdA
+    * createdAt
 
 ## .sessionWithDevice(tokenId) ##
 

--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -72,7 +72,6 @@ The following datatypes are used throughout this document:
 * Account Reset Tokens:
     * accountResetToken         : `GET /accountResetToken/:id`
     * deleteAccountResetToken   : `DEL /accountResetToken/:id`
-    * createAccountResetToken   : `PUT /accountResetToken/:id`
 * Key Fetch Tokens:
     * keyFetchToken             : `GET /keyFetchToken/:id`
     * keyFetchTokenWithVerificationStatus : `GET /keyFetchToken/:id/verified`
@@ -997,60 +996,6 @@ Content-Length: 2
     * Conditions: if something goes wrong on the server
     * Content-Type : 'application/json'
     * Body : `{"code":"InternalError","message":"...<message related to the error>..."}`
-
-
-## createAccountResetToken : `PUT /accountResetToken/<tokenId>`
-
-Since only one `accountResetToken` is allowed for each account at any time, any subsequent new token will delete the
-old one.
-
-### Example
-
-```
-curl \
-    -v \
-    -X PUT \
-    -H "Content-Type: application/json" \
-    -d '{
-        "uid" :  "6044486dd15b42e08b1fb9167415b9ac",
-        "data" : "b034061cc2886a3c3c08bd4e9bbc8afc4bc3fc9bca12d5b5d0aa7e0a7f78b9ce",
-        "createdAt" : 1425004396952
-    }' \
-    http://localhost:8000/accountResetToken/da7e3b59fc6021836ed205d2176c11819932c9554bec5a40a1f4178b7f08194d
-```
-
-### Request
-
-* Method : PUT
-* Path : `/accountResetToken/<tokenId>`
-    * tokenId : hex256
-* Params:
-    * uid : hex128
-    * data : hex256
-    * createdAt : epoch
-
-### Response
-
-```
-HTTP/1.1 200 OK
-Content-Type: application/json
-Content-Length: 2
-
-{}
-```
-
-* Status Code : 200 OK
-    * Content-Type : 'application/json'
-    * Body : {}
-* Status Code : 409 Conflict
-    * Conditions: if this `tokenId` already exists
-    * Content-Type : 'application/json'
-    * Body : {"message":"Record already exists"}
-* Status Code : 500 Internal Server Error
-    * Conditions: if something goes wrong on the server
-    * Content-Type : 'application/json'
-    * Body : {"code":"InternalError","message":"...<message related to the error>..."}
-```
 
 
 ## accountResetToken : `GET /accountResetToken/<tokenId>`

--- a/fxa-auth-db-server/index.js
+++ b/fxa-auth-db-server/index.js
@@ -70,7 +70,6 @@ function createServer(db) {
 
   api.get('/accountResetToken/:id', reply(db.accountResetToken))
   api.del('/accountResetToken/:id', reply(db.deleteAccountResetToken))
-  api.put('/accountResetToken/:id', reply(db.createAccountResetToken))
 
   api.get('/passwordChangeToken/:id', reply(db.passwordChangeToken))
   api.del('/passwordChangeToken/:id', reply(db.deletePasswordChangeToken))

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -753,7 +753,7 @@ module.exports = function(cfg, server) {
   test(
     'account reset token handling',
     function (t) {
-      t.plan(11)
+      t.plan(15)
       var user = fake.newUserDataHex()
       return client.putThen('/account/' + user.accountId, user.account)
         .then(function() {
@@ -763,7 +763,17 @@ module.exports = function(cfg, server) {
           t.fail('A non-existant session token should not have returned anything')
         }, function(err) {
           t.pass('No session token exists yet')
-          return client.putThen('/accountResetToken/' + user.accountResetTokenId, user.accountResetToken)
+          return client.putThen('/passwordForgotToken/' + user.passwordForgotTokenId, user.passwordForgotToken)
+        })
+        .then(function(r) {
+          respOk(t, r)
+          // now, verify the password (which inserts the accountResetToken)
+          return client.postThen('/passwordForgotToken/' + user.passwordForgotTokenId + '/verified', user.accountResetToken)
+        })
+        .then(function(r) {
+          respOk(t, r)
+          // check the accountResetToken exists
+          return client.getThen('/accountResetToken/' + user.accountResetTokenId)
         })
         .then(function(r) {
           respOk(t, r)
@@ -920,7 +930,6 @@ module.exports = function(cfg, server) {
         .then(function(r) {
           respOk(t, r)
           // now, verify the password (which inserts the accountResetToken)
-          user.accountResetToken.tokenId = user.accountResetTokenId
           return client.postThen('/passwordForgotToken/' + user.passwordForgotTokenId + '/verified', user.accountResetToken)
         })
         .then(function(r) {

--- a/fxa-auth-db-server/test/fake.js
+++ b/fxa-auth-db-server/test/fake.js
@@ -86,6 +86,7 @@ module.exports.newUserDataHex = function() {
   // accountResetToken
   data.accountResetTokenId = hex32()
   data.accountResetToken = {
+    tokenId : data.accountResetTokenId,
     data : hex32(),
     uid : data.accountId,
     createdAt: Date.now()
@@ -151,6 +152,7 @@ module.exports.newUserDataBuffer = function() {
   // accountResetToken
   data.accountResetTokenId = buf32()
   data.accountResetToken = {
+    tokenId : data.accountResetTokenId,
     data : buf32(),
     uid : data.accountId,
     createdAt: Date.now()

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -180,22 +180,6 @@ module.exports = function (log, error) {
     return P.resolve({})
   }
 
-  Memory.prototype.createAccountResetToken = function (tokenId, accountResetToken) {
-    tokenId = tokenId.toString('hex')
-
-    // Delete any accountResetTokens for this uid (since we're only
-    // allowed one at a time).
-    deleteByUid(accountResetToken.uid.toString('hex'), accountResetTokens)
-
-    accountResetTokens[tokenId] = {
-      tokenData: accountResetToken.data,
-      uid: accountResetToken.uid,
-      createdAt: accountResetToken.createdAt,
-    }
-
-    return P.resolve({})
-  }
-
   Memory.prototype.createDevice = function (uid, deviceId, deviceInfo) {
     return getAccountByUid(uid)
       .then(
@@ -668,9 +652,25 @@ module.exports = function (log, error) {
   Memory.prototype.forgotPasswordVerified = function (tokenId, accountResetToken) {
     return P.all([
       this.deletePasswordForgotToken(tokenId),
-      this.createAccountResetToken(accountResetToken.tokenId, accountResetToken),
+      createAccountResetToken(),
       this.verifyEmail(accountResetToken.uid)
     ])
+
+    function createAccountResetToken() {
+      var tokenId = accountResetToken.tokenId.toString('hex')
+
+      // Delete any accountResetTokens for this uid (since we're only
+      // allowed one at a time).
+      deleteByUid(accountResetToken.uid.toString('hex'), accountResetTokens)
+
+      accountResetTokens[tokenId] = {
+        tokenData: accountResetToken.data,
+        uid: accountResetToken.uid,
+        createdAt: accountResetToken.createdAt
+      }
+
+      return P.resolve({})
+    }
   }
 
   Memory.prototype.resetAccount = function (uid, data) {

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -224,22 +224,6 @@ module.exports = function (log, error) {
     )
   }
 
-  // Insert : accountResetTokens
-  // Values : tokenId = $1, tokenData = $2, uid = $3, createdAt = $4
-  var CREATE_ACCOUNT_RESET_TOKEN = 'CALL createAccountResetToken_2(?, ?, ?, ?)'
-
-  MySql.prototype.createAccountResetToken = function (tokenId, accountResetToken) {
-    return this.write(
-      CREATE_ACCOUNT_RESET_TOKEN,
-      [
-        tokenId,
-        accountResetToken.data,
-        accountResetToken.uid,
-        accountResetToken.createdAt
-      ]
-    )
-  }
-
   // Insert : passwordForgotTokens
   // Values : tokenId = $1, tokenData = $2, uid = $3, passCode = $4, createdAt = $5, tries = $6
   var CREATE_PASSWORD_FORGOT_TOKEN = 'CALL createPasswordForgotToken_2(?, ?, ?, ?, ?, ?)'

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the schema/ directory.
-module.exports.level = 26
+module.exports.level = 27

--- a/lib/db/schema/patch-026-027.sql
+++ b/lib/db/schema/patch-026-027.sql
@@ -1,0 +1,5 @@
+-- Drop unused createAccountResetToken stored procedure.
+DROP PROCEDURE `createAccountResetToken_2`;
+
+-- Schema patch-level increment.
+UPDATE dbMetadata SET value = '27' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-027-026.sql
+++ b/lib/db/schema/patch-027-026.sql
@@ -1,0 +1,26 @@
+-- -- Reinstate dropped createAccountResetToken stored procedure
+
+--CREATE PROCEDURE `createAccountResetToken_2` (
+--    IN tokenId BINARY(32),
+--    IN tokenData BINARY(32),
+--    IN uid BINARY(16),
+--    IN createdAt BIGINT UNSIGNED
+--)
+--BEGIN
+--    -- Since we only ever want one accountResetToken per uid, then we
+--    -- do a replace - generally due to a collision on the unique uid field.
+--    REPLACE INTO accountResetTokens(
+--        tokenId,
+--        tokenData,
+--        uid,
+--        createdAt
+--    )
+--    VALUES(
+--        tokenId,
+--        tokenData,
+--        uid,
+--        createdAt
+--    );
+--END;
+
+--UPDATE dbMetadata SET value = '26' WHERE name = 'schema-patch-level';

--- a/test/local/prune_tokens.js
+++ b/test/local/prune_tokens.js
@@ -34,7 +34,10 @@ DB.connect(config)
           var user = fake.newUserDataBuffer()
           return db.createAccount(user.accountId, user.account)
             .then(function() {
-              return db.createAccountResetToken(user.accountResetTokenId, user.accountResetToken)
+              return db.createPasswordForgotToken(user.passwordForgotTokenId, user.passwordForgotToken)
+            })
+            .then(function() {
+              return db.forgotPasswordVerified(user.accountResetTokenId, user.accountResetToken)
             })
             .then(function() {
               // now set it to be a day ago


### PR DESCRIPTION
Fixes #150. Will need to be rebased after #153 is merged.

I'm not 100% certain that we actually want to do this, although there wasn't any disagreement on the issue.

Anyway, this removes the endpoint and stored procedure for `createAccountResetToken`. They're never called and the corresponding auth server code was removed in https://github.com/mozilla/fxa-auth-server/pull/1384. Account reset tokens are exclusively created through the `forgotPasswordVerified` stored procedure.

Both me and @rfk had a look in Kibana for requests to this endpoint, none were found.

However, given my track record in this repo, it's quite possible that I've missed some crucial unforeseen operational effect on the production db.

@rfk, @jrgm r?