### PR TITLE
feat(email): Remove temporary table from `accountEmails` query

### DIFF
--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -786,7 +786,7 @@ module.exports = function (log, error) {
 
   // Select : emails
   // Values : uid = $1
-  var ACCOUNT_EMAILS = 'CALL accountEmails_2(?)'
+  var ACCOUNT_EMAILS = 'CALL accountEmails_3(?)'
   MySql.prototype.accountEmails = function (uid) {
     return this.readOneFromFirstResult(
       ACCOUNT_EMAILS,

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 51
+module.exports.level = 52

--- a/lib/db/schema/patch-051-052.sql
+++ b/lib/db/schema/patch-051-052.sql
@@ -1,0 +1,8 @@
+CREATE PROCEDURE `accountEmails_3` (
+    IN `inUid` BINARY(16)
+)
+BEGIN
+    SELECT * FROM emails WHERE uid = inUid ORDER BY isPrimary=true DESC;
+END;
+
+UPDATE dbMetadata SET value = '52' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-051-052.sql
+++ b/lib/db/schema/patch-051-052.sql
@@ -2,7 +2,34 @@ CREATE PROCEDURE `accountEmails_3` (
     IN `inUid` BINARY(16)
 )
 BEGIN
-    SELECT * FROM emails WHERE uid = inUid ORDER BY isPrimary=true DESC;
+	(SELECT
+        a.normalizedEmail,
+        a.email,
+        a.uid,
+        a.emailCode,
+        a.emailVerified AS isVerified,
+        TRUE AS isPrimary,
+        a.createdAt
+    FROM
+        accounts a
+    WHERE
+        uid = inUid)
+
+    UNION DISTINCT
+
+    (SELECT
+        e.normalizedEmail,
+        e.email,
+        e.uid,
+        e.emailCode,
+        e.isVerified,
+        e.isPrimary,
+        e.createdAt
+    FROM
+        emails e
+    WHERE
+        uid = inUid)
+    ORDER BY isPrimary DESC;
 END;
 
 UPDATE dbMetadata SET value = '52' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-052-051.sql
+++ b/lib/db/schema/patch-052-051.sql
@@ -1,0 +1,3 @@
+-- DROP PROCEDURE `accountEmails_3`;
+
+-- UPDATE dbMetadata SET value = '51' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
The PR removes the use of a temporary table in favor of using a select statement. This is the exact query that was planned for next [train](https://github.com/mozilla/fxa-auth-db-mysql/blob/c5a4ad50d412dc0dd4e3e53a24aeda3ee85b9fde/lib/db/schema/patch-051-052.sql#L1).

 Using this query assumes that all email data has been migrated to the emails table. I believe we would still have to merge this back into master, to ensure it correctly matches state of database.

@jbuck @rfk r?