### PR TITLE
fix(db): ensure that devices get deleted with session tokens

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -183,7 +183,8 @@ EXCEPTION TO NOTES: currently the backend sets `verifierSetAt` to be `Date.now()
 
 ## .deleteAccount(uid) ##
 
-Deletes the account specified by `uid` and deletes all tokens related to this account.
+Deletes the account specified by `uid`
+and all tokens and devices related to this account.
 
 Parameters:
 
@@ -341,6 +342,13 @@ These fields are represented as
 ### .deleteAccountResetToken(tokenId) ###
 
 Will delete the token of the correct type designated by the given `tokenId`.
+For `sessionTokens`,
+associated records in `devices` and `unverifiedTokens`
+will also be deleted.
+For `keyFetchTokens`,
+associated records in `unverifiedTokens`
+will also be deleted.
+
 
 ## .updateSessionToken(tokenId, token) ##
 

--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -962,6 +962,7 @@ Content-Length: 285
 
 This operation is idempotent. If you delete a `tokenId` twice, the same result occurs. In fact, if you delete a
 `tokenId` that doesn't exist, it also returns the same `200 OK` result (since it is already not there).
+Also deletes any device records associated with the session.
 
 ### Example
 

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -195,7 +195,7 @@ module.exports = function(cfg, server) {
   test(
     'session token handling',
     function (t) {
-      t.plan(133)
+      t.plan(141)
       var user = fake.newUserDataHex()
       var verifiedUser = fake.newUserDataHex()
       delete verifiedUser.sessionToken.tokenVerificationId
@@ -455,6 +455,19 @@ module.exports = function(cfg, server) {
           t.equal(token.uaDeviceType, 'different device type', 'uaDeviceType was updated')
           t.equal(token.lastAccessTime, 42, 'lastAccessTime was updated')
 
+          // Create a device
+          return client.putThen('/account/' + user.accountId + '/device/' + user.deviceId, user.device)
+        })
+        .then(function(r) {
+          respOk(t, r)
+
+          // Fetch devices for the account
+          return client.getThen('/account/' + user.accountId + '/devices')
+        })
+        .then(function(r) {
+          respOk(t, r)
+          t.equal(r.obj.length, 1, 'account has one device')
+
           // Delete both session tokens
           return P.all([
             client.delThen('/sessionToken/' + user.sessionTokenId),
@@ -466,6 +479,13 @@ module.exports = function(cfg, server) {
           results.forEach(function (result) {
             respOk(t, result)
           })
+
+          // Fetch devices for the account
+          return client.getThen('/account/' + user.accountId + '/devices')
+        })
+        .then(function(r) {
+          respOk(t, r)
+          t.equal(r.obj.length, 0, 'account has no devices')
 
           // Fetch all of the session tokens for the account
           return client.getThen('/account/' + user.accountId + '/sessions')

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -271,11 +271,31 @@ module.exports = function (log, error) {
 
   Memory.prototype.deleteSessionToken = function (tokenId) {
     tokenId = tokenId.toString('hex')
+    var sessionToken = sessionTokens[tokenId]
 
-    delete unverifiedTokens[tokenId]
-    delete sessionTokens[tokenId]
+    return P.resolve()
+      .then(function () {
+        if (sessionToken) {
+          return getAccountByUid(sessionToken.uid)
+            .then(function (account) {
+              var devices = account.devices
 
-    return P.resolve({})
+              Object.keys(devices).forEach(function (key) {
+                var sessionTokenId = devices[key].sessionTokenId
+
+                if (sessionTokenId && sessionTokenId.toString('hex') === tokenId) {
+                  delete devices[key]
+                }
+              })
+            })
+        }
+      })
+      .then(function () {
+        delete unverifiedTokens[tokenId]
+        delete sessionTokens[tokenId]
+
+        return {}
+      })
   }
 
   Memory.prototype.deleteKeyFetchToken = function (tokenId) {

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -498,9 +498,9 @@ module.exports = function (log, error) {
     return this.write(DELETE_ACCOUNT, [uid])
   }
 
-  // Delete : sessionTokens, unverifiedTokens
+  // Delete : sessionTokens, unverifiedTokens, devices
   // Where  : tokenId = $1
-  var DELETE_SESSION_TOKEN = 'CALL deleteSessionToken_2(?)'
+  var DELETE_SESSION_TOKEN = 'CALL deleteSessionToken_3(?)'
 
   MySql.prototype.deleteSessionToken = function (tokenId) {
     return this.write(DELETE_SESSION_TOKEN, [tokenId])

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the schema/ directory.
-module.exports.level = 29
+module.exports.level = 30

--- a/lib/db/schema/patch-029-30.sql
+++ b/lib/db/schema/patch-029-30.sql
@@ -11,9 +11,13 @@ BEGIN
 
   START TRANSACTION;
 
+  -- The 'devices' table has an index on (uid, sessionTokenId),
+  -- so we have to look up the uid in order to do this efficiently.
+  DELETE FROM devices
+    WHERE sessionTokenId = tokenIdArg
+    AND uid = (SELECT uid FROM sessionTokens WHERE tokenId = tokenIdArg);
   DELETE FROM sessionTokens WHERE tokenId = tokenIdArg;
   DELETE FROM unverifiedTokens WHERE tokenId = tokenIdArg;
-  DELETE FROM devices WHERE sessionTokenId = tokenIdArg;
 
   COMMIT;
 END;

--- a/lib/db/schema/patch-029-30.sql
+++ b/lib/db/schema/patch-029-30.sql
@@ -1,0 +1,23 @@
+-- Update deleteSessionToken stored procedure to delete from devices.
+CREATE PROCEDURE `deleteSessionToken_3` (
+  IN `tokenIdArg` BINARY(32)
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  DELETE FROM sessionTokens WHERE tokenId = tokenIdArg;
+  DELETE FROM unverifiedTokens WHERE tokenId = tokenIdArg;
+  DELETE FROM devices WHERE sessionTokenId = tokenIdArg;
+
+  COMMIT;
+END;
+
+-- Update the patch level.
+UPDATE dbMetadata SET value = '30' WHERE name = 'schema-patch-level';
+

--- a/lib/db/schema/patch-030-029.sql
+++ b/lib/db/schema/patch-030-029.sql
@@ -1,0 +1,4 @@
+-- DROP PROCEDURE `deleteSessionToken_3`;
+
+-- UPDATE dbMetadata SET value = '29' WHERE name = 'schema-patch-level';
+


### PR DESCRIPTION
Fixes mozilla/fxa-auth-server#1423 (although I've found another related problem that we also need to fix, see mozilla/fxa-content-server#4060).

The fix itself is straightforward, just ensuring that we delete any device records inside `deleteSessionToken`. However there is also another change in the migration that may be contentious: I'm explicitly purging all session-less device records.

This is because any such records only exist in our db because of earlier problems with our implementation of device registration. I can think of no legitimate reason for them to exist and we definitely don't want them to show up in anyone's device list.

@rfk, I'm tagging you for the review because of the contentious bit, are you comfortable with us doing that? I know we discussed earlier on about only doing it for placeholder devices but, having given it some further thought, I think we should be more ruthless.