### PR TITLE
fix(securityEvents): Tweak securityEvents db queries based on @jrgm feedback

### DIFF
--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -518,7 +518,7 @@ module.exports = function (log, error) {
 
   // Delete : unverifiedTokens
   // Where  : tokenVerificationId = $1, uid = $2
-  var VERIFY_TOKENS = 'CALL verifyToken_2(?, ?)'
+  var VERIFY_TOKENS = 'CALL verifyToken_3(?, ?)'
 
   MySql.prototype.verifyTokens = function (tokenVerificationId, accountData) {
     return this.read(VERIFY_TOKENS, [tokenVerificationId, accountData.uid])
@@ -1136,7 +1136,7 @@ module.exports = function (log, error) {
     'account.reset': 3
   }
 
-  var CREATE_SECURITY_EVENT = 'CALL createSecurityEvent_1(?, ?, ?, ?, ?)'
+  var CREATE_SECURITY_EVENT = 'CALL createSecurityEvent_2(?, ?, ?, ?, ?)'
   MySql.prototype.createSecurityEvent = function (data) {
     var uid = data.uid
     var tokenId = data.tokenId

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the schema/ directory.
-module.exports.level = 35
+module.exports.level = 36

--- a/lib/db/schema/patch-035-036.sql
+++ b/lib/db/schema/patch-035-036.sql
@@ -1,0 +1,110 @@
+-- This migration makes two changes to the securityEvents table.
+--
+--  1) Store the tokenVerificationId in the event data, making it
+--     more efficient to mark them as verified because we can use
+--     a direct index lookup.
+--
+--  2) Use an index on (uid, ipAddrHmac, createdAt) to replace the
+--     one on (uid, ipAddrHmac), since we want to sort the results
+--     anyway.
+--
+-- It's a little complicated in order to support forward and backward
+-- compatibility, and it makes an important assumtion:
+--
+--  NB:  we assume that the previous deployment has security events
+--       disabled, and hence that there's no data already in the table.
+--
+
+-- To begin, here's the stuff we need to add.
+-- This is all backwards-compatible, because nothing
+-- is inserting events into the table yet.
+
+ALTER TABLE securityEvents
+ADD COLUMN tokenVerificationId BINARY(16),
+ALGORITHM = INPLACE, LOCK = NONE;
+
+CREATE INDEX securityEvents_uid_tokenVerificationId
+ON securityEvents (uid, tokenVerificationId)
+ALGORITHM = INPLACE LOCK = NONE;
+
+CREATE INDEX securityEvents_uid_ipAddrHmac_createdAt
+ON securityEvents (uid, ipAddrHmac, createdAt)
+ALGORITHM = INPLACE LOCK = NONE;
+
+-- Update createSecurityEvent to insert the `tokenVerificationId`
+-- alongside the other fields.  We must continue writing the
+-- `tokenId` for this deployment, because code from the previous
+-- train can still call  `verifyToken_2`, and that uses `tokenId`
+-- to mark security events as verified.
+
+CREATE PROCEDURE `createSecurityEvent_2` (
+    IN inUid BINARY(16),
+    IN inToken BINARY(32),
+    IN inName INT,
+    IN inIpAddr BINARY(32),
+    IN inCreatedAt BIGINT SIGNED
+)
+BEGIN
+    DECLARE inTokenVerificationId BINARY(16);
+    SET inTokenVerificationId = (
+      SELECT tokenVerificationId
+      FROM unverifiedTokens u
+      WHERE u.uid = inUid AND u.tokenId = inToken
+    );
+    INSERT INTO securityEvents(
+        uid,
+        tokenId,
+        tokenVerificationId,
+        verified,
+        nameId,
+        ipAddrHmac,
+        createdAt
+    )
+    VALUES(
+        inUid,
+        inToken,
+        inTokenVerificationId,
+        inTokenVerificationId IS NULL,
+        inName,
+        inIpAddr,
+        inCreatedAt
+    );
+END;
+
+-- Update `verifyToken` to find security events via
+-- `tokenVerificationId`, which can make proper use of
+-- an index for efficient lookup.
+
+CREATE PROCEDURE `verifyToken_3` (
+  IN `tokenVerificationIdArg` BINARY(16),
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  UPDATE securityEvents
+  SET verified = true
+  WHERE tokenVerificationId = tokenVerificationIdArg
+  AND uid = uidArg;
+
+  DELETE FROM unverifiedTokens
+  WHERE tokenVerificationId = tokenVerificationIdArg
+  AND uid = uidArg;
+END;
+
+-- It's safe to drop the previous index on (uid, ipAddrHmac)
+-- because it's a strict prefix of the one we added above.
+-- Any queries that were using it will just start using the
+-- new one instead.
+
+DROP INDEX securityEvents_uid_ipAddrHmac
+ON securityEvents
+ALGORITHM = INPLACE LOCK = NONE;
+
+-- But it's *not* safe to do the following in the same deployment,
+-- because of the potential for `verifyToken_2` to be called:
+--
+--  * drop the tokenId column, which is replaced by tokenVerificationId
+--  * drop the corresponding securityEvents_uid_tokenId index
+--
+-- We'll need to do these in a follow-up migration.
+
+UPDATE dbMetadata SET value = '36' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-036-035.sql
+++ b/lib/db/schema/patch-036-035.sql
@@ -1,0 +1,22 @@
+-- Rollback to previous logic for securityEvents table.
+
+-- CREATE INDEX securityEvents_uid_ipAddrHmac
+-- ON securityEvents (uid, ipAddrHmac)
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- DROP PROCEDURE `verifyToken_3`
+-- DROP PROCEDURE `createSecurityEvent_2`
+
+-- DROP INDEX securityEvents_uid_tokenVerificationId
+-- ON securityEvents
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- DROP INDEX securityEvents_uid_ipAddrHmac_createdAt
+-- ON securityEvents
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- ALTER TABLE `securityEvents`
+-- DROP COLUMN `tokenVerificationId`
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- UPDATE dbMetadata SET value = '35' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
Here's some proposed tweaks to the DB queries for security events, based on feedback/concerns from @jrgm in https://bugzilla.mozilla.org/show_bug.cgi?id=1304287#c8

* Add `createdAt` to the index we use for fetching the events
* Store the tokenVerificationId on the event, so that we can directly look it up to verify it rather than indirecting through the tokenId.

The fetch query no longer threatens to use a filesort:

```
mysql> explain     SELECT         n.name,         e.verified,         e.createdAt     FROM         securityEvents e     LEFT JOIN securityEventNames n         ON e.nameId = n.id     WHERE         e.uid = unhex('000000111')     AND         e.ipAddr
+----+-------------+-------+------------+--------+-----------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+--------------+------+----------+-------------+
| id | select_type | table | partitions | type   | possible_keys                                                                                             | key                                     | key_len | ref          | rows | filtered | Extra       |
+----+-------------+-------+------------+--------+-----------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+--------------+------+----------+-------------+
|  1 | SIMPLE      | e     | NULL       | ref    | securityEvents_uid_tokenId,securityEvents_uid_tokenVerificationId,securityEvents_uid_ipAddrHmac_createdAt | securityEvents_uid_ipAddrHmac_createdAt | 48      | const,const  |    1 |    10.00 | Using where |
|  1 | SIMPLE      | n     | NULL       | eq_ref | PRIMARY                                                                                                   | PRIMARY                                 | 4       | fxa.e.nameId |    1 |   100.00 | NULL        |
+----+-------------+-------+------------+--------+-----------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+--------------+------+----------+-------------+
```

@seanmonstar r?