### PR TITLE
refactor(db): Remove account unlock related code.

### DIFF
--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -490,9 +490,9 @@ module.exports = function (log, error) {
   // DELETE
 
   // Delete : sessionTokens, keyFetchTokens, accountResetTokens, passwordChangeTokens,
-  //          passwordForgotTokens, accountUnlockCodes, accounts, devices, unverifiedTokens
+  //          passwordForgotTokens, accounts, devices, unverifiedTokens
   // Where  : uid = $1
-  var DELETE_ACCOUNT = 'CALL deleteAccount_8(?)'
+  var DELETE_ACCOUNT = 'CALL deleteAccount_9(?)'
 
   MySql.prototype.deleteAccount = function (uid) {
     return this.write(DELETE_ACCOUNT, [uid])
@@ -638,7 +638,7 @@ module.exports = function (log, error) {
 
   // Step   : 1
   // Delete : sessionTokens, keyFetchTokens, accountResetTokens, passwordChangeTokens,
-  //          passwordForgotTokens, accountUnlockCodes, devices, unverifiedTokens
+  //          passwordForgotTokens, devices, unverifiedTokens
   // Where  : uid = $1
   //
   // Step   : 2
@@ -675,12 +675,7 @@ module.exports = function (log, error) {
   // Update : accounts
   // Set    : emailVerified = true
   // Where  : uid = $4
-  //
-  // Step   : 4
-  // Delete : accountUnlockCodes
-  // Where  : uid = $4
-  //
-  var FORGOT_PASSWORD_VERIFIED = 'CALL forgotPasswordVerified_4(?, ?, ?, ?, ?)'
+  var FORGOT_PASSWORD_VERIFIED = 'CALL forgotPasswordVerified_5(?, ?, ?, ?, ?)'
 
   MySql.prototype.forgotPasswordVerified = function (tokenId, accountResetToken) {
     return this.write(

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -645,7 +645,7 @@ module.exports = function (log, error) {
   // Update : accounts
   // Set    : verifyHash = $2, authSalt = $3, wrapWrapKb = $4, verifierSetAt = $5, verifierVersion = $6
   // Where  : uid = $1
-  var RESET_ACCOUNT = 'CALL resetAccount_6(?, ?, ?, ?, ?, ?)'
+  var RESET_ACCOUNT = 'CALL resetAccount_7(?, ?, ?, ?, ?, ?)'
 
   MySql.prototype.resetAccount = function (uid, data) {
     return this.write(

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the schema/ directory.
-module.exports.level = 31
+module.exports.level = 32

--- a/lib/db/schema/README.md
+++ b/lib/db/schema/README.md
@@ -32,7 +32,6 @@ To document this, we're trying to keep to the following order though obviously d
 * accountResetTokens
 * passwordChangeTokens
 * passwordForgotTokens
-* accountUnlockCodes
 * accounts
 * eventLog
 

--- a/lib/db/schema/patch-031-032.sql
+++ b/lib/db/schema/patch-031-032.sql
@@ -1,0 +1,83 @@
+-- Update deleteAccount to remove accountUnlockCodes
+CREATE PROCEDURE `deleteAccount_9` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  DELETE FROM sessionTokens WHERE uid = uidArg;
+  DELETE FROM keyFetchTokens WHERE uid = uidArg;
+  DELETE FROM accountResetTokens WHERE uid = uidArg;
+  DELETE FROM passwordChangeTokens WHERE uid = uidArg;
+  DELETE FROM passwordForgotTokens WHERE uid = uidArg;
+  DELETE FROM accounts WHERE uid = uidArg;
+  DELETE FROM devices WHERE uid = uidArg;
+  DELETE FROM unverifiedTokens WHERE uid = uidArg;
+
+  INSERT INTO eventLog(
+    uid,
+    typ,
+    iat
+  )
+  VALUES(
+    uidArg,
+    "delete",
+    UNIX_TIMESTAMP()
+  );
+
+  COMMIT;
+END;
+
+-- Updated to not set lockedAt since it's no longer used.
+CREATE PROCEDURE `forgotPasswordVerified_5` (
+    IN `inPasswordForgotTokenId` BINARY(32),
+    IN `inAccountResetTokenId` BINARY(32),
+    IN `inTokenData` BINARY(32),
+    IN `inUid` BINARY(16),
+    IN `inCreatedAt` BIGINT UNSIGNED
+)
+BEGIN
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        -- ERROR
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    START TRANSACTION;
+
+    -- Since we only ever want one accountResetToken per uid, then we
+    -- do a replace - generally due to a collision on the unique uid field.
+    REPLACE INTO accountResetTokens(
+        tokenId,
+        tokenData,
+        uid,
+        createdAt
+    )
+    VALUES(
+        inAccountResetTokenId,
+        inTokenData,
+        inUid,
+        inCreatedAt
+    );
+
+    DELETE FROM passwordForgotTokens WHERE tokenId = inPasswordForgotTokenId;
+
+    DELETE FROM accountUnlockCodes WHERE uid = inUid;
+
+    UPDATE accounts SET emailVerified = true WHERE uid = inUid;
+
+    COMMIT;
+END;
+
+
+DROP TABLE accountUnlockCodes;
+
+-- Schema patch-level increment.
+UPDATE dbMetadata SET value = '32' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-032-031.sql
+++ b/lib/db/schema/patch-032-031.sql
@@ -1,0 +1,11 @@
+-- -- the codes to unlock an account
+-- CREATE TABLE accountUnlockCodes (
+--   uid BINARY(16) PRIMARY KEY NOT NULL,
+--   unlockCode BINARY(16) NOT NULL
+-- ) ENGINE=InnoDB;
+--
+-- DROP PROCEDURE `forgotPasswordVerified_5`;
+-- DROP PROCEDURE `deleteAccount_9`;
+--
+-- -- Schema patch-level decrement.
+-- UPDATE dbMetadata SET value = '31' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-032-031.sql
+++ b/lib/db/schema/patch-032-031.sql
@@ -4,6 +4,7 @@
 --   unlockCode BINARY(16) NOT NULL
 -- ) ENGINE=InnoDB;
 --
+-- DROP PROCEDURE `resetAccunt_7`;
 -- DROP PROCEDURE `forgotPasswordVerified_5`;
 -- DROP PROCEDURE `deleteAccount_9`;
 --

--- a/lib/db/schema/patch-032-031.sql
+++ b/lib/db/schema/patch-032-031.sql
@@ -4,7 +4,7 @@
 --   unlockCode BINARY(16) NOT NULL
 -- ) ENGINE=InnoDB;
 --
--- DROP PROCEDURE `resetAccunt_7`;
+-- DROP PROCEDURE `resetAccount_7`;
 -- DROP PROCEDURE `forgotPasswordVerified_5`;
 -- DROP PROCEDURE `deleteAccount_9`;
 --


### PR DESCRIPTION
@jrgm thinks that the `lockedAt` column on the account table does not take
up enough space to warrant the effort needed to remove it.

@philbooth - mind having an initial look at this to see if I'm in the right track?