### PR TITLE
fix(email): Return `createdAt` when calling mysql db.emailRecord

### DIFF
--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -454,9 +454,9 @@ module.exports = function (log, error) {
   }
 
   // Select : accounts
-  // Fields : uid, email, normalizedEmail, emailVerified, emailCode, kA, wrapWrapKb, verifierVersion, authSalt, verifierSetAt, lockedAt
+  // Fields : uid, email, normalizedEmail, emailVerified, emailCode, kA, wrapWrapKb, verifierVersion, authSalt, verifierSetAt, createdAt, lockedAt
   // Where  : accounts.normalizedEmail = LOWER($1)
-  var EMAIL_RECORD = 'CALL emailRecord_3(?)'
+  var EMAIL_RECORD = 'CALL emailRecord_4(?)'
 
   MySql.prototype.emailRecord = function (emailBuffer) {
     return this.readFirstResult(EMAIL_RECORD, [emailBuffer.toString('utf8')])

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 43
+module.exports.level = 44

--- a/lib/db/schema/patch-043-044.sql
+++ b/lib/db/schema/patch-043-044.sql
@@ -1,0 +1,27 @@
+-- Update email record to return `createdAt`
+-- emailRecord v4
+CREATE PROCEDURE `emailRecord_4` (
+    IN `inEmail` VARCHAR(255)
+)
+BEGIN
+    SELECT
+        a.uid,
+        a.email,
+        a.normalizedEmail,
+        a.emailVerified,
+        a.emailCode,
+        a.kA,
+        a.wrapWrapKb,
+        a.verifierVersion,
+        a.authSalt,
+        a.verifierSetAt,
+        a.lockedAt,
+        a.createdAt
+    FROM
+        accounts a
+    WHERE
+        a.normalizedEmail = LOWER(inEmail)
+    ;
+END;
+
+UPDATE dbMetadata SET value = '44' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-044-043.sql
+++ b/lib/db/schema/patch-044-043.sql
@@ -1,0 +1,3 @@
+-- DROP PROCEDURE `emailRecord_4`;
+
+-- UPDATE dbMetadata SET value = '43' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
The PR updates the `emailRecord` mysql db call to return its `createdAt` value as well. This matches what the mem db call returns.

Connects with https://github.com/mozilla/fxa-auth-server/issues/1671

@rfk r?
