### PR TITLE
feat(email): Add email table migration script

### DIFF
--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 50
+module.exports.level = 51

--- a/lib/db/schema/patch-050-051.sql
+++ b/lib/db/schema/patch-050-051.sql
@@ -1,0 +1,26 @@
+-- Migration to copy account emails that are not on the emails table
+-- Sets the email as the primary email for account
+INSERT INTO emails(
+        normalizedEmail,
+        email,
+        uid,
+        emailCode,
+        isVerified,
+        isPrimary,
+        createdAt
+    )
+SELECT
+    normalizedEmail,
+    email,
+    uid,
+    emailCode,
+    emailVerified,
+    true,
+    createdAt
+FROM accounts a
+WHERE
+    a.uid
+NOT IN
+    (SELECT uid FROM emails);
+
+UPDATE dbMetadata SET value = '51' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-051-050.sql
+++ b/lib/db/schema/patch-051-050.sql
@@ -1,0 +1,1 @@
+-- UPDATE dbMetadata SET value = '50' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
New and improved email table migration script. Copies all emails on the account table into the emails table.

Replaces https://github.com/mozilla/fxa-auth-db-mysql/pull/243. This will be a point release for the next train.