### PR TITLE
Make db_patcher.js compatible with mysql 5.5 (current debian jessie version)

### DIFF
--- a/lib/db/schema/patch-022-023.sql
+++ b/lib/db/schema/patch-022-023.sql
@@ -6,18 +6,15 @@
 -- * Alters three stored procedures, createDevice, updateDevice and
 --   sessionWithDevice to work with the new columns
 
--- 2-steps callbackPublicKey change: we avoid junk values, and we don't block
--- concurent queries.
+-- 2-steps callbackPublicKey change: we avoid junk values
 
 ALTER TABLE devices
 CHANGE callbackPublicKey oldCallbackPublicKey BINARY(32),
 ADD COLUMN callbackPublicKey CHAR(88),
-ADD COLUMN callbackAuthKey CHAR(24),
-ALGORITHM = INPLACE, LOCK = NONE;
+ADD COLUMN callbackAuthKey CHAR(24);
 
 ALTER TABLE devices
-DROP COLUMN oldCallbackPublicKey,
-ALGORITHM = INPLACE, LOCK = NONE;
+DROP COLUMN oldCallbackPublicKey;
 
 CREATE PROCEDURE `accountDevices_4` (
   IN `inUid` BINARY(16)

--- a/lib/db/schema/patch-028-029.sql
+++ b/lib/db/schema/patch-028-029.sql
@@ -5,8 +5,7 @@
 
 -- Add a 'mustVerify' column to unverifiedTokens table.
 ALTER TABLE `unverifiedTokens`
-ADD COLUMN mustVerify BOOLEAN NOT NULL DEFAULT TRUE,
-ALGORITHM = INPLACE, LOCK = NONE;
+ADD COLUMN mustVerify BOOLEAN NOT NULL DEFAULT TRUE;
 
 -- Update createSessionToken stored procedure to accept `mustVerify` parameter.
 CREATE PROCEDURE `createSessionToken_4` (


### PR DESCRIPTION
It removes `ALGORITHM = INPLACE, LOCK = NONE` from `lib/db/schema/patch-022-023.sql` and from `lib/db/schema/patch-028-029.sql`.

I am far from being a mysql expert -  I don't even consider myself a mysql newbie :wink:. This allows me to execute `node bin/db_patcher.js` to create the necessary *fxa* database using mysql 5.5. As far as I understand, this just makes the whole thing slower. If this is so, I don't believe it is a great deal, as this only gets executed once when creating the database.

Of course, I might be wrong and this might break all kinds of stuff. So please, somebody who knows something take a look at this :smile:. That is, if you consider this a nice "feature".

Thank you!

P.S.- This is not needed from 5.6 onwards, but I'd personally prefer not having to install it.

P.P.S- Is it possible to create different statements depending on the mysql version, which could be nice in order to optimise it when a newer version of mysql is available? I haven't been able to find relevant information on the Internet.