### PR TITLE
fix(bufferize): Only bufferize params we explicitly want as buffers.

### DIFF
--- a/fxa-auth-db-server/index.js
+++ b/fxa-auth-db-server/index.js
@@ -43,14 +43,25 @@ function createServer(db) {
   var api = restify.createServer()
   api.use(restify.bodyParser())
   api.use(restify.queryParser())
-  api.use(bufferize.bufferizeRequest.bind(null, [
-    'uaBrowser',
-    'uaBrowserVersion',
-    'uaOS',
-    'uaOSVersion',
-    'uaDeviceType',
-    'unblockCode'
-  ]))
+  api.use(bufferize.bufferizeRequest.bind(null, new Set([
+    // These are all the different params that we handle as binary Buffers,
+    // but are passed into the API as hex strings.
+    'authKey',
+    'authSalt',
+    'data',
+    'deviceId',
+    'emailCode',
+    'id',
+    'kA',
+    'keyBundle',
+    'passCode',
+    'sessionTokenId',
+    'tokenId',
+    'tokenVerificationId',
+    'uid',
+    'verifyHash',
+    'wrapWrapKb'
+  ])))
 
   api.get('/account/:id', withIdAndBody(db.account))
   api.del('/account/:id', withIdAndBody(db.deleteAccount))

--- a/fxa-auth-db-server/lib/bufferize.js
+++ b/fxa-auth-db-server/lib/bufferize.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var HEX_STRING = /^(?:[a-fA-F0-9]{2})+$/
-
 function unbuffer(object) {
   var keys = Object.keys(object)
   for (var i = 0; i < keys.length; i++) {
@@ -15,21 +13,22 @@ function unbuffer(object) {
   return object
 }
 
-function bufferize(object, ignore) {
+function bufferize(object, onlyTheseKeys) {
   var keys = Object.keys(object)
+  if (onlyTheseKeys) {
+    keys = keys.filter(key => onlyTheseKeys.has(key))
+  }
   for (var i = 0; i < keys.length; i++) {
     var key = keys[i]
     var value = object[key]
-    if (ignore.indexOf(key) === -1 && typeof value === 'string' && HEX_STRING.test(value)) {
-      object[key] = Buffer(value, 'hex')
-    }
+    object[key] = new Buffer(value, 'hex')
   }
   return object
 }
 
-function bufferizeRequest(ignore, req, res, next) {
-  if (req.body) { req.body = bufferize(req.body, ignore) }
-  if (req.params) { req.params = bufferize(req.params, ignore) }
+function bufferizeRequest(keys, req, res, next) {
+  if (req.body) { req.body = bufferize(req.body, keys) }
+  if (req.params) { req.params = bufferize(req.params, keys) }
   next()
 }
 

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -112,7 +112,7 @@ module.exports = function(cfg, server) {
     'account not found',
     function (t) {
       t.plan(2)
-      return client.getThen('/account/hello-world')
+      return client.getThen('/account/0123456789ABCDEF0123456789ABCDEF')
         .then(function(r) {
           t.fail('This request should have failed (instead it suceeded)')
         }, function(err) {
@@ -508,7 +508,7 @@ module.exports = function(cfg, server) {
   test(
     'device handling',
     function (t) {
-      t.plan(63)
+      t.plan(69)
       var user = fake.newUserDataHex()
       var zombieUser = fake.newUserDataHex()
       return client.getThen('/account/' + user.accountId + '/devices')
@@ -612,6 +612,20 @@ module.exports = function(cfg, server) {
           var devices = r.obj
           t.equal(devices.length, 1, 'devices contains one item again')
 
+          return client.postThen('/account/' + user.accountId + '/device/' + user.deviceId + '/update', {
+            name: '4a6f686e'
+          })
+        })
+        .then(function(r) {
+          respOk(t, r)
+          return client.getThen('/account/' + user.accountId + '/devices')
+        })
+        .then(function(r) {
+          respOk(t, r)
+          var devices = r.obj
+          t.equal(devices.length, 1, 'devices contains one item again')
+          t.equal(devices[0].name, '4a6f686e', 'name was not automagically bufferized')
+
           return client.delThen('/account/' + user.accountId + '/device/' + user.deviceId)
         })
         .then(function(r) {
@@ -628,7 +642,7 @@ module.exports = function(cfg, server) {
   test(
     'key fetch token handling',
     function (t) {
-      t.plan(43)
+      t.plan(41)
       var user = fake.newUserDataHex()
       user.sessionToken.tokenVerificationId = user.keyFetchToken.tokenVerificationId
       var verifiedUser = fake.newUserDataHex()
@@ -771,18 +785,6 @@ module.exports = function(cfg, server) {
         })
         .then(function (r) {
           t.equal(r.obj.tokenVerificationId, null, 'tokenVerificationId is null')
-
-          // Attempt to verify the verified key fetch token
-          return client.postThen('/tokens/' + verifiedUser.keyFetchToken.tokenVerificationId + '/verify', {
-            uid: user.accountId
-          })
-        })
-        .then(function () {
-          t.fail('Verifying a verified token should have failed')
-        }, function (err) {
-          testNotFound(t, err)
-        })
-        .then(function () {
           // Delete both key fetch tokens
           return P.all([
             client.delThen('/keyFetchToken/' + user.keyFetchTokenId),

--- a/fxa-auth-db-server/test/local/bufferize.js
+++ b/fxa-auth-db-server/test/local/bufferize.js
@@ -7,7 +7,7 @@ var sinon = require('sinon')
 test(
   'bufferize module',
   function (t) {
-    t.plan(38)
+    t.plan(45)
 
     var bufferize = require('../../lib/bufferize')
     t.type(bufferize, 'object', 'bufferize exports object')
@@ -28,13 +28,10 @@ test(
     result = bufferize.bufferize({
       foo: '00',
       bar: 'ffff',
-      baz: '000',
-      qux: 'fg',
-      wibble: '00'
-    }, [ 'wibble' ])
+    })
 
     t.type(result, 'object', 'bufferize.bufferize returned object')
-    t.equal(Object.keys(result).length, 5, 'bufferize.bufferize returned correct number of properties')
+    t.equal(Object.keys(result).length, 2, 'bufferize.bufferize returned correct number of properties')
     t.ok(Buffer.isBuffer(result.foo), 'bufferize.bufferize returned buffer for 00')
     t.equal(result.foo.length, 1, 'bufferize.bufferize returned correct length for 00')
     t.equal(result.foo[0], 0x00, 'bufferize.bufferize returned correct data for 00')
@@ -42,9 +39,23 @@ test(
     t.equal(result.bar.length, 2, 'bufferize.bufferize returned correct length for ffff')
     t.equal(result.bar[0], 0xff, 'bufferize.bufferize returned correct first byte for ffff')
     t.equal(result.bar[1], 0xff, 'bufferize.bufferize returned correct second byte for ffff')
-    t.equal(result.baz, '000', 'bufferize.bufferize preserved string 000')
-    t.equal(result.qux, 'fg', 'bufferize.bufferize preserved string fg')
-    t.equal(result.wibble, '00', 'bufferize.bufferize ignored nominated property')
+
+    result = bufferize.bufferize({
+      foo: '00',
+      bar: 'ffff',
+      wibble: '00'
+    }, new Set(['foo', 'bar']))
+
+    t.type(result, 'object', 'bufferize.bufferize returned object')
+    t.equal(Object.keys(result).length, 3, 'bufferize.bufferize returned correct number of properties')
+    t.ok(Buffer.isBuffer(result.foo), 'bufferize.bufferize returned buffer for 00')
+    t.equal(result.foo.length, 1, 'bufferize.bufferize returned correct length for 00')
+    t.equal(result.foo[0], 0x00, 'bufferize.bufferize returned correct data for 00')
+    t.ok(Buffer.isBuffer(result.bar), 'bufferize.bufferize returned buffer for ffff')
+    t.equal(result.bar.length, 2, 'bufferize.bufferize returned correct length for ffff')
+    t.equal(result.bar[0], 0xff, 'bufferize.bufferize returned correct first byte for ffff')
+    t.equal(result.bar[1], 0xff, 'bufferize.bufferize returned correct second byte for ffff')
+    t.equal(result.wibble, '00', 'bufferize.bufferize ignored property not in match list')
 
     var request = {
       body: {
@@ -58,13 +69,14 @@ test(
       }
     }
     var next = sinon.spy()
-    bufferize.bufferizeRequest([ 'nope', 'n' ], request, {}, next)
+    var keys = new Set(['yes', 'y'])
+    bufferize.bufferizeRequest(keys, request, {}, next)
 
     t.equal(Object.keys(request).length, 2, 'bufferize.bufferizeRequest did not mess with request')
 
     t.equal(Object.keys(request.body).length, 3, 'bufferize.bufferizeRequest did not mess with request.body')
     t.equal(request.body.no, 'badf00d', 'bufferize.bufferizeRequest preserved body string badf00d')
-    t.equal(request.body.nope, 'f00d', 'bufferize.bufferizeRequest ignored nominated body property')
+    t.equal(request.body.nope, 'f00d', 'bufferize.bufferizeRequest ignored body property not in matchlist')
     t.ok(Buffer.isBuffer(request.body.yes), 'bufferize.bufferizeRequest returned buffer for body f00d')
     t.equal(request.body.yes.length, 2, 'bufferize.bufferizeRequest returned correct length for body f00d')
     t.equal(request.body.yes[0], 0xf0, 'bufferize.bufferizeRequest returned correct first byte for body f00d')
@@ -77,7 +89,7 @@ test(
     t.equal(request.params.y[1], 0xad, 'bufferize.bufferizeRequest returned correct second byte for params deadbeef')
     t.equal(request.params.y[2], 0xbe, 'bufferize.bufferizeRequest returned correct third byte for params deadbeef')
     t.equal(request.params.y[3], 0xef, 'bufferize.bufferizeRequest returned correct fourth byte for params deadbeef')
-    t.equal(request.params.n, 'deadbeef', 'bufferize.bufferizeRequest ignored nominated params property')
+    t.equal(request.params.n, 'deadbeef', 'bufferize.bufferizeRequest ignored params not in matchlist')
     t.ok(next.calledOnce, 'bufferize.bufferizeRequest called next')
 
     t.end()


### PR DESCRIPTION
The previous behaviour was to automagically bufferize anything that looked like a hex string, unless it was on an explicit list of "things we don't want as buffers".  A list we've failed to keep up to date.

This changes it to use an explicit list of things that we expect to be buffers, and leave everything else alone.  It removes the guesswork and the associated potential for unexpected foot/bullet
interactions.

To nobody's surprise, this was masking a couple of (thankfully harmless) bugs in our test suite.

@philbooth r?