### PR TITLE
fix(db): don't return zombie devices from accountDevices

### DIFF
--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -392,19 +392,25 @@ module.exports = function (log, error) {
     return getAccountByUid(uid)
       .then(
         function(account) {
-          return Object.keys(account.devices).map(
-            function (id) {
-              var device = account.devices[id]
-              var sessionKey = (device.sessionTokenId || '').toString('hex')
-              var session = sessionTokens[sessionKey]
-              if (session) {
-                SESSION_FIELDS.forEach(function (key) {
-                  device[key] = session[key]
-                })
+          return Object.keys(account.devices)
+            .map(
+              function (id) {
+                var device = account.devices[id]
+                var sessionKey = (device.sessionTokenId || '').toString('hex')
+                var session = sessionTokens[sessionKey]
+                if (session) {
+                  SESSION_FIELDS.forEach(function (key) {
+                    device[key] = session[key]
+                  })
+                  return device
+                }
               }
-              return device
-            }
-          )
+            )
+            .filter(
+              function (device) {
+                return !! device
+              }
+            )
         },
         function (err) {
           return []

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -336,7 +336,7 @@ module.exports = function (log, error) {
   //          d.callbackPublicKey, d.callbackAuthKey, s.uaBrowser, s.uaBrowserVersion,
   //          s.uaOS, s.uaOSVersion, s.uaDeviceType, s.lastAccessTime
   // Where  : d.uid = $1
-  var ACCOUNT_DEVICES = 'CALL accountDevices_4(?)'
+  var ACCOUNT_DEVICES = 'CALL accountDevices_5(?)'
 
   MySql.prototype.accountDevices = function (uid) {
     return this.readOneFromFirstResult(ACCOUNT_DEVICES, [uid])

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the schema/ directory.
-module.exports.level = 30
+module.exports.level = 31

--- a/lib/db/schema/patch-030-031.sql
+++ b/lib/db/schema/patch-030-031.sql
@@ -1,0 +1,28 @@
+-- Alter the accountDevices stored procedure to use INNER JOIN instead of
+-- LEFT JOIN. There are zombie device records, we don't care about them.
+CREATE PROCEDURE `accountDevices_5` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  SELECT
+    d.uid,
+    d.id,
+    d.sessionTokenId,
+    d.name,
+    d.type,
+    d.createdAt,
+    d.callbackURL,
+    d.callbackPublicKey,
+    d.callbackAuthKey,
+    s.uaBrowser,
+    s.uaBrowserVersion,
+    s.uaOS,
+    s.uaOSVersion,
+    s.uaDeviceType,
+    s.lastAccessTime
+  FROM devices d INNER JOIN sessionTokens s
+  ON d.sessionTokenId = s.tokenId
+  WHERE d.uid = uidArg;
+END;
+
+UPDATE dbMetadata SET value = '31' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-031-030.sql
+++ b/lib/db/schema/patch-031-030.sql
@@ -1,0 +1,4 @@
+-- DROP PROCEDURE `accountDevices_5`;
+
+-- UPDATE dbMetadata SET value = '30' WHERE name = 'schema-patch-level';
+


### PR DESCRIPTION
Fixes #162.

Possibly this is wrong because I've ploughed the `INNER JOIN` furrow raised in https://github.com/mozilla/fxa-auth-db-mysql/issues/162#issuecomment-243435229, without waiting for feedback. I figured I may as well offer something concrete to discuss.

But more importantly, in implementing it I've realised that this is a tricky feature to test. The problem is that there's no way for the tests to create zombie device records any more.

At first I thought that was fine, it's enough to know that the existing tests aren't broken. But of course it isn't fine AT ALL, because the whole point of making this change is that we need to be sure these zombie records aren't returned to the caller. Even if we opt for returning a `NULL` session token id instead of what I did here, we still won't be able to test it unless we add some special magic for inserting zombie devices.

All I can think of is to create some sort of back-channel stored procedure, *which is not allowed to be invoked by the production code!* That sounds scary but maybe it's fine really because, after all, we have lots of other tests to test what the rest of the code is or isn't doing, so we just need to add some more that assert nothing calls the back-channel.

Anyway, this was weird enough to make me stop, slap the `WIP` label on it and come here to ask the question. @rfk, what do you reckon?