### PR TITLE
fix(emailBounces): receive the email parameter in the url as hex

### DIFF
--- a/fxa-auth-db-server/index.js
+++ b/fxa-auth-db-server/index.js
@@ -107,7 +107,7 @@ function createServer(db) {
   api.get('/securityEvents/:id/ip/:ipAddr', withParams(db.securityEvents))
   api.post('/securityEvents', withBodyAndQuery(db.createSecurityEvent))
 
-  api.get('/emailBounces/:email', op(req => db.fetchEmailBounces(req.params.email)))
+  api.get('/emailBounces/:id', withIdAndBody(db.fetchEmailBounces))
   api.post('/emailBounces', withBodyAndQuery(db.createEmailBounce))
 
   api.get('/emailRecord/:id', withIdAndBody(db.emailRecord))

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -1142,7 +1142,7 @@ module.exports = function(cfg, server) {
         .then(
           function (r) {
             respOkEmpty(t, r)
-            return client.getThen('/emailBounces/' + email)
+            return client.getThen('/emailBounces/' + Buffer(email).toString('hex'))
           }
         )
         .then(

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -1104,8 +1104,8 @@ module.exports = function (log, error) {
   }
 
   const FETCH_EMAIL_BOUNCES = 'CALL fetchEmailBounces_1(?)'
-  MySql.prototype.fetchEmailBounces = function (email) {
-    return this.read(FETCH_EMAIL_BOUNCES, [email])
+  MySql.prototype.fetchEmailBounces = function (emailBuffer) {
+    return this.read(FETCH_EMAIL_BOUNCES, [emailBuffer.toString('utf8')])
       .then(result => result[0])
   }
 


### PR DESCRIPTION
The auth server hasn't used this route yet, so no coordination dance required. This makes it match `/emailRecord/:id`.