### PR TITLE
feat(db): store flowIds with signinCodes

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -52,7 +52,7 @@ There are a number of methods that a DB storage backend should implement:
 * Email Bounces
     * .createEmailBounce(body)
 * Signin codes
-    * .createSigninCode(code, uid, createdAt)
+    * .createSigninCode(code, uid, createdAt, flowId)
     * .consumeSigninCode(code)
 * General
     * .ping()
@@ -592,7 +592,7 @@ Parameters:
   * bounceType: The bounce type ([`'Permanent'`, `'Transient'`, `'Complaint'`])
   * bounceSubType: The bounce sub type string
 
-## .createSigninCode(code, uid, createdAt)
+## .createSigninCode(code, uid, createdAt, flowId)
 
 Create a user-specific, time-limited, single-use code
 that can be used for expedited sign-in.
@@ -605,6 +605,8 @@ Parameters:
   The uid for the relevant user
 * `createdAt` (number):
   Creation timestamp for the code, milliseconds since the epoch
+* `flowId` (Buffer32):
+  The flow id of the originating flow.
 
 ## .consumeSigninCode(code)
 

--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -1777,7 +1777,7 @@ curl \
     -v \
     -X PUT \
     -H "Content-Type: application/json" \
-    -d '{"uid":"fdea27c8188b3d980a28917bc1399e47","createdAt":1494253830983}' \
+    -d '{"uid":"fdea27c8188b3d980a28917bc1399e47","createdAt":1494253830983,"flowId":"e04c12c6c97d8b61f0874f5ddd3447fa7a6e89459f0878746e6f2e6aa846345a"}' \
     http://localhost:8000/signinCodes/1234567890ab
 ```
 
@@ -1789,6 +1789,7 @@ curl \
 * Params:
     * `uid` : hex128
     * `createdAt` : epoch
+    * `flowId` : hex256
 
 ### Response
 
@@ -1825,6 +1826,12 @@ curl \
     http://localhost:8000/signinCodes/1234567890ab/consume
 ```
 
+### Request
+
+* Method : `POST`
+* Path : `/signinCodes/<code>/consume`
+    * `code` : hex
+
 ### Response
 
 ```
@@ -1832,12 +1839,12 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Content-Length: 2
 
-{"email":"foo@example.com"}
+{"email":"foo@example.com","flowId":"e04c12c6c97d8b61f0874f5ddd3447fa7a6e89459f0878746e6f2e6aa846345a"}
 ```
 
 * Status Code : `200 OK`
     * Content-Type : `application/json`
-    * Body : `{"email":"foo@example.com"}`
+    * Body : `{"email":"foo@example.com","flowId":"e04c12c6c97d8b61f0874f5ddd3447fa7a6e89459f0878746e6f2e6aa846345a"}`
 * Status Code : 404 Not Found
     * Conditions: if the specified sign-in code doesn't exist
     * Content-Type : `application/json`
@@ -1846,10 +1853,4 @@ Content-Length: 2
     * Conditions: if something goes wrong on the server
     * Content-Type : `application/json`
     * Body : `{"code":"InternalError","message":"..."}`
-
-### Request
-
-* Method : `DELETE`
-* Path : `/signinCodes/<code>
-    * `code` : hex
 

--- a/fxa-auth-db-server/index.js
+++ b/fxa-auth-db-server/index.js
@@ -56,6 +56,7 @@ function createServer(db) {
     'data',
     'deviceId',
     'emailCode',
+    'flowId',
     'id',
     'kA',
     'keyBundle',
@@ -192,7 +193,7 @@ function createServer(db) {
 
   api.put(
     '/signinCodes/:code',
-    op(req => db.createSigninCode(req.params.code, req.body.uid, req.body.createdAt))
+    op(req => db.createSigninCode(req.params.code, req.body.uid, req.body.createdAt, req.body.flowId))
   )
 
   api.post(

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -1083,17 +1083,14 @@ module.exports = function (log, error) {
     return P.resolve({})
   }
 
-  Memory.prototype.createSigninCode = (code, uid, createdAt) => {
+  Memory.prototype.createSigninCode = (code, uid, createdAt, flowId) => {
     code = code.toString('hex')
 
     if (signinCodes[code]) {
       return P.reject(error.duplicate())
     }
 
-    signinCodes[code] = {
-      uid: uid.toString('hex'),
-      createdAt
-    }
+    signinCodes[code] = { uid, createdAt, flowId }
 
     return P.resolve({})
   }
@@ -1107,9 +1104,10 @@ module.exports = function (log, error) {
     }
 
     const email = accounts[signinCodes[code].uid.toString('hex')].email
+    const flowId = signinCodes[code].flowId
     delete signinCodes[code]
 
-    return P.resolve({ email })
+    return P.resolve({ email, flowId })
   }
 
   // UTILITY FUNCTIONS

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -1174,16 +1174,16 @@ module.exports = function (log, error) {
   }
 
   // Insert : signinCodes
-  // Values : hash = $1, uid = $2, createdAt = $3
-  const CREATE_SIGNIN_CODE = 'CALL createSigninCode_1(?, ?, ?)'
-  MySql.prototype.createSigninCode = function (code, uid, createdAt) {
+  // Values : hash = $1, uid = $2, createdAt = $3, flowId = $4
+  const CREATE_SIGNIN_CODE = 'CALL createSigninCode_2(?, ?, ?, ?)'
+  MySql.prototype.createSigninCode = function (code, uid, createdAt, flowId) {
     // code is hashed to thwart timing attacks
-    return this.write(CREATE_SIGNIN_CODE, [ createHash(code), uid, createdAt ])
+    return this.write(CREATE_SIGNIN_CODE, [ createHash(code), uid, createdAt, flowId ])
   }
 
   // Delete : signinCodes
   // Where : hash = $1, createdAt > now - config.signinCodesMaxAge
-  const CONSUME_SIGNIN_CODE = 'CALL consumeSigninCode_3(?, ?)'
+  const CONSUME_SIGNIN_CODE = 'CALL consumeSigninCode_4(?, ?)'
   MySql.prototype.consumeSigninCode = function (code) {
     const newerThan = Date.now() - this.options.signinCodesMaxAge
     return this.readFirstResult(CONSUME_SIGNIN_CODE, [ createHash(code), newerThan ])

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 52
+module.exports.level = 53

--- a/lib/db/schema/patch-052-053.sql
+++ b/lib/db/schema/patch-052-053.sql
@@ -1,0 +1,45 @@
+ALTER TABLE `signinCodes`
+ADD COLUMN `flowId` BINARY(32),
+ALGORITHM = INPLACE, LOCK = NONE;
+
+CREATE PROCEDURE `createSigninCode_2` (
+  IN `hashArg` BINARY(32),
+  IN `uidArg` BINARY(16),
+  IN `createdAtArg` BIGINT UNSIGNED,
+  IN `flowIdArg` BINARY(32)
+)
+BEGIN
+  INSERT INTO signinCodes(hash, uid, createdAt, flowId)
+  VALUES(hashArg, uidArg, createdAtArg, flowIdArg);
+END;
+
+CREATE PROCEDURE `consumeSigninCode_4` (
+  IN `hashArg` BINARY(32),
+  IN `newerThan` BIGINT UNSIGNED
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  SELECT sc.flowId, e.email
+  FROM signinCodes AS sc
+  INNER JOIN emails AS e
+  ON sc.hash = hashArg
+  AND sc.createdAt > newerThan
+  AND sc.uid = e.uid
+  AND e.isPrimary = true;
+
+  DELETE FROM signinCodes
+  WHERE hash = hashArg
+  AND createdAt > newerThan;
+
+  COMMIT;
+END;
+
+UPDATE dbMetadata SET value = '53' WHERE name = 'schema-patch-level';
+

--- a/lib/db/schema/patch-053-052.sql
+++ b/lib/db/schema/patch-053-052.sql
@@ -1,0 +1,10 @@
+--DROP PROCEDURE `consumeSigninCode_4`;
+
+--DROP PROCEDURE `createSigninCode_2`;
+
+--ALTER TABLE `signinCodes`
+--DROP COLUMN `flowId`,
+--ALGORITHM = INPLACE, LOCK = NONE;
+
+--UPDATE dbMetadata SET value = '52' WHERE name = 'schema-patch-level';
+


### PR DESCRIPTION
Related to mozilla/fxa-auth-server#1945.

Stores `flowId` in the `signinCodes` table so that we can emit a `flow.continued` event in the auth server, which enables us to link up the flows at either end of connect another device.

@mozilla/fxa-devs r?

(and @vbudhram, sorry for yet another merge conflict in this repo, maybe you will merge ahead of me this time :smile:)