### PR TITLE
feat(db): return account.email from accountDevices

### DIFF
--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -652,7 +652,8 @@ Content-Type: application/json
         "uaOS": "Android",
         "uaOSVersion": "5.1",
         "uaDeviceType": "mobile",
-        "lastAccessTime": 1437992394186
+        "lastAccessTime": 1437992394186,
+        "email": "foo@example.org"
     }
 ]
 ```

--- a/fxa-auth-db-server/test/backend/db_tests.js
+++ b/fxa-auth-db-server/test/backend/db_tests.js
@@ -1021,7 +1021,7 @@ module.exports = function(config, DB) {
         test(
           'db.accountDevices',
           function (t) {
-            t.plan(75)
+            t.plan(77)
             var deviceId = newUuid()
             var sessionTokenId = hex32()
             var zombieSessionTokenId = hex32()
@@ -1094,6 +1094,7 @@ module.exports = function(config, DB) {
                 t.equal(device.callbackPublicKey, null, 'callbackPublicKey')
                 t.equal(device.callbackAuthKey, null, 'callbackAuthKey')
                 t.ok(device.lastAccessTime > 0, 'has a lastAccessTime')
+                t.equal(device.email, ACCOUNT.email, 'email should be account email')
 
                 // Fetch the session token with its verification state and device info
                 return db.sessionWithDevice(sessionTokenId)
@@ -1153,6 +1154,7 @@ module.exports = function(config, DB) {
                 t.equal(device.callbackPublicKey, deviceInfo.callbackPublicKey, 'callbackPublicKey')
                 t.equal(device.callbackAuthKey, deviceInfo.callbackAuthKey, 'callbackAuthKey')
                 t.ok(device.lastAccessTime > 0, 'has a lastAccessTime')
+                t.equal(device.email, ACCOUNT.email, 'email should be account email')
 
                 // Create a second session token
                 return db.createSessionToken(newSessionTokenId, SESSION_TOKEN)

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -508,7 +508,7 @@ module.exports = function(cfg, server) {
   test(
     'device handling',
     function (t) {
-      t.plan(61)
+      t.plan(63)
       var user = fake.newUserDataHex()
       var zombieUser = fake.newUserDataHex()
       return client.getThen('/account/' + user.accountId + '/devices')
@@ -536,7 +536,7 @@ module.exports = function(cfg, server) {
           respOk(t, r)
           var devices = r.obj
           t.equal(devices.length, 1, 'devices contains one item')
-          t.equal(Object.keys(devices[0]).length, 15, 'device has fourteen properties')
+          t.equal(Object.keys(devices[0]).length, 16, 'device has sixteen properties')
           t.equal(devices[0].uid, user.accountId, 'uid is correct')
           t.equal(devices[0].id, user.deviceId, 'id is correct')
           t.equal(devices[0].sessionTokenId, user.sessionTokenId, 'sessionTokenId is correct')
@@ -552,6 +552,7 @@ module.exports = function(cfg, server) {
           t.equal(devices[0].uaOSVersion, user.sessionToken.uaOSVersion, 'uaOSVersion is correct')
           t.equal(devices[0].uaDeviceType, user.sessionToken.uaDeviceType, 'uaDeviceType is correct')
           t.equal(devices[0].lastAccessTime, user.sessionToken.createdAt, 'lastAccessTime is correct')
+          t.equal(devices[0].email, user.account.email, 'email is correct')
           return client.postThen('/account/' + user.accountId + '/device/' + user.deviceId + '/update', {
             name: 'wibble',
             type: 'mobile',
@@ -583,6 +584,7 @@ module.exports = function(cfg, server) {
           t.equal(devices[0].uaOSVersion, user.sessionToken.uaOSVersion, 'uaOSVersion is correct')
           t.equal(devices[0].uaDeviceType, user.sessionToken.uaDeviceType, 'uaDeviceType is correct')
           t.equal(devices[0].lastAccessTime, user.sessionToken.createdAt, 'lastAccessTime is correct')
+          t.equal(devices[0].email, user.account.email, 'email is correct')
 
           return client.postThen('/account/' + user.accountId + '/device/' + user.deviceId + '/update', {
             sessionTokenId: zombieUser.sessionTokenId

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -412,6 +412,7 @@ module.exports = function (log, error) {
                   SESSION_FIELDS.forEach(function (key) {
                     device[key] = session[key]
                   })
+                  device.email = account.email
                   return device
                 }
               }

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -333,12 +333,12 @@ module.exports = function (log, error) {
     })
   }
 
-  // Select : devices d, sessionTokens s
+  // Select : devices d, sessionTokens s, accounts a
   // Fields : d.uid, d.id, d.sessionTokenId, d.name, d.type, d.createdAt, d.callbackURL,
   //          d.callbackPublicKey, d.callbackAuthKey, s.uaBrowser, s.uaBrowserVersion,
-  //          s.uaOS, s.uaOSVersion, s.uaDeviceType, s.lastAccessTime
+  //          s.uaOS, s.uaOSVersion, s.uaDeviceType, s.lastAccessTime, a.email
   // Where  : d.uid = $1
-  var ACCOUNT_DEVICES = 'CALL accountDevices_5(?)'
+  var ACCOUNT_DEVICES = 'CALL accountDevices_6(?)'
 
   MySql.prototype.accountDevices = function (uid) {
     return this.readOneFromFirstResult(ACCOUNT_DEVICES, [uid])

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the schema/ directory.
-module.exports.level = 33
+module.exports.level = 34

--- a/lib/db/schema/patch-033-034.sql
+++ b/lib/db/schema/patch-033-034.sql
@@ -1,0 +1,33 @@
+-- Alter the accountDevices stored procedure to INNER JOIN with accounts
+-- so that we can disable devices.lastAccessTime by email address in the
+-- auth server.
+CREATE PROCEDURE `accountDevices_6` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  SELECT
+    d.uid,
+    d.id,
+    d.sessionTokenId,
+    d.name,
+    d.type,
+    d.createdAt,
+    d.callbackURL,
+    d.callbackPublicKey,
+    d.callbackAuthKey,
+    s.uaBrowser,
+    s.uaBrowserVersion,
+    s.uaOS,
+    s.uaOSVersion,
+    s.uaDeviceType,
+    s.lastAccessTime,
+	a.email
+  FROM devices AS d
+  INNER JOIN sessionTokens AS s
+    ON d.sessionTokenId = s.tokenId
+  INNER JOIN accounts AS a
+    ON d.uid = a.uid
+  WHERE d.uid = uidArg;
+END;
+
+UPDATE dbMetadata SET value = '34' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-034-033.sql
+++ b/lib/db/schema/patch-034-033.sql
@@ -1,0 +1,4 @@
+-- DROP PROCEDURE `accountDevices_6`;
+
+-- UPDATE dbMetadata SET value = '33' WHERE name = 'schema-patch-level';
+


### PR DESCRIPTION
This enables us to sample users by email address for the feature flag I'm adding for `device.lastAccessTime` in the auth server (see https://github.com/mozilla/fxa-auth-server/issues/1460).

@vladikoff or @vbudhram, r?