### PR TITLE
feat(email): Add get email endpoint

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -17,6 +17,7 @@ There are a number of methods that a DB storage backend should implement:
 * Accounts (using `email`)
     * .emailRecord(emailBuffer)
     * .accountExists(emailBuffer)
+    * .getEmail(emailBuffer)
 * Session Tokens
     * .createSessionToken(tokenId, sessionToken)
     * .updateSessionToken(tokenId, sessionToken)
@@ -316,6 +317,30 @@ Returns:
     * an empty object `{}`
 * rejects: with one of:
     * `error.notFound()` if no account exists for this email address
+    * any error from the underlying storage engine
+
+## .getEmail(emailBuffer) ##
+
+Get the email entry associated with this `emailBuffer`. This email is located on the secondary email table.
+
+Parameters:
+
+* email: the email address will be a hex encoded string, which is converted back to a string, then `.toLowerCase()`. In
+  the MySql backend we use `LOWER(?)` which uses the current locale for case-folding.
+
+Returns:
+
+* resolves with:
+    * `email` - consisting of:
+        * uid - (Buffer16)
+        * email - (string)
+        * emailCode - (Buffer16)
+        * isPrimary - (boolean)
+        * isVerified - (boolean)
+        * normalizedEmail - (string)        
+        * createdAt - (number)
+* rejects: with one of:
+    * `error.notFound()` if no email address exists on emails table
     * any error from the underlying storage engine
 
 ## Tokens ##

--- a/docs/API.md
+++ b/docs/API.md
@@ -17,7 +17,7 @@ There are a number of methods that a DB storage backend should implement:
 * Accounts (using `email`)
     * .emailRecord(emailBuffer)
     * .accountExists(emailBuffer)
-    * .getEmail(emailBuffer)
+    * .getSecondaryEmail(emailBuffer)
 * Session Tokens
     * .createSessionToken(tokenId, sessionToken)
     * .updateSessionToken(tokenId, sessionToken)
@@ -319,7 +319,7 @@ Returns:
     * `error.notFound()` if no account exists for this email address
     * any error from the underlying storage engine
 
-## .getEmail(emailBuffer) ##
+## .getSecondaryEmail(emailBuffer) ##
 
 Get the email entry associated with this `emailBuffer`. This email is located on the secondary email table.
 

--- a/fxa-auth-db-server/index.js
+++ b/fxa-auth-db-server/index.js
@@ -90,6 +90,12 @@ function createServer(db) {
     })
   )
 
+  api.get('/account/emails/:email',
+    op(function (req) {
+      return db.getEmail(req.params.email)
+    })
+  )
+
   api.get('/sessionToken/:id', withIdAndBody(db.sessionToken))
   api.del('/sessionToken/:id', withIdAndBody(db.deleteSessionToken))
   api.put('/sessionToken/:id', withIdAndBody(db.createSessionToken))

--- a/fxa-auth-db-server/index.js
+++ b/fxa-auth-db-server/index.js
@@ -89,12 +89,7 @@ function createServer(db) {
       return db.deleteEmail(req.params.id, req.params.email)
     })
   )
-
-  api.get('/account/emails/:email',
-    op(function (req) {
-      return db.getEmail(req.params.email)
-    })
-  )
+  api.get('/account/emails/:id', withIdAndBody(db.getEmail))
 
   api.get('/sessionToken/:id', withIdAndBody(db.sessionToken))
   api.del('/sessionToken/:id', withIdAndBody(db.deleteSessionToken))

--- a/fxa-auth-db-server/index.js
+++ b/fxa-auth-db-server/index.js
@@ -89,7 +89,11 @@ function createServer(db) {
       return db.deleteEmail(req.params.id, req.params.email)
     })
   )
-  api.get('/account/emails/:id', withIdAndBody(db.getEmail))
+  api.get('/account/emails/:email',
+    op(function (req) {
+      return db.getSecondaryEmail(Buffer(req.params.email, 'hex'))
+    })
+  )
 
   api.get('/sessionToken/:id', withIdAndBody(db.sessionToken))
   api.del('/sessionToken/:id', withIdAndBody(db.deleteSessionToken))

--- a/fxa-auth-db-server/index.js
+++ b/fxa-auth-db-server/index.js
@@ -89,7 +89,7 @@ function createServer(db) {
       return db.deleteEmail(req.params.id, req.params.email)
     })
   )
-  api.get('/account/emails/:email',
+  api.get('/email/:email',
     op(function (req) {
       return db.getSecondaryEmail(Buffer(req.params.email, 'hex'))
     })

--- a/fxa-auth-db-server/test/backend/db_tests.js
+++ b/fxa-auth-db-server/test/backend/db_tests.js
@@ -2052,7 +2052,7 @@ module.exports = function(config, DB) {
              * 2) Get `accountEmails` only returns email on account table
              * 3) Add an additional email
              * 4) Get `accountEmails` returns both emails
-             * 5) Get `getEmail` returns specified email on email table
+             * 5) Get `getSecondaryEmail` returns specified email on emails table
              * 5) Verify secondary email
              * 6) Get `accountEmails` returns both emails, shows verified
              * 7) Delete secondary email
@@ -2103,7 +2103,7 @@ module.exports = function(config, DB) {
                   t.equal(!!result[1].isVerified, secondEmail.isVerified, 'matches secondEmail isVerified')
 
                   // Get a specific email
-                  return db.getEmail(Buffer(secondEmail.email))
+                  return db.getSecondaryEmail(secondEmail.email)
                 }
               )
               .then(
@@ -2225,7 +2225,7 @@ module.exports = function(config, DB) {
               })
               .then(() => {
                 // Attempt to get a non-existent email
-                return db.getEmail(Buffer('non-existent@email.com'))
+                return db.getSecondaryEmail('non-existent@email.com')
                   .then(() => {
                     t.fail('Failed to not get a non-existent email')
                   })

--- a/fxa-auth-db-server/test/backend/db_tests.js
+++ b/fxa-auth-db-server/test/backend/db_tests.js
@@ -2103,7 +2103,7 @@ module.exports = function(config, DB) {
                   t.equal(!!result[1].isVerified, secondEmail.isVerified, 'matches secondEmail isVerified')
 
                   // Get a specific email
-                  return db.getEmail(secondEmail.email)
+                  return db.getEmail(Buffer(secondEmail.email))
                 }
               )
               .then(
@@ -2225,7 +2225,7 @@ module.exports = function(config, DB) {
               })
               .then(() => {
                 // Attempt to get a non-existent email
-                return db.getEmail('non-existent@email.com')
+                return db.getEmail(Buffer('non-existent@email.com'))
                   .then(() => {
                     t.fail('Failed to not get a non-existent email')
                   })

--- a/fxa-auth-db-server/test/backend/db_tests.js
+++ b/fxa-auth-db-server/test/backend/db_tests.js
@@ -2052,6 +2052,7 @@ module.exports = function(config, DB) {
              * 2) Get `accountEmails` only returns email on account table
              * 3) Add an additional email
              * 4) Get `accountEmails` returns both emails
+             * 5) Get `getEmail` returns specified email on email table
              * 5) Verify secondary email
              * 6) Get `accountEmails` returns both emails, shows verified
              * 7) Delete secondary email
@@ -2100,6 +2101,16 @@ module.exports = function(config, DB) {
                   t.equal(result[1].email, secondEmail.email, 'matches secondEmail email')
                   t.equal(!!result[1].isPrimary, false, 'isPrimary is false on secondEmail email')
                   t.equal(!!result[1].isVerified, secondEmail.isVerified, 'matches secondEmail isVerified')
+
+                  // Get a specific email
+                  return db.getEmail(secondEmail.email)
+                }
+              )
+              .then(
+                function(result) {
+                  t.equal(result.email, secondEmail.email, 'matches secondEmail email')
+                  t.equal(!!result.isPrimary, false, 'isPrimary is false on secondEmail email')
+                  t.equal(!!result.isVerified, secondEmail.isVerified, 'matches secondEmail isVerified')
 
                   // Verify second email
                   return db.verifyEmail(secondEmail.uid, secondEmail.emailCode)
@@ -2155,6 +2166,7 @@ module.exports = function(config, DB) {
                    * 1) Can not add an an email that exits in emails table or accounts table
                    * 2) Can not delete primary email
                    * 3) Can not create an new account that has an email in the emails table
+                   * 4) Can not get non-existent secondary email
                    */
 
                   // Attempt to add the account email to the emails table.
@@ -2209,6 +2221,17 @@ module.exports = function(config, DB) {
                   .catch(function (err) {
                     t.equal(err.errno, 101, 'should return duplicate entry errno')
                     t.equal(err.code, 409, 'should return duplicate entry code')
+                  })
+              })
+              .then(() => {
+                // Attempt to get a non-existent email
+                return db.getEmail('non-existent@email.com')
+                  .then(() => {
+                    t.fail('Failed to not get a non-existent email')
+                  })
+                  .catch((err) => {
+                    t.equal(err.errno, 116, 'should return not found errno')
+                    t.equal(err.code, 404, 'should return not found code')
                   })
               })
               .then(

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -201,7 +201,7 @@ module.exports = function(cfg, server) {
           t.equal(!!result[0].isVerified, !!user.account.emailVerified, 'matches account emailVerified')
 
           // Attempt to get a specific email
-          return client.getThen('/account/emails/' + thirdEmailRecord.email)
+          return client.getThen('/account/emails/' + emailToHex(thirdEmailRecord.email))
         })
         .then(function (r) {
           respOk(t, r)

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -201,7 +201,7 @@ module.exports = function(cfg, server) {
           t.equal(!!result[0].isVerified, !!user.account.emailVerified, 'matches account emailVerified')
 
           // Attempt to get a specific secondary email
-          return client.getThen('/account/emails/' + emailToHex(thirdEmailRecord.email))
+          return client.getThen('/email/' + emailToHex(thirdEmailRecord.email))
         })
         .then(function (r) {
           respOk(t, r)

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -122,7 +122,7 @@ module.exports = function(cfg, server) {
   )
 
   test(
-    'add account, add email, get emails, delete email',
+    'add account, add email, get email, get emails, delete email',
     function (t) {
       var user = fake.newUserDataHex()
       var secondEmailRecord = user.email
@@ -195,10 +195,21 @@ module.exports = function(cfg, server) {
           respOk(t, r)
 
           var result = r.obj
-          t.equal(result.length, 2, 'one email returned')
+          t.equal(result.length, 2, 'two emails returned')
           t.equal(result[0].email, user.account.email, 'matches account email')
           t.equal(!!result[0].isPrimary, true, 'isPrimary is true on account email')
           t.equal(!!result[0].isVerified, !!user.account.emailVerified, 'matches account emailVerified')
+
+          // Attempt to get a specific email
+          return client.getThen('/account/emails/' + thirdEmailRecord.email)
+        })
+        .then(function (r) {
+          respOk(t, r)
+
+          var result = r.obj
+          t.equal(result.email, thirdEmailRecord.email, 'matches email')
+          t.equal(!!result.isPrimary, false, 'isPrimary is false on email')
+          t.equal(!!result.isVerified, !!thirdEmailRecord.emailVerified, 'matches emailVerified')
         })
     }
   )

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -122,7 +122,7 @@ module.exports = function(cfg, server) {
   )
 
   test(
-    'add account, add email, get email, get emails, delete email',
+    'add account, add email, get secondary email, get emails, delete email',
     function (t) {
       var user = fake.newUserDataHex()
       var secondEmailRecord = user.email
@@ -200,7 +200,7 @@ module.exports = function(cfg, server) {
           t.equal(!!result[0].isPrimary, true, 'isPrimary is true on account email')
           t.equal(!!result[0].isVerified, !!user.account.emailVerified, 'matches account emailVerified')
 
-          // Attempt to get a specific email
+          // Attempt to get a specific secondary email
           return client.getThen('/account/emails/' + emailToHex(thirdEmailRecord.email))
         })
         .then(function (r) {

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -1016,7 +1016,7 @@ module.exports = function (log, error) {
     return P.resolve({})
   }
 
-  Memory.prototype.getEmail = function (emailBuffer) {
+  Memory.prototype.getSecondaryEmail = function (emailBuffer) {
     const normalizedEmail = emailBuffer.toString('utf8').toLowerCase()
 
     if (emails[normalizedEmail]) {

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -1016,8 +1016,8 @@ module.exports = function (log, error) {
     return P.resolve({})
   }
 
-  Memory.prototype.getEmail = function (email) {
-    const normalizedEmail = email.toLowerCase()
+  Memory.prototype.getEmail = function (emailBuffer) {
+    const normalizedEmail = emailBuffer.toString('utf8').toLowerCase()
 
     if (emails[normalizedEmail]) {
       return P.resolve(emails[normalizedEmail])

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -1016,6 +1016,16 @@ module.exports = function (log, error) {
     return P.resolve({})
   }
 
+  Memory.prototype.getEmail = function (email) {
+    const normalizedEmail = email.toLowerCase()
+
+    if (emails[normalizedEmail]) {
+      return P.resolve(emails[normalizedEmail])
+    } else {
+      return P.reject(error.notFound())
+    }
+  }
+
   Memory.prototype.accountEmails = function (uid) {
     var userEmails = []
 

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -779,9 +779,9 @@ module.exports = function (log, error) {
 
   // Get : email
   // Values : email = $1
-  var GET_EMAIL = 'CALL getEmail_1(?)'
-  MySql.prototype.getEmail = function (emailBuffer) {
-    return this.readFirstResult(GET_EMAIL, [emailBuffer.toString('utf8')])
+  var GET_SECONDARY_EMAIL = 'CALL getSecondaryEmail_1(?)'
+  MySql.prototype.getSecondaryEmail = function (emailBuffer) {
+    return this.readFirstResult(GET_SECONDARY_EMAIL, [emailBuffer.toString('utf8')])
   }
 
   // Select : emails

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -777,6 +777,13 @@ module.exports = function (log, error) {
     )
   }
 
+  // Get : email
+  // Values : normalizedEmail = $1
+  var GET_EMAIL = 'CALL getEmail_1(?)'
+  MySql.prototype.getEmail = function (email) {
+    return this.readFirstResult(GET_EMAIL, [email])
+  }
+
   // Select : emails
   // Values : uid = $1
   var ACCOUNT_EMAILS = 'CALL accountEmails_1(?)'

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -778,10 +778,10 @@ module.exports = function (log, error) {
   }
 
   // Get : email
-  // Values : normalizedEmail = $1
+  // Values : email = $1
   var GET_EMAIL = 'CALL getEmail_1(?)'
-  MySql.prototype.getEmail = function (email) {
-    return this.readFirstResult(GET_EMAIL, [email])
+  MySql.prototype.getEmail = function (emailBuffer) {
+    return this.readFirstResult(GET_EMAIL, [emailBuffer.toString('utf8')])
   }
 
   // Select : emails

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 46
+module.exports.level = 47

--- a/lib/db/schema/patch-046-047.sql
+++ b/lib/db/schema/patch-046-047.sql
@@ -1,6 +1,7 @@
--- Add ability to get a specific email
+-- Add ability to get a specific email on the emails table
+-- Differs from `emailRecord` that returns a filtered account object
 
-CREATE PROCEDURE `getEmail_1` (
+CREATE PROCEDURE `getSecondaryEmail_1` (
     IN `email` VARCHAR(255)
 )
 BEGIN

--- a/lib/db/schema/patch-046-047.sql
+++ b/lib/db/schema/patch-046-047.sql
@@ -1,0 +1,10 @@
+-- Add ability to get a specific email
+
+CREATE PROCEDURE `getEmail_1` (
+    IN `email` VARCHAR(255)
+)
+BEGIN
+    SELECT * FROM emails WHERE normalizedEmail = LOWER(email);
+END;
+
+UPDATE dbMetadata SET value = '47' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-047-046.sql
+++ b/lib/db/schema/patch-047-046.sql
@@ -1,3 +1,3 @@
--- DROP PROCEDURE `getEmail_1`;
+-- DROP PROCEDURE `getSecondaryEmail_1`;
 
 -- UPDATE dbMetadata SET value = '46' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-047-046.sql
+++ b/lib/db/schema/patch-047-046.sql
@@ -1,0 +1,3 @@
+-- DROP PROCEDURE `getEmail_1`;
+
+-- UPDATE dbMetadata SET value = '46' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
This PR adds the `getEmail` endpoint. It will be used only by the auth-server to get a single email on the secondary table, which will then let the it intelligently choose how to proceed on login (display correct error message) or account create (display email unavailable).

Fixes #226 

@mozilla/fxa-devs r?