### PR TITLE
feat(email): correctly return `createdAt` when using accountRecord

### DIFF
--- a/fxa-auth-db-server/test/backend/db_tests.js
+++ b/fxa-auth-db-server/test/backend/db_tests.js
@@ -2554,6 +2554,8 @@ module.exports = function(config, DB) {
           .then((res) => {
             assert.deepEqual(res[0], res[1], 'should return the same account record regardless of email used')
             assert.deepEqual(res[0].primaryEmail, secondEmail.email, 'primary email should be set to update email')
+            assert.ok(res[0].createdAt, 'should set createdAt')
+            assert.deepEqual(res[0].createdAt, res[1].createdAt, 'account records should have the same createdAt')
           })
       })
     })

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -792,7 +792,7 @@ module.exports = function (log, error) {
   // Select : accounts
   // Fields : uid, email, normalizedEmail, emailVerified, emailCode, kA, wrapWrapKb, verifierVersion, authSalt, verifierSetAt, createdAt, lockedAt, primaryEmail
   // Where  : emails.normalizedEmail = LOWER($1)
-  var GET_ACCOUNT_RECORD = 'CALL accountRecord_1(?)'
+  var GET_ACCOUNT_RECORD = 'CALL accountRecord_2(?)'
   MySql.prototype.accountRecord = function (emailBuffer) {
     return this.readFirstResult(GET_ACCOUNT_RECORD, [emailBuffer.toString('utf8')])
   }

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 57
+module.exports.level = 58

--- a/lib/db/schema/patch-057-058.sql
+++ b/lib/db/schema/patch-057-058.sql
@@ -1,0 +1,31 @@
+CREATE PROCEDURE `accountRecord_2` (
+  IN `inEmail` VARCHAR(255)
+)
+BEGIN
+    SELECT
+        a.uid,
+        a.email,
+        a.normalizedEmail,
+        a.emailVerified,
+        a.emailCode,
+        a.kA,
+        a.wrapWrapKb,
+        a.verifierVersion,
+        a.authSalt,
+        a.verifierSetAt,
+        a.createdAt,
+        a.locale,
+        a.lockedAt,
+        e.normalizedEmail AS primaryEmail
+    FROM
+        accounts a,
+        emails e
+    WHERE
+        a.uid = (SELECT uid FROM emails WHERE normalizedEmail = LOWER(inEmail))
+    AND
+        a.uid = e.uid
+    AND
+        e.isPrimary = true;
+END;
+
+UPDATE dbMetadata SET value = '58' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-058-057.sql
+++ b/lib/db/schema/patch-058-057.sql
@@ -1,0 +1,3 @@
+-- DROP PROCEDURE `accountRecord_2`;
+
+-- UPDATE dbMetadata SET value = '57' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
Slight oversight in the mysql implementation for `accountRecord`, it didn't not return `createdBy` which caused https://travis-ci.org/mozilla/fxa-auth-server/jobs/252105845 to fail. Unfortunately, I did not catch this early enough and I'm guessing the migration has already run?

The tests now correctly pass on auth-server, https://travis-ci.org/mozilla/fxa-auth-server/builds/252500226.

@philbooth Sorry about that 😢, mind an r?

