### PR TITLE
fix(email): Use correct delete account procedure

### DIFF
--- a/fxa-auth-db-server/test/backend/db_tests.js
+++ b/fxa-auth-db-server/test/backend/db_tests.js
@@ -2180,11 +2180,22 @@ module.exports = function(config, DB) {
                     .then(function () {
                       testAccount.email = testSecondaryEmail.email
                       testAccount.normalizedEmail = testSecondaryEmail.normalizedEmail
+
+                      // Create new account with secondary email that was deleted
                       return db.createAccount(testAccount.uid, testAccount)
                         .catch(t.fail)
                     })
                     .then(function (res) {
                       t.deepEqual(res, {}, 'successfully created an account')
+
+                      // Attempt to create secondary email address
+                      return db.createEmail(testAccount.uid, testSecondaryEmail)
+                        .then(() => {
+                          t.fail(new Error('Should not have created secondary email'))
+                        })
+                        .catch((err) => {
+                          t.equal(err.errno, 101, 'Correct errno')
+                        })
                     })
                 }
               )

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -514,9 +514,9 @@ module.exports = function (log, error) {
   // DELETE
 
   // Delete : sessionTokens, keyFetchTokens, accountResetTokens, passwordChangeTokens,
-  //          passwordForgotTokens, accounts, devices, unverifiedTokens
+  //          passwordForgotTokens, accounts, devices, unverifiedTokens, emails
   // Where  : uid = $1
-  var DELETE_ACCOUNT = 'CALL deleteAccount_11(?)'
+  var DELETE_ACCOUNT = 'CALL deleteAccount_12(?)'
 
   MySql.prototype.deleteAccount = function (uid) {
     return this.write(DELETE_ACCOUNT, [uid])


### PR DESCRIPTION
This PR fixes the issue where secondary emails were not being deleted from the emails table when the account was delete. This caused new account creation to fail if they attempted to use an email in the secondary table. The procedure was [created](https://github.com/mozilla/fxa-auth-db-mysql/blob/master/lib/db/schema/patch-045-046.sql#L152) but the call in mysql was not updated it use it >.<

@mozilla/fxa-devs r?

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1362589.