### PR TITLE
feat(db): Record whether unverified tokens must be verified before use.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -276,7 +276,7 @@ Parameters.
 Each token takes the following fields for it's create method respectively:
 
 * sessionToken : data, uid, createdAt, uaBrowser, uaBrowserVersion, uaOS, uaOSVersion, uaDeviceType,
-                 tokenVerificationId
+                 mustVerify, tokenVerificationId
 * keyFetchToken : authKey, uid, keyBundle, createdAt, tokenVerificationId
 * passwordChangeToken : data, uid, createdAt
 * passwordForgotToken : data, uid, passCode, createdAt, triesxb
@@ -326,10 +326,10 @@ These fields are represented as
 * sessionTokenWithVerificationStatus : t.tokenData, t.uid, t.createdAt, t.uaBrowser, t.uaBrowserVersion,
                                        t.uaOS, t.uaOSVersion, t.uaDeviceType, t.lastAccessTime,
                                        a.emailVerified, a.email, a.emailCode, a.verifierSetAt,
-                                       a.createdAt AS accountCreatedAt, ut.tokenVerificationId
+                                       a.createdAt AS accountCreatedAt, ut.mustVerify, ut.tokenVerificationId
 * keyFetchToken : t.authKey, t.uid, t.keyBundle, t.createdAt, a.emailVerified, a.verifierSetAt
 * keyFetchTokenWithVerificationStatus : t.authKey, t.uid, t.keyBundle, t.createdAt, a.emailVerified,
-                                        a.verifierSetAt, ut.tokenVerificationId
+                                        a.verifierSetAt, ut.mustVerify, ut.tokenVerificationId
 * passwordChangeToken : t.tokenData, t.uid, t.createdAt, a.verifierSetAt
 * passwordForgotToken : t.tokenData, t.uid, t.createdAt, t.passCode, t.tries, a.email, a.verifierSetAt
 * accountResetToken : t.uid, t.tokenData, t.createdAt, a.verifierSetAt
@@ -450,7 +450,7 @@ The deviceCallbackPublicKey and deviceCallbackAuthKey fields are urlsafe-base64 
                  d.name AS deviceName, d.type AS deviceType,
                  d.createdAt AS deviceCreatedAt, d.callbackURL AS deviceCallbackURL,
                  d.callbackPublicKey AS deviceCallbackPublicKey,
-                 d.callbackAuthKey AS deviceCallbackAuthKey, ut.tokenVerificationId
+                 d.callbackAuthKey AS deviceCallbackAuthKey, ut.mustVerify, ut.tokenVerificationId
 
 ## .createVerificationReminder(body) ##
 

--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -508,6 +508,7 @@ curl \
         "uaOS" : Mac OS X,
         "uaOSVersion" : 10.10,
         "uaDeviceType" : null,
+        "mustVerify":true,
         "tokenVerificationId" : "5680a81ba029af7b829afb4aa6dbc23f"
     }' \
     http://localhost:8000/sessionToken/522c251a1623e1f1db1f4fe68b9594d26772d6e77e04cb68e110c58600f97a77
@@ -527,6 +528,7 @@ curl \
     * uaOS : string
     * uaOSVersion : string
     * uaDeviceType : string
+    * mustVerify : boolean,
     * tokenVerificationId : hex128
 
 ### Response
@@ -875,6 +877,7 @@ Content-Length: 285
     "verifierSetAt":1460548810011,
     "locale":"en_US",
     "accountCreatedAt":1460548810011,
+    "mustVerify":true,
     "tokenVerificationId":"12c41fac80fd6149f3f695e188b5f846"
 }
 ```
@@ -938,6 +941,7 @@ Content-Length: 285
     "deviceCreatedAt":1460548810011,
     "deviceCallbackURL":null,
     "deviceCallbackPublicKey":null,
+    "mustVerify":true,
     "tokenVerificationId":"12c41fac80fd6149f3f695e188b5f846"
 }
 ```

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -195,7 +195,7 @@ module.exports = function(cfg, server) {
   test(
     'session token handling',
     function (t) {
-      t.plan(127)
+      t.plan(133)
       var user = fake.newUserDataHex()
       var verifiedUser = fake.newUserDataHex()
       delete verifiedUser.sessionToken.tokenVerificationId
@@ -280,6 +280,7 @@ module.exports = function(cfg, server) {
           t.deepEqual(token.emailCode, user.account.emailCode, 'token emailCode same as account emailCode')
           t.ok(token.verifierSetAt, 'verifierSetAt is set to a truthy value')
           t.ok(token.accountCreatedAt > 0, 'accountCreatedAt is positive number')
+          t.equal(token.mustVerify, undefined, 'mustVerify is undefined')
           t.equal(token.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
 
           // Fetch the session token with its verification state
@@ -302,6 +303,7 @@ module.exports = function(cfg, server) {
           t.deepEqual(token.emailCode, user.account.emailCode, 'token emailCode same as account emailCode')
           t.ok(token.verifierSetAt, 'verifierSetAt is set to a truthy value')
           t.ok(token.accountCreatedAt > 0, 'accountCreatedAt is positive number')
+          t.equal(!!token.mustVerify, !!user.sessionToken.mustVerify, 'mustVerify is correct')
           t.equal(token.tokenVerificationId, user.sessionToken.tokenVerificationId, 'tokenVerificationId is correct')
 
           // Create a verified session token
@@ -330,6 +332,7 @@ module.exports = function(cfg, server) {
           t.deepEqual(token.emailCode, verifiedUser.account.emailCode, 'token emailCode same as account emailCode')
           t.ok(token.verifierSetAt, 'verifierSetAt is set to a truthy value')
           t.ok(token.accountCreatedAt > 0, 'accountCreatedAt is positive number')
+          t.equal(token.mustVerify, undefined, 'mustVerify is undefined')
           t.equal(token.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
 
           // Fetch the verified session token with its verification state
@@ -352,6 +355,7 @@ module.exports = function(cfg, server) {
           t.deepEqual(token.emailCode, verifiedUser.account.emailCode, 'token emailCode same as account emailCode')
           t.ok(token.verifierSetAt, 'verifierSetAt is set to a truthy value')
           t.ok(token.accountCreatedAt > 0, 'accountCreatedAt is positive number')
+          t.equal(token.mustVerify, null, 'mustVerify is null')
           t.equal(token.tokenVerificationId, null, 'tokenVerificationId is null')
 
           // Attempt to verify a non-existent session token
@@ -384,12 +388,14 @@ module.exports = function(cfg, server) {
           return client.getThen('/sessionToken/' + user.sessionTokenId)
         })
         .then(function(r) {
+          t.equal(r.obj.mustVerify, undefined, 'mustVerify is undefined')
           t.equal(r.obj.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
 
           // Fetch the newly verified session token with its verification state
           return client.getThen('/sessionToken/' + user.sessionTokenId + '/verified')
         })
         .then(function(r) {
+          t.equal(r.obj.mustVerify, null, 'mustVerify is null')
           t.equal(r.obj.tokenVerificationId, null, 'tokenVerificationId is null')
 
           // Attempt to verify the session token again

--- a/fxa-auth-db-server/test/fake.js
+++ b/fxa-auth-db-server/test/fake.js
@@ -57,6 +57,7 @@ module.exports.newUserDataHex = function() {
     uaOS: 'fake OS',
     uaOSVersion: 'fake OS version',
     uaDeviceType: 'fake device type',
+    mustVerify: true,
     tokenVerificationId: hex16()
   }
 

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -99,6 +99,7 @@ module.exports = function (log, error) {
     if (sessionToken.tokenVerificationId) {
       unverifiedTokens[tokenId] = {
         tokenVerificationId: sessionToken.tokenVerificationId,
+        mustVerify: !!sessionToken.mustVerify,
         uid: sessionToken.uid
       }
     }
@@ -513,8 +514,13 @@ module.exports = function (log, error) {
 
     return this.sessionToken(tokenId)
       .then(function (sessionToken) {
-        sessionToken.tokenVerificationId = unverifiedTokens[tokenId] ?
-          unverifiedTokens[tokenId].tokenVerificationId : null
+        if (unverifiedTokens[tokenId]) {
+          sessionToken.mustVerify = unverifiedTokens[tokenId].mustVerify
+          sessionToken.tokenVerificationId = unverifiedTokens[tokenId].tokenVerificationId
+        } else {
+          sessionToken.mustVerify = null
+          sessionToken.tokenVerificationId = null
+        }
         return sessionToken
       })
   }

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -182,8 +182,8 @@ module.exports = function (log, error) {
   // Insert : sessionTokens
   // Values : tokenId = $1, tokenData = $2, uid = $3, createdAt = $4,
   //          uaBrowser = $5, uaBrowserVersion = $6, uaOS = $7, uaOSVersion = $8,
-  //          uaDeviceType = $9, tokenVerificationId = $10
-  var CREATE_SESSION_TOKEN = 'CALL createSessionToken_3(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+  //          uaDeviceType = $9, tokenVerificationId = $10, mustVerify = $11
+  var CREATE_SESSION_TOKEN = 'CALL createSessionToken_4(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
 
   MySql.prototype.createSessionToken = function (tokenId, sessionToken) {
     return this.write(
@@ -198,7 +198,8 @@ module.exports = function (log, error) {
         sessionToken.uaOS,
         sessionToken.uaOSVersion,
         sessionToken.uaDeviceType,
-        sessionToken.tokenVerificationId
+        sessionToken.tokenVerificationId,
+        !!sessionToken.mustVerify
       ]
     )
   }
@@ -348,10 +349,10 @@ module.exports = function (log, error) {
   //          d.id AS deviceId, d.name AS deviceName, d.type AS deviceType, d.createdAt
   //          AS deviceCreatedAt, d.callbackURL AS deviceCallbackURL, d.callbackPublicKey
   //          AS deviceCallbackPublicKey, d.callbackAuthKey AS deviceCallbackAuthKey,
-  //          ut.tokenVerificationId
+  //          ut.tokenVerificationId, ut.mustVerify
   // Where  : t.tokenId = $1 AND t.uid = a.uid AND t.tokenId = d.sessionTokenId AND
   //          t.uid = d.uid AND t.tokenId = u.tokenId
-  var SESSION_DEVICE = 'CALL sessionWithDevice_3(?)'
+  var SESSION_DEVICE = 'CALL sessionWithDevice_4(?)'
 
   MySql.prototype.sessionWithDevice = function (id) {
     return this.readFirstResult(SESSION_DEVICE, [id])
@@ -383,9 +384,9 @@ module.exports = function (log, error) {
   // Fields : t.tokenData, t.uid, t.createdAt, t.uaBrowser, t.uaBrowserVersion,
   //          t.uaOS, t.uaOSVersion, t.uaDeviceType, t.lastAccessTime,
   //          a.emailVerified, a.email, a.emailCode, a.verifierSetAt, a.locale,
-  //          a.createdAt AS accountCreatedAt, ut.tokenVerificationId
+  //          a.createdAt AS accountCreatedAt, ut.tokenVerificationId, ut.mustVerify
   // Where  : t.tokenId = $1 AND t.uid = a.uid AND t.tokenId = ut.tokenId
-  var SESSION_TOKEN_VERIFIED = 'CALL sessionTokenWithVerificationStatus_1(?)'
+  var SESSION_TOKEN_VERIFIED = 'CALL sessionTokenWithVerificationStatus_2(?)'
 
   MySql.prototype.sessionTokenWithVerificationStatus = function (tokenId) {
     return this.readFirstResult(SESSION_TOKEN_VERIFIED, [tokenId])

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the schema/ directory.
-module.exports.level = 28
+module.exports.level = 29

--- a/lib/db/schema/patch-028-029.sql
+++ b/lib/db/schema/patch-028-029.sql
@@ -1,0 +1,148 @@
+--
+-- This migration adds a 'mustVerify' boolean column
+-- to the unverified tokens table, defaulting it to true.
+--
+
+-- Add a 'mustVerify' column to unverifiedTokens table.
+ALTER TABLE `unverifiedTokens`
+ADD COLUMN mustVerify BOOLEAN NOT NULL DEFAULT TRUE,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+-- Update createSessionToken stored procedure to accept `mustVerify` parameter.
+CREATE PROCEDURE `createSessionToken_4` (
+  IN `tokenId` BINARY(32),
+  IN `tokenData` BINARY(32),
+  IN `uid` BINARY(16),
+  IN `createdAt` BIGINT UNSIGNED,
+  IN `uaBrowser` VARCHAR(255),
+  IN `uaBrowserVersion` VARCHAR(255),
+  IN `uaOS` VARCHAR(255),
+  IN `uaOSVersion` VARCHAR(255),
+  IN `uaDeviceType` VARCHAR(255),
+  IN `tokenVerificationId` BINARY(16),
+  IN `mustVerify` BOOLEAN
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  INSERT INTO sessionTokens(
+    tokenId,
+    tokenData,
+    uid,
+    createdAt,
+    uaBrowser,
+    uaBrowserVersion,
+    uaOS,
+    uaOSVersion,
+    uaDeviceType,
+    lastAccessTime
+  )
+  VALUES(
+    tokenId,
+    tokenData,
+    uid,
+    createdAt,
+    uaBrowser,
+    uaBrowserVersion,
+    uaOS,
+    uaOSVersion,
+    uaDeviceType,
+    createdAt
+  );
+
+  IF tokenVerificationId IS NOT NULL THEN
+    INSERT INTO unverifiedTokens(
+      tokenId,
+      tokenVerificationId,
+      uid,
+      mustVerify
+    )
+    VALUES(
+      tokenId,
+      tokenVerificationId,
+      uid,
+      mustVerify
+    );
+  END IF;
+
+  COMMIT;
+END;
+
+-- Alter sessionTokenWithVerificationStatus to report the new field.
+CREATE PROCEDURE `sessionTokenWithVerificationStatus_2` (
+  IN `tokenIdArg` BINARY(32)
+)
+BEGIN
+  SELECT
+    t.tokenData,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.lastAccessTime,
+    a.emailVerified,
+    a.email,
+    a.emailCode,
+    a.verifierSetAt,
+    a.locale,
+    a.createdAt AS accountCreatedAt,
+    ut.tokenVerificationId,
+    ut.mustVerify
+  FROM sessionTokens AS t
+  LEFT JOIN accounts AS a
+    ON t.uid = a.uid
+  LEFT JOIN unverifiedTokens AS ut
+    ON t.tokenId = ut.tokenId
+  WHERE t.tokenId = tokenIdArg;
+END;
+
+-- Update sessionWithDevice to report the new field.
+CREATE PROCEDURE `sessionWithDevice_4` (
+  IN `tokenIdArg` BINARY(32)
+)
+BEGIN
+  SELECT
+    t.tokenData,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.lastAccessTime,
+    a.emailVerified,
+    a.email,
+    a.emailCode,
+    a.verifierSetAt,
+    a.locale,
+    a.createdAt AS accountCreatedAt,
+    d.id AS deviceId,
+    d.name AS deviceName,
+    d.type AS deviceType,
+    d.createdAt AS deviceCreatedAt,
+    d.callbackURL AS deviceCallbackURL,
+    d.callbackPublicKey AS deviceCallbackPublicKey,
+    d.callbackAuthKey AS deviceCallbackAuthKey,
+    ut.tokenVerificationId,
+    ut.mustVerify
+  FROM sessionTokens AS t
+  LEFT JOIN accounts AS a
+    ON t.uid = a.uid
+  LEFT JOIN devices AS d
+    ON (t.tokenId = d.sessionTokenId AND t.uid = d.uid)
+  LEFT JOIN unverifiedTokens AS ut
+    ON t.tokenId = ut.tokenId
+  WHERE t.tokenId = tokenIdArg;
+END;
+
+UPDATE dbMetadata SET value = '29' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-029-028.sql
+++ b/lib/db/schema/patch-029-028.sql
@@ -1,0 +1,9 @@
+-- ALTER TABLE `unverifiedTokens`
+-- DROP COLUMN mustVerify
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- DROP PROCEDURE `createSessionToken_4`;
+-- DROP PROCEDURE `sessionTokenWithVerificationStatus_2`;
+-- DROP PROCEDURE `sessionWithDevice_4`;
+
+-- UPDATE dbMetadata SET value = '28' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
Fixes #151.

@pb @vbudhram here's my sketch for how we might explicitly track whether an unverified sessionToken wanted keys or not.  It will require a corresponding change in the auth-server to send over the new state, which I've added in https://github.com/mozilla/fxa-auth-server/pull/1376.  In particular, see here for how I think we'd want to use it:

  https://github.com/mozilla/fxa-auth-server/pull/1376/files#diff-ab87c506e682e952973178a41792df12R1158

Does this seem like a reasonable path forward?