### PR TITLE
fix(security): Fix the endpoints for /securityEvents.

### DIFF
--- a/fxa-auth-db-server/test/backend/db_tests.js
+++ b/fxa-auth-db-server/test/backend/db_tests.js
@@ -1489,7 +1489,7 @@ module.exports = function(config, DB) {
             function query (uid, addr, cb) {
               return function () {
                 return db.securityEvents({
-                  uid: uid,
+                  id: uid,
                   ipAddr: addr
                 })
                 .then(cb)

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -853,7 +853,7 @@ module.exports = function (log, error) {
   }
 
   Memory.prototype.securityEvents = function (where) {
-    var key = where.uid.toString('hex')
+    var key = where.id.toString('hex')
     var events = securityEvents[key] || []
     var addr = where.ipAddr
     if (ip.isV4Format(addr)) {

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -1114,7 +1114,7 @@ module.exports = function (log, error) {
 
   var FETCH_SECURITY_EVENTS = 'CALL fetchSecurityEvents_1(?, ?)'
   MySql.prototype.securityEvents = function (where) {
-    var uid = where.uid
+    var uid = where.id
 
     var ipAddr = ipHmac(this.ipHmacKey, uid, where.ipAddr)
     return this.read(FETCH_SECURITY_EVENTS, [uid, ipAddr])


### PR DESCRIPTION
There were problems with the auth-server integration.
* convert GET /securityEvents to GET /securityEvents/:id/ip/:ipAddr
  to be more RESTful and work with the auth-server's pool get API
* for POST /securityEvents, pass the body and query parameters, fixing the
  former attempt to pass the param's id and body.
* in fxa-auth-db-server/index.js, add 3 helper functions so it's easy to know
  what data is passed to the db methods.

fixes #171 

@rfk, @seanmonstar - r? 
