### PR TITLE
fix(bufferize): Only bufferize params we explicitly want as buffers.

### DIFF
--- a/fxa-auth-db-server/index.js
+++ b/fxa-auth-db-server/index.js
@@ -43,14 +43,25 @@ function createServer(db) {
   var api = restify.createServer()
   api.use(restify.bodyParser())
   api.use(restify.queryParser())
-  api.use(bufferize.bufferizeRequest.bind(null, [
-    'uaBrowser',
-    'uaBrowserVersion',
-    'uaOS',
-    'uaOSVersion',
-    'uaDeviceType',
-    'unblockCode'
-  ]))
+  api.use(bufferize.bufferizeRequest.bind(null, new Set([
+    // These are all the different params that we handle as binary Buffers,
+    // but are passed into the API as hex strings.
+    'authKey',
+    'authSalt',
+    'data',
+    'deviceId',
+    'emailCode',
+    'id',
+    'kA',
+    'keyBundle',
+    'passCode',
+    'sessionTokenId',
+    'tokenId',
+    'tokenVerificationId',
+    'uid',
+    'verifyHash',
+    'wrapWrapKb'
+  ])))
 
   api.get('/account/:id', withIdAndBody(db.account))
   api.del('/account/:id', withIdAndBody(db.deleteAccount))


### PR DESCRIPTION
We had to back out the version of this from #182, due to test bustage in auth-server.  Here's another stab at it incorporating the error cases @vladikoff identified over in #184.

Let's not merge this until we have an auth-server branch with tests fixes, passing against this branch of auth-db-mysql.

@vladikoff r?
