### PR TITLE
feat(db): enable signinCode expiry

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -64,6 +64,12 @@ module.exports = function (fs, path, url, convict) {
       format: 'duration',
       env: 'PRUNE_TOKENS_MAX_AGE',
     },
+    signinCodesMaxAge: {
+      doc: 'Maximum age for signinCodes, after which they will expire',
+      default: '2 days',
+      format: 'duration',
+      env: 'SIGNIN_CODES_MAX_AGE',
+    },
     master: {
       user: {
         doc: 'The user to connect to for MySql',

--- a/docs/API.md
+++ b/docs/API.md
@@ -54,7 +54,6 @@ There are a number of methods that a DB storage backend should implement:
 * Signin codes
     * .createSigninCode(code, uid, createdAt)
     * .consumeSigninCode(code)
-    * .expireSigninCodes(olderThan)
 * General
     * .ping()
     * .close()
@@ -615,15 +614,4 @@ Parameters:
 
 * `code` (Buffer):
   The value of the code
-
-## .expireSigninCodes(olderThan)
-
-Delete expired sign-in codes.
-
-Parameters:
-
-* `olderThan` (number):
-  Threshold timestamp for deletion,
-  if `createdAt` is less than this number
-  the sign-in code will be deleted.
 

--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -94,7 +94,6 @@ The following datatypes are used throughout this document:
 * Sign-in codes
     * createSigninCode          : `PUT /signinCodes/:code`
     * consumeSigninCode         : `POST /signinCodes/:code/consume`
-    * expireSigninCodes         : `DELETE /signinCodes/expire/:olderThan`
 
 ## Ping : `GET /`
 
@@ -1853,41 +1852,4 @@ Content-Length: 2
 * Method : `DELETE`
 * Path : `/signinCodes/<code>
     * `code` : hex
-
-## expireSigninCodes : `DELETE /signinCodes/expire/:olderThan`
-
-Delete expired sign-in codes.
-
-### Example
-
-```
-curl \
-    -v \
-    -X DELETE \
-    http://localhost:8000/signinCodes/expire/1494253830983
-```
-
-### Request
-
-* Method : `DELETE`
-* Path : `/signinCodes/expire/<olderThan>
-    * `olderThan` : epoch
-
-### Response
-
-```
-HTTP/1.1 200 OK
-Content-Type: application/json
-Content-Length: 2
-
-{}
-```
-
-* Status Code : `200 OK`
-    * Content-Type : `application/json`
-    * Body : `{}`
-* Status Code : `500 Internal Server Error`
-    * Conditions: if something goes wrong on the server
-    * Content-Type : `application/json`
-    * Body : `{"code":"InternalError","message":"..."}`
 

--- a/fxa-auth-db-server/index.js
+++ b/fxa-auth-db-server/index.js
@@ -200,11 +200,6 @@ function createServer(db) {
     op(req => db.consumeSigninCode(req.params.code))
   )
 
-  api.del(
-    '/signinCodes/expire/:olderThan',
-    op(req => db.expireSigninCodes(req.params.olderThan))
-  )
-
   api.get(
     '/',
     function (req, res, next) {

--- a/fxa-auth-db-server/test/backend/db_tests.js
+++ b/fxa-auth-db-server/test/backend/db_tests.js
@@ -2228,24 +2228,23 @@ module.exports = function(config, DB) {
     )
 
     it('sign-in codes', () => {
-      const SIGNIN_CODES = [ hex6(), hex6(), hex6(), hex6() ]
+      const SIGNIN_CODES = [ hex6(), hex6(), hex6() ]
       const NOW = Date.now()
-      const TIMESTAMPS = [ NOW - 4, NOW - 3, NOW - 2, NOW - 1 ]
+      const TIMESTAMPS = [ NOW - 1, NOW - 2, NOW - config.signinCodesMaxAge - 1 ]
 
       // Create an account
       return db.createAccount(ACCOUNT.uid, ACCOUNT)
-        // Create 4 sign-in codes
+        // Create 3 sign-in codes, two fresh and the other expired
         .then(() => P.all([
           db.createSigninCode(SIGNIN_CODES[0], ACCOUNT.uid, TIMESTAMPS[0]),
           db.createSigninCode(SIGNIN_CODES[1], ACCOUNT.uid, TIMESTAMPS[1]),
-          db.createSigninCode(SIGNIN_CODES[2], ACCOUNT.uid, TIMESTAMPS[2]),
-          db.createSigninCode(SIGNIN_CODES[3], ACCOUNT.uid, TIMESTAMPS[3])
+          db.createSigninCode(SIGNIN_CODES[2], ACCOUNT.uid, TIMESTAMPS[2])
         ]))
         .then(results => {
           results.forEach(r => assert.deepEqual(r, {}, 'createSigninCode should return an empty object'))
 
           // Attempt to create a duplicate code
-          return db.createSigninCode(SIGNIN_CODES[2], ACCOUNT.uid, TIMESTAMPS[2])
+          return db.createSigninCode(SIGNIN_CODES[0], ACCOUNT.uid, TIMESTAMPS[0])
             .then(
               () => assert(false, 'db.createSigninCode should fail for duplicate codes'),
               err => {
@@ -2256,46 +2255,28 @@ module.exports = function(config, DB) {
             )
         })
         .then(() => {
-          // Expire 2 of the codes
-          return db.expireSigninCodes(TIMESTAMPS[2])
-        })
-        .then(result => {
-          assert.deepEqual(result, {}, 'expireSigninCodes should return an empty object')
-
-          // Attempt to use the 1st expired code
+          // Consume a fresh code
           return db.consumeSigninCode(SIGNIN_CODES[0])
-            .then(
-              () => assert(false, 'db.consumeSigninCode should fail for expired codes'),
-              err => {
-                assert(err, 'db.consumeSigninCode should reject with an error')
-                assert.equal(err.code, 404, 'db.consumeSigninCode should reject with code 404')
-                assert.equal(err.errno, 116, 'db.consumeSigninCode should reject with errno 116')
-              }
-            )
-        })
-        .then(() => {
-          // Attempt to use the 2nd expired code
-          return db.consumeSigninCode(SIGNIN_CODES[1])
-            .then(
-              () => assert(false, 'db.consumeSigninCode should fail for expired codes'),
-              err => {
-                assert(err, 'db.consumeSigninCode should reject with an error')
-                assert.equal(err.code, 404, 'db.consumeSigninCode should reject with code 404')
-                assert.equal(err.errno, 116, 'db.consumeSigninCode should reject with errno 116')
-              }
-            )
-        })
-        .then(() => {
-          // Use a non-expired code
-          return db.consumeSigninCode(SIGNIN_CODES[2])
         })
         .then(result => {
           assert.deepEqual(result, { email: ACCOUNT.email }, 'db.consumeSigninCode should return an email address for non-expired codes')
 
-          // Attempt to re-use a used code
+          // Attempt to re-consume the consumed code
+          return db.consumeSigninCode(SIGNIN_CODES[0])
+            .then(
+              () => assert(false, 'db.consumeSigninCode should fail for consumed codes'),
+              err => {
+                assert(err, 'db.consumeSigninCode should reject with an error')
+                assert.equal(err.code, 404, 'db.consumeSigninCode should reject with code 404')
+                assert.equal(err.errno, 116, 'db.consumeSigninCode should reject with errno 116')
+              }
+            )
+        })
+        .then(() => {
+          // Attempt to consume the expired code
           return db.consumeSigninCode(SIGNIN_CODES[2])
             .then(
-              () => assert(false, 'db.consumeSigninCode should fail for used codes'),
+              () => assert(false, 'db.consumeSigninCode should fail for expired codes'),
               err => {
                 assert(err, 'db.consumeSigninCode should reject with an error')
                 assert.equal(err.code, 404, 'db.consumeSigninCode should reject with code 404')
@@ -2306,8 +2287,8 @@ module.exports = function(config, DB) {
         // Clean up the account
         .then(() => db.deleteAccount(ACCOUNT.uid))
         .then(() => {
-          // Attempt to use an unused code associated with a deleted account
-          return db.consumeSigninCode(SIGNIN_CODES[3])
+          // Attempt to use an unused fresh code associated with a deleted account
+          return db.consumeSigninCode(SIGNIN_CODES[1])
             .then(
               () => assert(false, 'db.consumeSigninCode should fail for deleted accounts'),
               err => {

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -8,6 +8,7 @@ const P = require('bluebird')
 const extend = require('util')._extend
 const ip = require('ip')
 const dbUtil = require('./util')
+const config = require('../../config')
 
 // our data stores
 var accounts = {}
@@ -1091,9 +1092,10 @@ module.exports = function (log, error) {
   }
 
   Memory.prototype.consumeSigninCode = code => {
+    const newerThan = Date.now() - config.signinCodesMaxAge
     code = code.toString('hex')
 
-    if (! signinCodes[code]) {
+    if (! signinCodes[code] || signinCodes[code].createdAt <= newerThan) {
       return P.reject(error.notFound())
     }
 
@@ -1101,16 +1103,6 @@ module.exports = function (log, error) {
     delete signinCodes[code]
 
     return P.resolve({ email })
-  }
-
-  Memory.prototype.expireSigninCodes = olderThan => {
-    Object.keys(signinCodes).forEach(code => {
-      if (signinCodes[code].createdAt < olderThan) {
-        delete signinCodes[code]
-      }
-    })
-
-    return P.resolve({})
   }
 
   // UTILITY FUNCTIONS

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -1024,7 +1024,7 @@ module.exports = function (log, error) {
   // exposed for testing only
   MySql.prototype.retryable_ = retryable
 
-  var PRUNE = 'CALL prune_2(?)'
+  var PRUNE = 'CALL prune_3(?)'
   MySql.prototype.pruneTokens = function () {
     log.info('MySql.pruneTokens')
 
@@ -1183,17 +1183,11 @@ module.exports = function (log, error) {
   }
 
   // Delete : signinCodes
-  // Where : hash = $1
-  const CONSUME_SIGNIN_CODE = 'CALL consumeSigninCode_1(?)'
+  // Where : hash = $1, createdAt > now - config.signinCodesMaxAge
+  const CONSUME_SIGNIN_CODE = 'CALL consumeSigninCode_2(?, ?)'
   MySql.prototype.consumeSigninCode = function (code) {
-    return this.readFirstResult(CONSUME_SIGNIN_CODE, [ createHash(code) ])
-  }
-
-  // Delete : signinCodes
-  // Where : createdAt < $1
-  const EXPIRE_SIGNIN_CODES = 'CALL expireSigninCodes_1(?)'
-  MySql.prototype.expireSigninCodes = function (olderThan) {
-    return this.write(EXPIRE_SIGNIN_CODES, [ olderThan ])
+    const newerThan = Date.now() - this.options.signinCodesMaxAge
+    return this.readFirstResult(CONSUME_SIGNIN_CODE, [ createHash(code), newerThan ])
   }
 
   return MySql

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 48
+module.exports.level = 49

--- a/lib/db/schema/patch-048-049.sql
+++ b/lib/db/schema/patch-048-049.sql
@@ -1,0 +1,47 @@
+CREATE PROCEDURE `prune_3` (IN `olderThan` BIGINT UNSIGNED)
+BEGIN
+  SELECT @lockAcquired := GET_LOCK('fxa-auth-server.prune-lock', 3);
+
+  IF @lockAcquired THEN
+    DELETE FROM accountResetTokens WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+    DELETE FROM passwordForgotTokens WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+    DELETE FROM passwordChangeTokens WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+    DELETE FROM unblockCodes WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+    DELETE FROM signinCodes WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+
+    SELECT RELEASE_LOCK('fxa-auth-server.prune-lock');
+  END IF;
+END;
+
+DROP PROCEDURE `expireSigninCodes_1`;
+
+CREATE PROCEDURE `consumeSigninCode_2` (
+  IN `hashArg` BINARY(32),
+  IN `newerThan` BIGINT UNSIGNED
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  SELECT email
+  FROM accounts
+  WHERE uid = (
+    SELECT uid
+    FROM signinCodes
+    WHERE hash = hashArg
+	AND createdAt > newerThan
+  );
+
+  DELETE FROM signinCodes
+  WHERE hash = hashArg
+  AND createdAt > newerThan;
+
+  COMMIT;
+END;
+
+UPDATE dbMetadata SET value = '49' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-049-048.sql
+++ b/lib/db/schema/patch-049-048.sql
@@ -1,0 +1,13 @@
+--DROP PROCEDURE `prune_3`;
+
+--CREATE PROCEDURE `expireSigninCodes_1` (
+--  IN `olderThan` BIGINT UNSIGNED
+--)
+--BEGIN
+--  DELETE FROM signinCodes
+--  WHERE createdAt < olderThan;
+--END;
+
+--DROP PROCEDURE `consumeSigninCode_2`;
+
+--UPDATE dbMetadata SET value = '48' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
Fixes mozilla/fxa-auth-server#1898.

I opened that issue in the auth server because I thought I'd stick the responsibility for it in an auth server process and call the existing endpoint for expiring sign-in codes. @rfk subsequently pointed out that we already have logic for expiring stuff in this repo so I should lean on that, which is what I've done here.

One side-effect of leaning on that code is that `signinCodes` will hang around in the table for 3 months before they're physically deleted. There's no harm in that of course, and it could even be useful if we ever decide to lengthen the expiry period. But 3 months does seem a bit unnecessary so if people want, I could tweak the logic so that `signinCodes` gets a different max-age to the token tables.

Other than that this should hopefully be unsurprising.

@mozilla/fxa-devs r?