### PR TITLE
fix(security-events): Correctly handle tokenless security events in mem backend

### DIFF
--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -329,7 +329,7 @@ module.exports = function (log, error) {
 
       // update securityEvents table
       (securityEvents[uid] || []).forEach(function (ev) {
-        if (ev.tokenId.toString('hex') === tokenId) {
+        if (ev.tokenId && ev.tokenId.toString('hex') === tokenId) {
           ev.verified = true
         }
       })
@@ -898,7 +898,7 @@ module.exports = function (log, error) {
       addr = '::' + addr
     }
 
-    var verified = (data.tokenId && !unverifiedTokens[data.tokenId.toString('hex')])
+    var verified = !data.tokenId || !unverifiedTokens[data.tokenId.toString('hex')]
 
     var event = {
       createdAt: Date.now(),
@@ -932,7 +932,7 @@ module.exports = function (log, error) {
         createdAt: ev.createdAt,
         verified: ev.verified
       }
-    }))
+    }).reverse())
   }
 
   Memory.prototype.createUnblockCode = function (uid, code) {


### PR DESCRIPTION
The 'account.reset' security event may not be associated with a session token, but we didn't have sufficient test coverage for this.  The mem and mysql backends were handling it differently, and the mem backout would error out in some cases.  This PR:

* Fixes a bug in the mem backend where it might try to dereference an undefined tokenId
* Adds a test that events without a token are *verified* by default, and changes the mem backend to match this behaviour, which was already present in the mysql backend.
* Makes the mem backend return results most-recent-first, matching how the mysql backend does it.

@seanmonstar does this sound correct?