### PR TITLE
feat(signinCodes): migration and endpoints for signinCodes table

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -50,6 +50,11 @@ There are a number of methods that a DB storage backend should implement:
     * .fetchReminders(body, query)
     * .deleteReminder(body)
 * Email Bounces
+    * .createEmailBounce(body)
+* Signin codes
+    * .createSigninCode(code, uid, createdAt)
+    * .useSigninCode(code)
+    * .expireSigninCodes(olderThan)
 * General
     * .ping()
     * .close()
@@ -64,6 +69,7 @@ is shown afterwards.
 * number - a number (integer only)
 * string - a string of undetermined length
 * Buffer - a Buffer of undetermined length
+* Buffer6 - a Buffer of length 6 bytes
 * Buffer16 - a Buffer of length 16 bytes
 * Buffer32 - a Buffer of length 32 bytes
 * Buffer64 - a Buffer of length 64 bytes
@@ -588,4 +594,37 @@ Parameters:
   * bounceType: The bounce type ([`'Permanent'`, `'Transient'`, `'Complaint'`])
   * bounceSubType: The bounce sub type string
 
-(Ends)
+## .createSigninCode(code, uid, createdAt)
+
+Create a user-specific, time-limited, single-use code
+that can be used for expedited sign-in.
+
+Parameters:
+
+* `code` (Buffer6):
+  The value of the code
+* `uid` (Buffer16):
+  The uid for the relevant user
+* `createdAt` (number):
+  Creation timestamp for the code, milliseconds since the epoch
+
+## .useSigninCode(code)
+
+Use (and delete) a sign-in code.
+
+Parameters:
+
+* `code` (Buffer6):
+  The value of the code
+
+## .expireSigninCodes(olderThan)
+
+Delete expired sign-in codes.
+
+Parameters:
+
+* `olderThan` (number):
+  Threshold timestamp for deletion,
+  if `createdAt` is less than this number
+  the sign-in code will be deleted.
+

--- a/docs/API.md
+++ b/docs/API.md
@@ -69,7 +69,6 @@ is shown afterwards.
 * number - a number (integer only)
 * string - a string of undetermined length
 * Buffer - a Buffer of undetermined length
-* Buffer6 - a Buffer of length 6 bytes
 * Buffer16 - a Buffer of length 16 bytes
 * Buffer32 - a Buffer of length 32 bytes
 * Buffer64 - a Buffer of length 64 bytes
@@ -601,7 +600,7 @@ that can be used for expedited sign-in.
 
 Parameters:
 
-* `code` (Buffer6):
+* `code` (Buffer):
   The value of the code
 * `uid` (Buffer16):
   The uid for the relevant user
@@ -614,7 +613,7 @@ Use (and delete) a sign-in code.
 
 Parameters:
 
-* `code` (Buffer6):
+* `code` (Buffer):
   The value of the code
 
 ## .expireSigninCodes(olderThan)

--- a/docs/API.md
+++ b/docs/API.md
@@ -53,7 +53,7 @@ There are a number of methods that a DB storage backend should implement:
     * .createEmailBounce(body)
 * Signin codes
     * .createSigninCode(code, uid, createdAt)
-    * .useSigninCode(code)
+    * .consumeSigninCode(code)
     * .expireSigninCodes(olderThan)
 * General
     * .ping()
@@ -608,7 +608,7 @@ Parameters:
 * `createdAt` (number):
   Creation timestamp for the code, milliseconds since the epoch
 
-## .useSigninCode(code)
+## .consumeSigninCode(code)
 
 Use (and delete) a sign-in code.
 

--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -35,10 +35,10 @@ All responses conform to the following:
 The following datatypes are used throughout this document:
 
 * epoch     : the date in ms since epoch. eg. 1424819640738 such as that returned from `Date.now()`
-* hex48     : a 48 bit value in hex encoding. ie. 12 chars long (6 bytes)
 * hex128    : a 128 bit value in hex encoding. ie. 32 chars long (16 bytes)
 * hex256    : a 256 bit value in hex encoding. ie. 64 chars long (32 bytes)
 * hex768    : a 768 bit value in hex encoding. ie. 192 chars long (96 bytes)
+* hex       : a hex string representing n bytes of binary data.
 * string255 : a string up to 255 characters/bytes long
 
 # Operations
@@ -1786,7 +1786,7 @@ curl \
 
 * Method : `PUT`
 * Path : `/signinCodes/<code>
-    * `code` : hex48
+    * `code` : hex
 * Params:
     * `uid` : hex128
 	* `createdAt` : epoch
@@ -1852,7 +1852,7 @@ Content-Length: 2
 
 * Method : `DELETE`
 * Path : `/signinCodes/<code>
-    * `code` : hex48
+    * `code` : hex
 
 ## expireSigninCodes : `DELETE /signinCodes/expire/:olderThan`
 

--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -93,7 +93,7 @@ The following datatypes are used throughout this document:
     * verifyTokens              : `POST /tokens/:tokenVerificationId/verify`
 * Sign-in codes
     * createSigninCode          : `PUT /signinCodes/:code`
-    * useSigninCode             : `DELETE /signinCodes/:code`
+    * consumeSigninCode         : `DELETE /signinCodes/:code`
     * expireSigninCodes         : `DELETE /signinCodes/expire/:olderThan`
 
 ## Ping : `GET /`
@@ -1813,7 +1813,7 @@ Content-Length: 2
     * Content-Type : `application/json`
     * Body : `{"code":"InternalError","message":"..."}`
 
-## useSigninCode : `DELETE /signinCodes/:code`
+## consumeSigninCode : `DELETE /signinCodes/:code`
 
 Use a sign-in code.
 

--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -1833,12 +1833,12 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Content-Length: 2
 
-{}
+{"email":"foo@example.com"}
 ```
 
 * Status Code : `200 OK`
     * Content-Type : `application/json`
-    * Body : `{}`
+    * Body : `{"email":"foo@example.com"}`
 * Status Code : 404 Not Found
     * Conditions: if the specified sign-in code doesn't exist
     * Content-Type : `application/json`
@@ -1870,7 +1870,7 @@ curl \
 ### Request
 
 * Method : `DELETE`
-* Path : `/signinCodes/<olderThan>
+* Path : `/signinCodes/expire/<olderThan>
     * `olderThan` : epoch
 
 ### Response

--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -35,7 +35,7 @@ All responses conform to the following:
 The following datatypes are used throughout this document:
 
 * epoch     : the date in ms since epoch. eg. 1424819640738 such as that returned from `Date.now()`
-* hex48     : a 64 bit value in hex encoding. ie. 12 chars long (6 bytes)
+* hex48     : a 48 bit value in hex encoding. ie. 12 chars long (6 bytes)
 * hex128    : a 128 bit value in hex encoding. ie. 32 chars long (16 bytes)
 * hex256    : a 256 bit value in hex encoding. ie. 64 chars long (32 bytes)
 * hex768    : a 768 bit value in hex encoding. ie. 192 chars long (96 bytes)

--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -35,6 +35,7 @@ All responses conform to the following:
 The following datatypes are used throughout this document:
 
 * epoch     : the date in ms since epoch. eg. 1424819640738 such as that returned from `Date.now()`
+* hex48     : a 64 bit value in hex encoding. ie. 12 chars long (6 bytes)
 * hex128    : a 128 bit value in hex encoding. ie. 32 chars long (16 bytes)
 * hex256    : a 256 bit value in hex encoding. ie. 64 chars long (32 bytes)
 * hex768    : a 768 bit value in hex encoding. ie. 192 chars long (96 bytes)
@@ -62,34 +63,38 @@ The following datatypes are used throughout this document:
 * Devices:
     * createDevice              : `PUT /account/:id/device/:deviceId`
     * updateDevice              : `POST /account/:id/device/:deviceId/update`
-    * deleteDevice              : `DEL /account/:id/device/:deviceId`
+    * deleteDevice              : `DELETE /account/:id/device/:deviceId`
 * Session Tokens:
     * sessionToken              : `GET /sessionToken/:id`
     * sessionTokenWithVerificationStatus : `GET /sessionToken/:id/verified`
     * sessionWithDevice         : `GET /sessionToken/:id/device`
-    * deleteSessionToken        : `DEL /sessionToken/:id`
+    * deleteSessionToken        : `DELETE /sessionToken/:id`
     * createSessionToken        : `PUT /sessionToken/:id`
     * updateSessionToken        : `POST /sessionToken/:id/update`
 * Account Reset Tokens:
     * accountResetToken         : `GET /accountResetToken/:id`
-    * deleteAccountResetToken   : `DEL /accountResetToken/:id`
+    * deleteAccountResetToken   : `DELETE /accountResetToken/:id`
 * Key Fetch Tokens:
     * keyFetchToken             : `GET /keyFetchToken/:id`
     * keyFetchTokenWithVerificationStatus : `GET /keyFetchToken/:id/verified`
-    * deleteKeyFetchToken       : `DEL /keyFetchToken/:id`
+    * deleteKeyFetchToken       : `DELETE /keyFetchToken/:id`
     * createKeyFetchToken       : `PUT /keyFetchToken/:id`
 * Password Change Tokens:
     * passwordChangeToken       : `GET /passwordChangeToken/:id`
-    * deletePasswordChangeToken : `DEL /passwordChangeToken/:id`
+    * deletePasswordChangeToken : `DELETE /passwordChangeToken/:id`
     * createPasswordChangeToken : `PUT /passwordChangeToken/:id`
 * Password Forgot Tokens:
     * passwordForgotToken       : `GET /passwordForgotToken/:id`
-    * deletePasswordForgotToken : `DEL /passwordForgotToken/:id`
+    * deletePasswordForgotToken : `DELETE /passwordForgotToken/:id`
     * createPasswordForgotToken : `PUT /passwordForgotToken/:id`
     * updatePasswordForgotToken : `POST /passwordForgotToken/:id/update`
     * forgotPasswordVerified    : `POST /passwordForgotToken/:id/verified`
 * Unverified tokens:
     * verifyTokens              : `POST /tokens/:tokenVerificationId/verify`
+* Sign-in codes
+    * createSigninCode          : `PUT /signinCodes/:code`
+    * useSigninCode             : `DELETE /signinCodes/:code`
+    * expireSigninCodes         : `DELETE /signinCodes/expire/:olderThan`
 
 ## Ping : `GET /`
 
@@ -809,7 +814,7 @@ Content-Type: application/json
     * Content-Type : 'application/json'
     * Body : `{"code":"InternalError","message":"...<message related to the error>..."}`
 
-## deleteDevice : `DEL /account/<uid>/device/<deviceId>`
+## deleteDevice : `DELETE /account/<uid>/device/<deviceId>`
 
 ### Example
 
@@ -1008,7 +1013,7 @@ Content-Length: 285
     * Content-Type : 'application/json'
     * Body : `{"code":"InternalError","message":"...<message related to the error>..."}`
 
-## deleteSessionToken : `DEL /sessionToken/<tokenId>`
+## deleteSessionToken : `DELETE /sessionToken/<tokenId>`
 
 This operation is idempotent. If you delete a `tokenId` twice, the same result occurs. In fact, if you delete a
 `tokenId` that doesn't exist, it also returns the same `200 OK` result (since it is already not there).
@@ -1099,7 +1104,7 @@ Content-Length: 177
     * Body : `{"code":"InternalError","message":"...<message related to the error>..."}`
 
 
-## deleteAccountResetToken : `DEL /accountResetToken/<tokenId>`
+## deleteAccountResetToken : `DELETE /accountResetToken/<tokenId>`
 
 This operation is idempotent. If you delete a `tokenId` twice, the same result occurs. In fact, if you delete a
 `tokenId` that doesn't exist, it also returns the same `200 OK` result (since it is already not there).
@@ -1289,7 +1294,7 @@ Content-Length: 399
     * Content-Type : 'application/json'
     * Body : `{"code":"InternalError","message":"...<message related to the error>..."}`
 
-## deleteKeyFetchToken : `DEL /keyFetchToken/<tokenId>`
+## deleteKeyFetchToken : `DELETE /keyFetchToken/<tokenId>`
 
 This operation is idempotent. If you delete a `tokenId` twice, the same result occurs. In fact, if you delete a
 `tokenId` that doesn't exist, it also returns the same `200 OK` result (since it is already not there).
@@ -1425,7 +1430,7 @@ Content-Length: 177
     * Body : `{"code":"InternalError","message":"...<message related to the error>..."}`
 
 
-## deletePasswordChangeToken : `DEL /passwordChangeToken/<tokenId>`
+## deletePasswordChangeToken : `DELETE /passwordChangeToken/<tokenId>`
 
 This operation is idempotent. If you delete a `tokenId` twice, the same result occurs. In fact, if you delete a
 `tokenId` that doesn't exist, it also returns the same `200 OK` result (since it is already not there).
@@ -1567,7 +1572,7 @@ Content-Length: 259
     * Content-Type : 'application/json'
     * Body : `{"code":"InternalError","message":"...<message related to the error>..."}`
 
-## deletePasswordForgotToken : `DEL /passwordForgotToken/<tokenId>`
+## deletePasswordForgotToken : `DELETE /passwordForgotToken/<tokenId>`
 
 This operation is idempotent. If you delete a `tokenId` twice, the same result occurs. In fact, if you delete a
 `tokenId` that doesn't exist, it also returns the same `200 OK` result (since it is already not there).
@@ -1760,4 +1765,129 @@ Content-Length: 2
     * Content-Type : 'application/json'
     * Body : {"code":"InternalError","message":"...<message related to the error>..."}
 ```
+
+## createSigninCode : `PUT /signinCodes/:code`
+
+Create a user-specific, time-limited, single-use code
+that can be used for expedited sign-in.
+
+### Example
+
+```
+curl \
+    -v \
+    -X PUT \
+    -H "Content-Type: application/json" \
+    -d '{"uid":"fdea27c8188b3d980a28917bc1399e47","createdAt":1494253830983}' \
+    http://localhost:8000/signinCodes/1234567890ab
+```
+
+### Request
+
+* Method : `PUT`
+* Path : `/signinCodes/<code>
+    * `code` : hex48
+* Params:
+    * `uid` : hex128
+	* `createdAt` : epoch
+
+### Response
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 2
+
+{}
+```
+
+* Status Code : `200 OK`
+    * Content-Type : `application/json`
+    * Body : `{}`
+* Status Code : `409 Conflict`
+    * Conditions: if the specified sign-in code already exists
+    * Content-Type : `application/json`
+    * Body : `{"errno":101,"message":"Record already exists"}`
+* Status Code : `500 Internal Server Error`
+    * Conditions: if something goes wrong on the server
+    * Content-Type : `application/json`
+    * Body : `{"code":"InternalError","message":"..."}`
+
+## useSigninCode : `DELETE /signinCodes/:code`
+
+Use a sign-in code.
+
+### Example
+
+```
+curl \
+    -v \
+    -X DELETE \
+    http://localhost:8000/signinCodes/1234567890ab
+```
+
+### Response
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 2
+
+{}
+```
+
+* Status Code : `200 OK`
+    * Content-Type : `application/json`
+    * Body : `{}`
+* Status Code : 404 Not Found
+    * Conditions: if the specified sign-in code doesn't exist
+    * Content-Type : `application/json`
+    * Body : `{"errno":116,"message":"Not found"}`
+* Status Code : `500 Internal Server Error`
+    * Conditions: if something goes wrong on the server
+    * Content-Type : `application/json`
+    * Body : `{"code":"InternalError","message":"..."}`
+
+### Request
+
+* Method : `DELETE`
+* Path : `/signinCodes/<code>
+    * `code` : hex48
+
+## expireSigninCodes : `DELETE /signinCodes/expire/:olderThan`
+
+Delete expired sign-in codes.
+
+### Example
+
+```
+curl \
+    -v \
+    -X DELETE \
+    http://localhost:8000/signinCodes/expire/1494253830983
+```
+
+### Request
+
+* Method : `DELETE`
+* Path : `/signinCodes/<olderThan>
+    * `olderThan` : epoch
+
+### Response
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 2
+
+{}
+```
+
+* Status Code : `200 OK`
+    * Content-Type : `application/json`
+    * Body : `{}`
+* Status Code : `500 Internal Server Error`
+    * Conditions: if something goes wrong on the server
+    * Content-Type : `application/json`
+    * Body : `{"code":"InternalError","message":"..."}`
 

--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -1789,7 +1789,7 @@ curl \
     * `code` : hex
 * Params:
     * `uid` : hex128
-	* `createdAt` : epoch
+    * `createdAt` : epoch
 
 ### Response
 

--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -93,7 +93,7 @@ The following datatypes are used throughout this document:
     * verifyTokens              : `POST /tokens/:tokenVerificationId/verify`
 * Sign-in codes
     * createSigninCode          : `PUT /signinCodes/:code`
-    * consumeSigninCode         : `DELETE /signinCodes/:code`
+    * consumeSigninCode         : `POST /signinCodes/:code/consume`
     * expireSigninCodes         : `DELETE /signinCodes/expire/:olderThan`
 
 ## Ping : `GET /`
@@ -1813,17 +1813,17 @@ Content-Length: 2
     * Content-Type : `application/json`
     * Body : `{"code":"InternalError","message":"..."}`
 
-## consumeSigninCode : `DELETE /signinCodes/:code`
+## consumeSigninCode : `POST /signinCodes/:code/consume`
 
-Use a sign-in code.
+Use (and delete) a sign-in code.
 
 ### Example
 
 ```
 curl \
     -v \
-    -X DELETE \
-    http://localhost:8000/signinCodes/1234567890ab
+    -X POST \
+    http://localhost:8000/signinCodes/1234567890ab/consume
 ```
 
 ### Response

--- a/fxa-auth-db-server/index.js
+++ b/fxa-auth-db-server/index.js
@@ -195,8 +195,8 @@ function createServer(db) {
     op(req => db.createSigninCode(req.params.code, req.body.uid, req.body.createdAt))
   )
 
-  api.del(
-    '/signinCodes/:code',
+  api.post(
+    '/signinCodes/:code/consume',
     op(req => db.consumeSigninCode(req.params.code))
   )
 

--- a/fxa-auth-db-server/index.js
+++ b/fxa-auth-db-server/index.js
@@ -190,6 +190,21 @@ function createServer(db) {
     })
   )
 
+  api.put(
+    '/signinCodes/:code',
+    op(req => db.createSigninCode(req.params.code, req.body.uid, req.body.createdAt))
+  )
+
+  api.del(
+    '/signinCodes/:code',
+    op(req => db.useSigninCode(req.params.code))
+  )
+
+  api.del(
+    '/signinCodes/expire/:olderThan',
+    op(req => db.expireSigninCodes(req.params.olderThan))
+  )
+
   api.get(
     '/',
     function (req, res, next) {

--- a/fxa-auth-db-server/index.js
+++ b/fxa-auth-db-server/index.js
@@ -197,7 +197,7 @@ function createServer(db) {
 
   api.del(
     '/signinCodes/:code',
-    op(req => db.useSigninCode(req.params.code))
+    op(req => db.consumeSigninCode(req.params.code))
   )
 
   api.del(

--- a/fxa-auth-db-server/test/backend/db_tests.js
+++ b/fxa-auth-db-server/test/backend/db_tests.js
@@ -2349,8 +2349,8 @@ module.exports = function(config, DB) {
                 .then(() => t.fail('db.createSigninCode should fail for duplicate codes'))
                 .catch(err => {
                   t.ok(err, 'db.createSigninCode should reject with an error')
-                  t.equal(err.code, 409, 'db.useSigninCode should reject with code 404')
-                  t.equal(err.errno, 101, 'db.useSigninCode should reject with errno 116')
+                  t.equal(err.code, 409, 'db.createSigninCode should reject with code 404')
+                  t.equal(err.errno, 101, 'db.createSigninCode should reject with errno 116')
                 })
             })
             .then(() => {
@@ -2361,38 +2361,38 @@ module.exports = function(config, DB) {
               t.deepEqual(result, {}, 'expireSigninCodes should return an empty object')
 
               // Attempt to use the 1st expired code
-              return db.useSigninCode(SIGNIN_CODES[0])
-                .then(() => t.fail('db.useSigninCode should fail for expired codes'))
+              return db.consumeSigninCode(SIGNIN_CODES[0])
+                .then(() => t.fail('db.consumeSigninCode should fail for expired codes'))
                 .catch(err => {
-                  t.ok(err, 'db.useSigninCode should reject with an error')
-                  t.equal(err.code, 404, 'db.useSigninCode should reject with code 404')
-                  t.equal(err.errno, 116, 'db.useSigninCode should reject with errno 116')
+                  t.ok(err, 'db.consumeSigninCode should reject with an error')
+                  t.equal(err.code, 404, 'db.consumeSigninCode should reject with code 404')
+                  t.equal(err.errno, 116, 'db.consumeSigninCode should reject with errno 116')
                 })
             })
             .then(() => {
               // Attempt to use the 2nd expired code
-              return db.useSigninCode(SIGNIN_CODES[1])
-                .then(() => t.fail('db.useSigninCode should fail for expired codes'))
+              return db.consumeSigninCode(SIGNIN_CODES[1])
+                .then(() => t.fail('db.consumeSigninCode should fail for expired codes'))
                 .catch(err => {
-                  t.ok(err, 'db.useSigninCode should reject with an error')
-                  t.equal(err.code, 404, 'db.useSigninCode should reject with code 404')
-                  t.equal(err.errno, 116, 'db.useSigninCode should reject with errno 116')
+                  t.ok(err, 'db.consumeSigninCode should reject with an error')
+                  t.equal(err.code, 404, 'db.consumeSigninCode should reject with code 404')
+                  t.equal(err.errno, 116, 'db.consumeSigninCode should reject with errno 116')
                 })
             })
             .then(() => {
               // Use the non-expired code
-              return db.useSigninCode(SIGNIN_CODES[2])
+              return db.consumeSigninCode(SIGNIN_CODES[2])
             })
             .then(result => {
-              t.deepEqual(result, { email: ACCOUNT.email }, 'db.useSigninCode should return an email address for non-expired codes')
+              t.deepEqual(result, { email: ACCOUNT.email }, 'db.consumeSigninCode should return an email address for non-expired codes')
 
               // Attempt to re-use a used code
-              return db.useSigninCode(SIGNIN_CODES[2])
-                .then(() => t.fail('db.useSigninCode should fail for used codes'))
+              return db.consumeSigninCode(SIGNIN_CODES[2])
+                .then(() => t.fail('db.consumeSigninCode should fail for used codes'))
                 .catch(err => {
-                  t.ok(err, 'db.useSigninCode should reject with an error')
-                  t.equal(err.code, 404, 'db.useSigninCode should reject with code 404')
-                  t.equal(err.errno, 116, 'db.useSigninCode should reject with errno 116')
+                  t.ok(err, 'db.consumeSigninCode should reject with an error')
+                  t.equal(err.code, 404, 'db.consumeSigninCode should reject with code 404')
+                  t.equal(err.errno, 116, 'db.consumeSigninCode should reject with errno 116')
                 })
             })
             // Clean up the account

--- a/fxa-auth-db-server/test/backend/db_tests.js
+++ b/fxa-auth-db-server/test/backend/db_tests.js
@@ -58,6 +58,7 @@ var ACCOUNT = createAccount()
 function hex(len) {
   return Buffer(crypto.randomBytes(len).toString('hex'), 'hex')
 }
+function hex6() { return hex(6) }
 function hex16() { return hex(16) }
 function hex32() { return hex(32) }
 // function hex64() { return hex(64) }
@@ -2324,6 +2325,79 @@ module.exports = function(config, DB) {
               )
           }
         )
+
+        test('sign-in codes', t => {
+          t.plan(17)
+
+          const SIGNIN_CODES = [ hex6(), hex6(), hex6() ]
+          const NOW = Date.now()
+          const TIMESTAMPS = [ NOW - 3, NOW - 2, NOW - 1 ]
+
+          // Create an account
+          return db.createAccount(ACCOUNT.uid, ACCOUNT)
+            // Create 3 sign-in codes
+            .then(() => P.all([
+              db.createSigninCode(SIGNIN_CODES[0], ACCOUNT.uid, TIMESTAMPS[0]),
+              db.createSigninCode(SIGNIN_CODES[1], ACCOUNT.uid, TIMESTAMPS[1]),
+              db.createSigninCode(SIGNIN_CODES[2], ACCOUNT.uid, TIMESTAMPS[2])
+            ]))
+            .then(results => {
+              results.forEach(r => t.deepEqual(r, {}, 'createSigninCode should return an empty object'))
+
+              // Attempt to create a duplicate code
+              return db.createSigninCode(SIGNIN_CODES[1], ACCOUNT.uid, TIMESTAMPS[1])
+                .then(() => t.fail('db.createSigninCode should fail for duplicate codes'))
+                .catch(err => {
+                  t.ok(err, 'db.createSigninCode should reject with an error')
+                  t.equal(err.code, 409, 'db.useSigninCode should reject with code 404')
+                  t.equal(err.errno, 101, 'db.useSigninCode should reject with errno 116')
+                })
+            })
+            .then(() => {
+              // Expire 2 of the codes
+              return db.expireSigninCodes(TIMESTAMPS[2])
+            })
+            .then(result => {
+              t.deepEqual(result, {}, 'expireSigninCodes should return an empty object')
+
+              // Attempt to use the 1st expired code
+              return db.useSigninCode(SIGNIN_CODES[0])
+                .then(() => t.fail('db.useSigninCode should fail for expired codes'))
+                .catch(err => {
+                  t.ok(err, 'db.useSigninCode should reject with an error')
+                  t.equal(err.code, 404, 'db.useSigninCode should reject with code 404')
+                  t.equal(err.errno, 116, 'db.useSigninCode should reject with errno 116')
+                })
+            })
+            .then(() => {
+              // Attempt to use the 2nd expired code
+              return db.useSigninCode(SIGNIN_CODES[1])
+                .then(() => t.fail('db.useSigninCode should fail for expired codes'))
+                .catch(err => {
+                  t.ok(err, 'db.useSigninCode should reject with an error')
+                  t.equal(err.code, 404, 'db.useSigninCode should reject with code 404')
+                  t.equal(err.errno, 116, 'db.useSigninCode should reject with errno 116')
+                })
+            })
+            .then(() => {
+              // Use the non-expired code
+              return db.useSigninCode(SIGNIN_CODES[2])
+            })
+            .then(result => {
+              t.deepEqual(result, { email: ACCOUNT.email }, 'db.useSigninCode should return an email address for non-expired codes')
+
+              // Attempt to re-use a used code
+              return db.useSigninCode(SIGNIN_CODES[2])
+                .then(() => t.fail('db.useSigninCode should fail for used codes'))
+                .catch(err => {
+                  t.ok(err, 'db.useSigninCode should reject with an error')
+                  t.equal(err.code, 404, 'db.useSigninCode should reject with code 404')
+                  t.equal(err.errno, 116, 'db.useSigninCode should reject with errno 116')
+                })
+            })
+            // Clean up the account
+            .then(() => db.deleteAccount(ACCOUNT.uid))
+        })
 
         test(
           'teardown',

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -52,6 +52,22 @@ function testNotFound(t, err) {
   }, 'Object contains no other fields')
 }
 
+// Helper function that performs two tests:
+//
+// (1) checks that the response is a 409
+// (2) checks that the error body for a 409 is consistent
+//
+// Takes the test object (t) and the error object (err).
+function testConflict (t, err) {
+  t.equal(err.statusCode, 409, 'err.statusCode should be 409')
+  t.deepEqual(err.body, {
+    message: 'Record already exists',
+    errno: 101,
+    error: 'Conflict',
+    code: 409
+  }, 'err.body should have correct properties set')
+}
+
 // Helper function that tests for the server failure event.
 //
 // Takes two arguments:
@@ -1248,6 +1264,68 @@ module.exports = function(cfg, server) {
         )
     }
   )
+
+  test('sign-in codes', t => {
+    t.plan(18)
+
+    const user = fake.newUserDataHex()
+    const now = Date.now()
+    const signinCodes = [ crypto.randomBytes(6).toString('hex'), crypto.randomBytes(6).toString('hex') ]
+    const timestamps = [ now - 2, now - 1 ]
+
+    // Create an account
+    return client.putThen(`/account/${user.accountId}`, user.account)
+      .then(() => {
+        // Create 2 sign-in codes
+        return P.all([
+          client.putThen(`/signinCodes/${signinCodes[0]}`, {
+            uid: user.accountId,
+            createdAt: timestamps[0]
+          }),
+          client.putThen(`/signinCodes/${signinCodes[1]}`, {
+            uid: user.accountId,
+            createdAt: timestamps[1]
+          })
+        ])
+      })
+      .then(r => {
+        respOkEmpty(t, r[0])
+        respOkEmpty(t, r[1])
+
+        // Attempt to create a duplicate sign-in code
+        return client.putThen(`/signinCodes/${signinCodes[0]}`, {
+          uid: user.accountId,
+          createdAt: timestamps[0]
+        })
+          .then(() => t.fail('creating a duplicate sign-in code should fail'))
+          .catch(err => testConflict(t, err))
+      })
+      .then(() => {
+        // Expire the first sign-in code
+        return client.delThen(`/signinCodes/expire/${timestamps[1]}`)
+      })
+      .then(r => {
+        respOkEmpty(t, r)
+
+        // Attempt to delete the 1st sign-in code
+        return client.delThen(`/signinCodes/${signinCodes[0]}`)
+          .then(() => t.fail('deleting an expired sign-in code should fail'))
+          .catch(err => testNotFound(t, err))
+      })
+      .then(() => {
+        // Delete the 2nd sign-in code
+        return client.delThen(`/signinCodes/${signinCodes[1]}`)
+      })
+      .then(r => {
+        respOk(t, r)
+        t.deepEqual(r.obj, { email: user.account.email }, 'deleting a sign-in code should return the email address')
+
+        // Attempt to delete the 2nd sign-in code again
+        return client.delThen(`/signinCodes/${signinCodes[0]}`)
+          .then(() => t.fail('deleting a deleted sign-in code should fail'))
+          .catch(err => testNotFound(t, err))
+      })
+  })
 
   test(
     'GET an unknown path',

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -1301,27 +1301,27 @@ module.exports = function(cfg, server) {
           .catch(err => testConflict(t, err))
       })
       .then(() => {
-        // Expire the first sign-in code
+        // Expire the 1st sign-in code
         return client.delThen(`/signinCodes/expire/${timestamps[1]}`)
       })
       .then(r => {
         respOkEmpty(t, r)
 
         // Attempt to delete the 1st sign-in code
-        return client.delThen(`/signinCodes/${signinCodes[0]}`)
+        return client.postThen(`/signinCodes/${signinCodes[0]}/consume`)
           .then(() => t.fail('deleting an expired sign-in code should fail'))
           .catch(err => testNotFound(t, err))
       })
       .then(() => {
         // Delete the 2nd sign-in code
-        return client.delThen(`/signinCodes/${signinCodes[1]}`)
+        return client.postThen(`/signinCodes/${signinCodes[1]}/consume`)
       })
       .then(r => {
         respOk(t, r)
         t.deepEqual(r.obj, { email: user.account.email }, 'deleting a sign-in code should return the email address')
 
         // Attempt to delete the 2nd sign-in code again
-        return client.delThen(`/signinCodes/${signinCodes[0]}`)
+        return client.postThen(`/signinCodes/${signinCodes[0]}/consume`)
           .then(() => t.fail('deleting a deleted sign-in code should fail'))
           .catch(err => testNotFound(t, err))
       })

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -1089,7 +1089,7 @@ module.exports = function (log, error) {
     return P.resolve({})
   }
 
-  Memory.prototype.useSigninCode = code => {
+  Memory.prototype.consumeSigninCode = code => {
     code = code.toString('hex')
 
     if (! signinCodes[code]) {

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -23,6 +23,7 @@ var securityEvents = {}
 var unblockCodes = {}
 var emailBounces = {}
 var emails = {}
+var signinCodes = {}
 
 var DEVICE_FIELDS = [
   'sessionTokenId',
@@ -1069,6 +1070,44 @@ module.exports = function (log, error) {
         return P.reject(error.cannotDeletePrimaryEmail())
       }
     }
+
+    return P.resolve({})
+  }
+
+  Memory.prototype.createSigninCode = (code, uid, createdAt) => {
+    code = code.toString('hex')
+
+    if (signinCodes[code]) {
+      return P.reject(error.duplicate())
+    }
+
+    signinCodes[code] = {
+      uid: uid.toString('hex'),
+      createdAt
+    }
+
+    return P.resolve({})
+  }
+
+  Memory.prototype.useSigninCode = code => {
+    code = code.toString('hex')
+
+    if (! signinCodes[code]) {
+      return P.reject(error.notFound())
+    }
+
+    const email = accounts[signinCodes[code].uid.toString('hex')].email
+    delete signinCodes[code]
+
+    return P.resolve({ email })
+  }
+
+  Memory.prototype.expireSigninCodes = olderThan => {
+    Object.keys(signinCodes).forEach(code => {
+      if (signinCodes[code].createdAt < olderThan) {
+        delete signinCodes[code]
+      }
+    })
 
     return P.resolve({})
   }

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -827,6 +827,7 @@ module.exports = function (log, error) {
           deleteByUid(uid, passwordForgotTokens)
           deleteByUid(uid, unverifiedTokens)
           deleteByUid(uid, emails)
+          deleteByUid(uid, signinCodes)
 
           delete uidByNormalizedEmail[account.normalizedEmail]
           delete accounts[uid]

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -1184,9 +1184,9 @@ module.exports = function (log, error) {
 
   // Delete : signinCodes
   // Where : hash = $1
-  const USE_SIGNIN_CODE = 'CALL useSigninCode_1(?)'
-  MySql.prototype.useSigninCode = function (code) {
-    return this.readFirstResult(USE_SIGNIN_CODE, [ createHash(code) ])
+  const CONSUME_SIGNIN_CODE = 'CALL consumeSigninCode_1(?)'
+  MySql.prototype.consumeSigninCode = function (code) {
+    return this.readFirstResult(CONSUME_SIGNIN_CODE, [ createHash(code) ])
   }
 
   // Delete : signinCodes

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -514,9 +514,9 @@ module.exports = function (log, error) {
   // DELETE
 
   // Delete : sessionTokens, keyFetchTokens, accountResetTokens, passwordChangeTokens,
-  //          passwordForgotTokens, accounts, devices, unverifiedTokens, emails
+  //          passwordForgotTokens, accounts, devices, unverifiedTokens, emails, signinCodes
   // Where  : uid = $1
-  var DELETE_ACCOUNT = 'CALL deleteAccount_12(?)'
+  var DELETE_ACCOUNT = 'CALL deleteAccount_13(?)'
 
   MySql.prototype.deleteAccount = function (uid) {
     return this.write(DELETE_ACCOUNT, [uid])

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -728,7 +728,7 @@ module.exports = function (log, error) {
 
   MySql.prototype.createUnblockCode = function (uid, code) {
     // hash the code since it's like a password
-    code = crypto.createHash('sha256').update(uid).update(code).digest()
+    code = createHash(uid, code)
     return this.write(
       CREATE_UNBLOCK_CODE,
       [ uid, code, Date.now() ],
@@ -742,7 +742,7 @@ module.exports = function (log, error) {
 
   MySql.prototype.consumeUnblockCode = function (uid, code) {
     // hash the code since it's like a password
-    code = crypto.createHash('sha256').update(uid).update(code).digest()
+    code = createHash(uid, code)
     return this.write(
       CONSUME_UNBLOCK_CODE,
       [ uid, code ],
@@ -1174,5 +1174,39 @@ module.exports = function (log, error) {
       .then(result => result[0])
   }
 
+  // Insert : signinCodes
+  // Values : hash = $1, uid = $2, createdAt = $3
+  const CREATE_SIGNIN_CODE = 'CALL createSigninCode_1(?, ?, ?)'
+  MySql.prototype.createSigninCode = function (code, uid, createdAt) {
+    // code is hashed to thwart timing attacks
+    return this.write(CREATE_SIGNIN_CODE, [ createHash(code), uid, createdAt ])
+  }
+
+  // Delete : signinCodes
+  // Where : hash = $1
+  const USE_SIGNIN_CODE = 'CALL useSigninCode_1(?)'
+  MySql.prototype.useSigninCode = function (code) {
+    return this.readFirstResult(USE_SIGNIN_CODE, [ createHash(code) ])
+  }
+
+  // Delete : signinCodes
+  // Where : createdAt < $1
+  const EXPIRE_SIGNIN_CODES = 'CALL expireSigninCodes_1(?)'
+  MySql.prototype.expireSigninCodes = function (olderThan) {
+    return this.write(EXPIRE_SIGNIN_CODES, [ olderThan ])
+  }
+
   return MySql
 }
+
+function createHash () {
+  const hash = crypto.createHash('sha256')
+
+  // Use ...rest operator and forEach when we're on node 6
+  for (let i = 0; i < arguments.length; ++i) {
+    hash.update(arguments[i])
+  }
+
+  return hash.digest()
+}
+

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 47
+module.exports.level = 48

--- a/lib/db/schema/patch-047-048.sql
+++ b/lib/db/schema/patch-047-048.sql
@@ -1,0 +1,80 @@
+CREATE TABLE IF NOT EXISTS `signinCodes` (
+  hash BINARY(32) NOT NULL PRIMARY KEY,
+  uid BINARY(16) NOT NULL,
+  createdAt BIGINT UNSIGNED NOT NULL,
+  INDEX signinCodes_createdAt (createdAt)
+) ENGINE=InnoDB;
+
+CREATE PROCEDURE `createSigninCode_1` (
+  IN `hashArg` BINARY(32),
+  IN `uidArg` BINARY(16),
+  IN `createdAtArg` BIGINT UNSIGNED
+)
+BEGIN
+  INSERT INTO signinCodes(hash, uid, createdAt)
+  VALUES(hashArg, uidArg, createdAtArg);
+END;
+
+CREATE PROCEDURE `useSigninCode_1` (
+  IN `hashArg` BINARY(32)
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  SELECT email
+  FROM accounts
+  WHERE uid = (
+    SELECT uid
+    FROM signinCodes
+    WHERE hash = hashArg
+  );
+
+  DELETE FROM signinCodes
+  WHERE hash = hashArg;
+
+  COMMIT;
+END;
+
+CREATE PROCEDURE `expireSigninCodes_1` (
+  IN `olderThan` BIGINT UNSIGNED
+)
+BEGIN
+  DELETE FROM signinCodes
+  WHERE createdAt < olderThan;
+END;
+
+CREATE PROCEDURE `deleteAccount_13` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  DELETE FROM sessionTokens WHERE uid = uidArg;
+  DELETE FROM keyFetchTokens WHERE uid = uidArg;
+  DELETE FROM accountResetTokens WHERE uid = uidArg;
+  DELETE FROM passwordChangeTokens WHERE uid = uidArg;
+  DELETE FROM passwordForgotTokens WHERE uid = uidArg;
+  DELETE FROM accounts WHERE uid = uidArg;
+  DELETE FROM devices WHERE uid = uidArg;
+  DELETE FROM unverifiedTokens WHERE uid = uidArg;
+  DELETE FROM unblockCodes WHERE uid = uidArg;
+  DELETE FROM emails WHERE uid = uidArg;
+  DELETE FROM signinCodes WHERE uid = uidArg;
+
+  COMMIT;
+END;
+
+
+UPDATE dbMetadata SET value = '48' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-047-048.sql
+++ b/lib/db/schema/patch-047-048.sql
@@ -15,7 +15,7 @@ BEGIN
   VALUES(hashArg, uidArg, createdAtArg);
 END;
 
-CREATE PROCEDURE `useSigninCode_1` (
+CREATE PROCEDURE `consumeSigninCode_1` (
   IN `hashArg` BINARY(32)
 )
 BEGIN

--- a/lib/db/schema/patch-048-047.sql
+++ b/lib/db/schema/patch-048-047.sql
@@ -1,4 +1,5 @@
 -- DROP PROCEDURE `deleteAccount_13`;
+-- DROP PROCEDURE `expireSigninCode_1`;
 -- DROP PROCEDURE `consumeSigninCode_1`;
 -- DROP PROCEDURE `createSigninCode_1`;
 

--- a/lib/db/schema/patch-048-047.sql
+++ b/lib/db/schema/patch-048-047.sql
@@ -1,5 +1,5 @@
 -- DROP PROCEDURE `deleteAccount_13`;
--- DROP PROCEDURE `useSigninCode_1`;
+-- DROP PROCEDURE `consumeSigninCode_1`;
 -- DROP PROCEDURE `createSigninCode_1`;
 
 -- DROP TABLE signinCodes;

--- a/lib/db/schema/patch-048-047.sql
+++ b/lib/db/schema/patch-048-047.sql
@@ -1,0 +1,7 @@
+-- DROP PROCEDURE `deleteAccount_13`;
+-- DROP PROCEDURE `useSigninCode_1`;
+-- DROP PROCEDURE `createSigninCode_1`;
+
+-- DROP TABLE signinCodes;
+
+-- UPDATE dbMetadata SET value = '47' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
Fixes #230. Replaces #234, implementing some of the suggested feedback from that PR.

Unresolved questions from that PR, copied over so we can continue the discussion here.

* https://github.com/mozilla/fxa-auth-db-mysql/pull/234#discussion_r115950898

  > @philbooth: I'm deeply uncertain about the name of this endpoint, if anyone has better suggestions hit me!
  > @vbudhram: Going to go out a limb and suggest `/code/signin/:code`. This might give us a little flexibility later on if we get different types of codes, ex 2FA.
  > @philbooth: I quite like `signinCodes` in the path because it matches the name of the underlying table and shows up when grepping for it.

* https://github.com/mozilla/fxa-auth-db-mysql/pull/234#discussion_r116005508

  > @vbudhram: The use of `DELETE` here seems a little strange to me, since it is going to use the code and not just delete it.
  > @philbooth: I opted for `DELETE` because it reflects the change in database state. What do you think it should be instead?

* https://github.com/mozilla/fxa-auth-db-mysql/pull/234#discussion_r116132208

  > @rfk: FWIW having a `DELETE` request that returns a response body seems super weird to me.
  > @philbooth: Same question I asked @vbudhram, what should I change it to? Fwiw, a `GET` request that deletes items from the database seems super weird to me. 😄

Thanks for your feedback, I think I addressed all the other points.