### PR TITLE
chore(tests): don't make eslint a prerequisite for the tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start-mem": "node ./bin/mem",
     "test": "npm run test-mysql && npm run test-mem && npm run test-server",
     "test-mem": "./scripts/mocha-coverage.js test/mem",
-    "test-mysql": "grunt && node ./bin/db_patcher.js >/dev/null && ./scripts/mocha-coverage.js test/backend test/local",
+    "test-mysql": "node ./bin/db_patcher.js >/dev/null && ./scripts/mocha-coverage.js test/backend test/local",
     "test-server": "./scripts/mocha-coverage.js fxa-auth-db-server/test/local",
     "test-travis": "grunt && node ./bin/db_patcher.js && ./scripts/mocha-coverage.js test/backend test/local fxa-auth-db-server/test/local"
   },


### PR DESCRIPTION
Fixes #257.

I should be able to run the tests locally without eslint getting in my grill about `console.log` or whatever. This does that.

@mozilla/fxa-devs r?