### PR TITLE
MySQL old_passwords compatibility: Add 'insecureAuth' config parameter.

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -109,6 +109,11 @@ module.exports = function (fs, path, url, convict) {
         format: 'nat',
         env: 'MYSQL_QUEUE_LIMIT',
       },
+      insecureAuth: {
+        doc: 'Use old_passwords auth to connect to MySql',
+        default: false,
+        env: 'MYSQL_INSECURE_AUTH',
+      }
     },
     slave: {
       user: {
@@ -155,6 +160,11 @@ module.exports = function (fs, path, url, convict) {
         format: 'nat',
         env: 'MYSQL_SLAVE_QUEUE_LIMIT',
       },
+      insecureAuth: {
+        doc: 'Use old_passwords auth to connect to MySql',
+        default: false,
+        env: 'MYSQL_SLAVE_INSECURE_AUTH',
+      }
     },
     ipHmacKey: {
       doc: 'A secret to hash IP addresses for security history events',


### PR DESCRIPTION
This allows to use mysql databases that for some reason cannot change to old_passwords = 0.

It adds the insecureAuth param to the MySQL config and allows to set it using an ENV variable to make it easy to change it from the servers.json file.

Its default value is false, so if not set, everything should behave like up until now.
