### PR TITLE
feat(email): Use an index when performing update in forgotPasswordVerify

### DIFF
--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -700,7 +700,12 @@ module.exports = function (log, error) {
   // Update : accounts
   // Set    : emailVerified = true
   // Where  : uid = $4
-  var FORGOT_PASSWORD_VERIFIED = 'CALL forgotPasswordVerified_6(?, ?, ?, ?, ?)'
+  //
+  // Step   : 4
+  // Update : emails
+  // Set    : isVerified = true
+  // Where  : isPrimary = true AND uid = $4
+  var FORGOT_PASSWORD_VERIFIED = 'CALL forgotPasswordVerified_7(?, ?, ?, ?, ?)'
 
   MySql.prototype.forgotPasswordVerified = function (tokenId, accountResetToken) {
     return this.write(

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 52
+module.exports.level = 53

--- a/lib/db/schema/patch-052-053.sql
+++ b/lib/db/schema/patch-052-053.sql
@@ -1,0 +1,41 @@
+CREATE PROCEDURE `forgotPasswordVerified_7` (
+    IN `inPasswordForgotTokenId` BINARY(32),
+    IN `inAccountResetTokenId` BINARY(32),
+    IN `inTokenData` BINARY(32),
+    IN `inUid` BINARY(16),
+    IN `inCreatedAt` BIGINT UNSIGNED
+)
+BEGIN
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        -- ERROR
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    START TRANSACTION;
+
+    -- Since we only ever want one accountResetToken per uid, then we
+    -- do a replace - generally due to a collision on the unique uid field.
+    REPLACE INTO accountResetTokens(
+        tokenId,
+        tokenData,
+        uid,
+        createdAt
+    )
+    VALUES(
+        inAccountResetTokenId,
+        inTokenData,
+        inUid,
+        inCreatedAt
+    );
+
+    DELETE FROM passwordForgotTokens WHERE tokenId = inPasswordForgotTokenId;
+
+    UPDATE accounts SET emailVerified = true WHERE uid = inUid;
+    UPDATE emails SET isVerified = true WHERE isPrimary = true AND uid = inUid;
+
+    COMMIT;
+END;
+
+UPDATE dbMetadata SET value = '53' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-053-052.sql
+++ b/lib/db/schema/patch-053-052.sql
@@ -1,0 +1,3 @@
+-- DROP PROCEDURE `forgotPasswordVerified_7`;
+
+-- UPDATE dbMetadata SET value = '52' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
From deployment, noticed that the `forgotPasswordVerify` SP was taking extra long to run. Turns out that the updated procedure was performing a table scan

`UPDATE emails SET isVerified = true WHERE email = (SELECT email FROM accounts WHERE uid = inUid); `

This PR updates SP to use index `normalizedEmail` on the WHERE clause and SELECT `normalizedEmail` from account table.

SQL Explain

<img width="595" alt="screen shot 2017-06-21 at 2 01 17 pm" src="https://user-images.githubusercontent.com/1295288/27400558-726aa42e-568e-11e7-9a95-4d5ab474a029.png">
<img width="634" alt="screen shot 2017-06-21 at 2 00 55 pm" src="https://user-images.githubusercontent.com/1295288/27400559-72881acc-568e-11e7-807e-0e7481add2b9.png">

Not sure if this will 100% remove all timeouts, but should increase speed of query.

@jbuck @jrgm Thoughts? r?