### PR TITLE
fix(nodejs): upgrade to 4.8.4 for security fixes

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -1,4 +1,4 @@
-FROM node:4.8.2-alpine
+FROM node:4.8.4-alpine
 
 RUN apk add --no-cache git
 


### PR DESCRIPTION
This needs to be in a 1.91.1 tag.