### PR TITLE
feat(schema): drop the uaFormFactor column from sessionTokens

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -433,7 +433,7 @@ Parameters.
 Each token takes the following fields for it's create method respectively:
 
 * sessionToken : data, uid, createdAt, uaBrowser, uaBrowserVersion, uaOS, uaOSVersion, uaDeviceType,
-                 uaFormFactor, mustVerify, tokenVerificationId
+                 mustVerify, tokenVerificationId
 * keyFetchToken : authKey, uid, keyBundle, createdAt, tokenVerificationId
 * passwordChangeToken : data, uid, createdAt
 * passwordForgotToken : data, uid, passCode, createdAt, triesxb
@@ -477,11 +477,11 @@ These fields are represented as
 `ut.*` for a field from `unverifiedTokens`.
 
 * sessionToken : t.tokenData, t.uid, t.createdAt, t.uaBrowser, t.uaBrowserVersion,
-                 t.uaOS, t.uaOSVersion, t.uaDeviceType, t.uaFormFactor, t.lastAccessTime,
+                 t.uaOS, t.uaOSVersion, t.uaDeviceType, t.lastAccessTime,
                  a.emailVerified, a.email, a.emailCode, a.verifierSetAt,
                  a.createdAt AS accountCreatedAt
 * sessionTokenWithVerificationStatus : t.tokenData, t.uid, t.createdAt, t.uaBrowser, t.uaBrowserVersion,
-                                       t.uaOS, t.uaOSVersion, t.uaDeviceType, t.uaFormFactor, t.lastAccessTime,
+                                       t.uaOS, t.uaOSVersion, t.uaDeviceType, t.lastAccessTime,
                                        a.emailVerified, a.email, a.emailCode, a.verifierSetAt,
                                        a.createdAt AS accountCreatedAt, ut.mustVerify, ut.tokenVerificationId
 * keyFetchToken : t.authKey, t.uid, t.keyBundle, t.createdAt, a.emailVerified, a.verifierSetAt
@@ -608,7 +608,7 @@ These fields are represented as
 The deviceCallbackPublicKey and deviceCallbackAuthKey fields are urlsafe-base64 strings, you can learn more about their format [here](https://developers.google.com/web/updates/2016/03/web-push-encryption).
 
 * sessionToken : t.tokenData, t.uid, t.createdAt, t.uaBrowser, t.uaBrowserVersion,
-                 t.uaOS, t.uaOSVersion, t.uaDeviceType, t.uaFormFactor, t.lastAccessTime,
+                 t.uaOS, t.uaOSVersion, t.uaDeviceType, t.lastAccessTime,
                  a.emailVerified, a.email, a.emailCode, a.verifierSetAt,
                  a.createdAt AS accountCreatedAt, d.id AS deviceId,
                  d.name AS deviceName, d.type AS deviceType,

--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -480,7 +480,6 @@ Content-Length: 371
         "uaOS":"Mac OS X",
         "uaOSVersion":"10.10",
         "uaDeviceType":null,
-        "uaFormFactor":null,
         "lastAccessTime":1441874852627
     }
 ]
@@ -516,7 +515,6 @@ curl \
         "uaOS" : Mac OS X,
         "uaOSVersion" : 10.10,
         "uaDeviceType" : null,
-        "uaFormFactor" : null,
         "mustVerify":true,
         "tokenVerificationId" : "5680a81ba029af7b829afb4aa6dbc23f"
     }' \
@@ -537,7 +535,6 @@ curl \
     * uaOS : string
     * uaOSVersion : string
     * uaDeviceType : string
-    * uaFormFactor : string
     * mustVerify : boolean,
     * tokenVerificationId : hex128
 
@@ -662,7 +659,6 @@ Content-Type: application/json
         "uaOS": "Android",
         "uaOSVersion": "5.1",
         "uaDeviceType": "mobile",
-        "uaFormFactor": null,
         "lastAccessTime": 1437992394186,
         "email": "foo@example.org"
     }
@@ -931,7 +927,6 @@ Content-Length: 285
     "uaOS":"Mac OS X",
     "uaOSVersion":"10.10",
     "uaDeviceType":null,
-    "uaFormFactor":null,
     "lastAccessTime":1460548810011
     "emailVerified":0,
     "email":"foo@example.com",
@@ -990,7 +985,6 @@ Content-Length: 285
     "uaOS":"Mac OS X",
     "uaOSVersion":"10.10",
     "uaDeviceType":null,
-    "uaFormFactor":null,
     "lastAccessTime":1460548810011
     "emailVerified":0,
     "email":"foo@example.com",

--- a/fxa-auth-db-server/test/backend/db_tests.js
+++ b/fxa-auth-db-server/test/backend/db_tests.js
@@ -83,7 +83,6 @@ const SESSION_TOKEN = {
   uaOS : 'mock OS',
   uaOSVersion : 'mock OS version',
   uaDeviceType : 'mock device type',
-  uaFormFactor : 'mock form factor',
   mustVerify: true,
   tokenVerificationId : hex16()
 }
@@ -258,7 +257,6 @@ module.exports = function(config, DB) {
           uaOS: 'baz',
           uaOSVersion: 'qux',
           uaDeviceType: 'wibble',
-          uaFormFactor: 'blee',
           mustVerify: false,
           tokenVerificationId: hex16()
         }
@@ -280,7 +278,7 @@ module.exports = function(config, DB) {
           })
           .then(function (sessions) {
             assert.equal(sessions.length, 1, 'sessions contains one item')
-            assert.equal(Object.keys(sessions[0]).length, 17, 'session has correct properties')
+            assert.equal(Object.keys(sessions[0]).length, 16, 'session has correct properties')
             assert.equal(sessions[0].tokenId.toString('hex'), SESSION_TOKEN_ID.toString('hex'), 'tokenId is correct')
             assert.equal(sessions[0].uid.toString('hex'), ACCOUNT.uid.toString('hex'), 'uid is correct')
             assert.equal(sessions[0].createdAt, SESSION_TOKEN.createdAt, 'createdAt is correct')
@@ -289,7 +287,6 @@ module.exports = function(config, DB) {
             assert.equal(sessions[0].uaOS, SESSION_TOKEN.uaOS, 'uaOS is correct')
             assert.equal(sessions[0].uaOSVersion, SESSION_TOKEN.uaOSVersion, 'uaOSVersion is correct')
             assert.equal(sessions[0].uaDeviceType, SESSION_TOKEN.uaDeviceType, 'uaDeviceType is correct')
-            assert.equal(sessions[0].uaFormFactor, SESSION_TOKEN.uaFormFactor, 'uaFormFactor is correct')
             assert.equal(sessions[0].lastAccessTime, SESSION_TOKEN.createdAt, 'lastAccessTime is correct')
 
             // Fetch the session token
@@ -305,7 +302,6 @@ module.exports = function(config, DB) {
             assert.equal(token.uaOS, SESSION_TOKEN.uaOS, 'uaOS is correct')
             assert.equal(token.uaOSVersion, SESSION_TOKEN.uaOSVersion, 'uaOSVersion is correct')
             assert.equal(token.uaDeviceType, SESSION_TOKEN.uaDeviceType, 'uaDeviceType is correct')
-            assert.equal(token.uaFormFactor, SESSION_TOKEN.uaFormFactor, 'uaFormFactor is correct')
             assert.equal(token.lastAccessTime, SESSION_TOKEN.createdAt, 'lastAccessTime was set')
             assert.equal(!! token.emailVerified, ACCOUNT.emailVerified, 'token emailVerified is same as account emailVerified')
             assert.equal(token.email, ACCOUNT.email, 'token email same as account email')
@@ -339,7 +335,6 @@ module.exports = function(config, DB) {
             assert.equal(sessions[0].uaOS, 'bar', 'uaOS is correct')
             assert.equal(sessions[0].uaOSVersion, '2', 'uaOSVersion is correct')
             assert.equal(sessions[0].uaDeviceType, 'baz', 'uaDeviceType is correct')
-            assert.equal(sessions[0].uaFormFactor, SESSION_TOKEN.uaFormFactor, 'uaFormFactor is correct')
             assert.equal(sessions[0].lastAccessTime, 42, 'lastAccessTime is correct')
 
             // Fetch the session token
@@ -354,7 +349,6 @@ module.exports = function(config, DB) {
             assert.equal(token.uaOS, 'bar', 'uaOS is correct')
             assert.equal(token.uaOSVersion, '2', 'uaOSVersion is correct')
             assert.equal(token.uaDeviceType, 'baz', 'uaDeviceType is correct')
-            assert.equal(token.uaFormFactor, SESSION_TOKEN.uaFormFactor, 'uaFormFactor is correct')
             assert.equal(token.lastAccessTime, 42, 'lastAccessTime is correct')
             assert.equal(!! token.emailVerified, ACCOUNT.emailVerified, 'token emailVerified is same as account emailVerified')
             assert.equal(token.email, ACCOUNT.email, 'token email same as account email')
@@ -376,7 +370,6 @@ module.exports = function(config, DB) {
             assert.equal(token.uaOS, 'bar', 'uaOS is correct')
             assert.equal(token.uaOSVersion, '2', 'uaOSVersion is correct')
             assert.equal(token.uaDeviceType, 'baz', 'uaDeviceType is correct')
-            assert.equal(token.uaFormFactor, SESSION_TOKEN.uaFormFactor, 'uaFormFactor is correct')
             assert.equal(token.lastAccessTime, 42, 'lastAccessTime is correct')
             assert.equal(!! token.emailVerified, ACCOUNT.emailVerified, 'token emailVerified is same as account emailVerified')
             assert.equal(token.email, ACCOUNT.email, 'token email same as account email')
@@ -395,8 +388,7 @@ module.exports = function(config, DB) {
               uaBrowserVersion: 'b',
               uaOS: 'c',
               uaOSVersion: 'd',
-              uaDeviceType: 'e',
-              uaFormFactor: 'f'
+              uaDeviceType: 'e'
             })
           })
           .then(function (result) {
@@ -418,7 +410,6 @@ module.exports = function(config, DB) {
             assert.equal(sessions[index].uaOS, 'c', 'uaOS is correct')
             assert.equal(sessions[index].uaOSVersion, 'd', 'uaOSVersion is correct')
             assert.equal(sessions[index].uaDeviceType, 'e', 'uaDeviceType is correct')
-            assert.equal(sessions[index].uaFormFactor, 'f', 'uaFormFactor is correct')
 
             // Fetch the verified session token
             return db.sessionToken(VERIFIED_SESSION_TOKEN_ID)
@@ -430,7 +421,6 @@ module.exports = function(config, DB) {
             assert.equal(token.uaOS, 'c', 'uaOS is correct')
             assert.equal(token.uaOSVersion, 'd', 'uaOSVersion is correct')
             assert.equal(token.uaDeviceType, 'e', 'uaDeviceType is correct')
-            assert.equal(token.uaFormFactor, 'f', 'uaFormFactor is correct')
             assert.equal(!! token.emailVerified, ACCOUNT.emailVerified, 'token emailVerified is same as account emailVerified')
             assert.equal(token.mustVerify, undefined, 'mustVerify is undefined')
             assert.equal(token.tokenVerificationId, undefined, 'tokenVerificationId is undefined')

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -345,7 +345,7 @@ module.exports = function(cfg, makeServer) {
             respOk(r)
             var sessions = r.obj
             assert.equal(sessions.length, 1, 'sessions contains one item')
-            assert.equal(Object.keys(sessions[0]).length, 17, 'session has correct properties')
+            assert.equal(Object.keys(sessions[0]).length, 16, 'session has correct properties')
             assert.equal(sessions[0].tokenId, user.sessionTokenId, 'tokenId is correct')
             assert.equal(sessions[0].uid, user.accountId, 'uid is correct')
             assert.equal(sessions[0].createdAt, user.sessionToken.createdAt, 'createdAt is correct')
@@ -354,7 +354,6 @@ module.exports = function(cfg, makeServer) {
             assert.equal(sessions[0].uaOS, user.sessionToken.uaOS, 'uaOS is correct')
             assert.equal(sessions[0].uaOSVersion, user.sessionToken.uaOSVersion, 'uaOSVersion is correct')
             assert.equal(sessions[0].uaDeviceType, user.sessionToken.uaDeviceType, 'uaDeviceType is correct')
-            assert.equal(sessions[0].uaFormFactor, user.sessionToken.uaFormFactor, 'uaFormFactor is correct')
             assert.equal(sessions[0].lastAccessTime, user.sessionToken.createdAt, 'lastAccessTime is correct')
 
             // Fetch the session token
@@ -371,7 +370,6 @@ module.exports = function(cfg, makeServer) {
             assert.equal(token.uaOS, user.sessionToken.uaOS, 'uaOS matches')
             assert.equal(token.uaOSVersion, user.sessionToken.uaOSVersion, 'uaOSVersion matches')
             assert.equal(token.uaDeviceType, user.sessionToken.uaDeviceType, 'uaDeviceType matches')
-            assert.equal(token.uaFormFactor, user.sessionToken.uaFormFactor, 'uaFormFactor matches')
             assert.equal(token.lastAccessTime, token.createdAt, 'lastAccessTime was set')
             assert.equal(!! token.emailVerified, user.account.emailVerified, 'emailVerified same as account emailVerified')
             assert.equal(token.email, user.account.email, 'token.email same as account email')
@@ -395,7 +393,6 @@ module.exports = function(cfg, makeServer) {
             assert.equal(token.uaOS, user.sessionToken.uaOS, 'uaOS matches')
             assert.equal(token.uaOSVersion, user.sessionToken.uaOSVersion, 'uaOSVersion matches')
             assert.equal(token.uaDeviceType, user.sessionToken.uaDeviceType, 'uaDeviceType matches')
-            assert.equal(token.uaFormFactor, user.sessionToken.uaFormFactor, 'uaFormFactor matches')
             assert.equal(token.lastAccessTime, token.createdAt, 'lastAccessTime was set')
             assert.equal(!! token.emailVerified, user.account.emailVerified, 'emailVerified same as account emailVerified')
             assert.equal(token.email, user.account.email, 'token.email same as account email')
@@ -425,7 +422,6 @@ module.exports = function(cfg, makeServer) {
             assert.equal(token.uaOS, verifiedUser.sessionToken.uaOS, 'uaOS matches')
             assert.equal(token.uaOSVersion, verifiedUser.sessionToken.uaOSVersion, 'uaOSVersion matches')
             assert.equal(token.uaDeviceType, verifiedUser.sessionToken.uaDeviceType, 'uaDeviceType matches')
-            assert.equal(token.uaFormFactor, verifiedUser.sessionToken.uaFormFactor, 'uaFormFactor matches')
             assert.equal(token.lastAccessTime, token.createdAt, 'lastAccessTime was set')
             assert.equal(!! token.emailVerified, verifiedUser.account.emailVerified, 'emailVerified same as account emailVerified')
             assert.equal(token.email, verifiedUser.account.email, 'token.email same as account email')
@@ -449,7 +445,6 @@ module.exports = function(cfg, makeServer) {
             assert.equal(token.uaOS, verifiedUser.sessionToken.uaOS, 'uaOS matches')
             assert.equal(token.uaOSVersion, verifiedUser.sessionToken.uaOSVersion, 'uaOSVersion matches')
             assert.equal(token.uaDeviceType, verifiedUser.sessionToken.uaDeviceType, 'uaDeviceType matches')
-            assert.equal(token.uaFormFactor, verifiedUser.sessionToken.uaFormFactor, 'uaFormFactor matches')
             assert.equal(token.lastAccessTime, token.createdAt, 'lastAccessTime was set')
             assert.equal(!! token.emailVerified, verifiedUser.account.emailVerified, 'emailVerified same as account emailVerified')
             assert.equal(token.email, verifiedUser.account.email, 'token.email same as account email')
@@ -590,7 +585,6 @@ module.exports = function(cfg, makeServer) {
             assert(s.uaBrowser)
             assert(s.uaBrowserVersion)
             assert(s.uaDeviceType)
-            assert(s.uaFormFactor)
             assert(s.uaOS)
             assert(s.uaOSVersion)
             assert(s.uid)
@@ -624,7 +618,7 @@ module.exports = function(cfg, makeServer) {
             return client.getThen('/sessionToken/' + user.sessionTokenId)
               .then(
                 () => assert(false, 'Fetching the non-existant sessionToken should have failed'),
-                () => assert('Fetching the non-existant sessionToken failed as expected')
+                err => testNotFound(err)
               )
           })
       }
@@ -660,7 +654,7 @@ module.exports = function(cfg, makeServer) {
             respOk(r)
             var devices = r.obj
             assert.equal(devices.length, 1, 'devices contains one item')
-            assert.equal(Object.keys(devices[0]).length, 17, 'device has seventeen properties')
+            assert.equal(Object.keys(devices[0]).length, 16, 'device has sixteen properties')
             assert.equal(devices[0].uid, user.accountId, 'uid is correct')
             assert.equal(devices[0].id, user.deviceId, 'id is correct')
             assert.equal(devices[0].sessionTokenId, user.sessionTokenId, 'sessionTokenId is correct')
@@ -675,7 +669,6 @@ module.exports = function(cfg, makeServer) {
             assert.equal(devices[0].uaOS, user.sessionToken.uaOS, 'uaOS is correct')
             assert.equal(devices[0].uaOSVersion, user.sessionToken.uaOSVersion, 'uaOSVersion is correct')
             assert.equal(devices[0].uaDeviceType, user.sessionToken.uaDeviceType, 'uaDeviceType is correct')
-            assert.equal(devices[0].uaFormFactor, user.sessionToken.uaFormFactor, 'uaFormFactor is correct')
             assert.equal(devices[0].lastAccessTime, user.sessionToken.createdAt, 'lastAccessTime is correct')
             assert.equal(devices[0].email, user.account.email, 'email is correct')
           })
@@ -723,7 +716,6 @@ module.exports = function(cfg, makeServer) {
             assert.equal(devices[0].uaOS, user.sessionToken.uaOS, 'uaOS is correct')
             assert.equal(devices[0].uaOSVersion, user.sessionToken.uaOSVersion, 'uaOSVersion is correct')
             assert.equal(devices[0].uaDeviceType, user.sessionToken.uaDeviceType, 'uaDeviceType is correct')
-            assert.equal(devices[0].uaFormFactor, user.sessionToken.uaFormFactor, 'uaFormFactor is correct')
             assert.equal(devices[0].lastAccessTime, user.sessionToken.createdAt, 'lastAccessTime is correct')
             assert.equal(devices[0].email, user.account.email, 'email is correct')
 

--- a/fxa-auth-db-server/test/fake.js
+++ b/fxa-auth-db-server/test/fake.js
@@ -57,7 +57,6 @@ module.exports.newUserDataHex = function() {
     uaOS: 'fake OS',
     uaOSVersion: 'fake OS version',
     uaDeviceType: 'fake device type',
-    uaFormFactor: 'fake form factor',
     mustVerify: true,
     tokenVerificationId: hex16()
   }

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -43,7 +43,6 @@ var SESSION_FIELDS = [
   'uaOS',
   'uaOSVersion',
   'uaDeviceType',
-  'uaFormFactor',
   'lastAccessTime'
 ]
 
@@ -115,7 +114,6 @@ module.exports = function (log, error) {
       uaOS: sessionToken.uaOS,
       uaOSVersion: sessionToken.uaOSVersion,
       uaDeviceType: sessionToken.uaDeviceType,
-      uaFormFactor: sessionToken.uaFormFactor,
       lastAccessTime: sessionToken.createdAt
     }
 
@@ -572,7 +570,6 @@ module.exports = function (log, error) {
           uaOS: sessionToken.uaOS || null,
           uaOSVersion: sessionToken.uaOSVersion || null,
           uaDeviceType: sessionToken.uaDeviceType || null,
-          uaFormFactor: sessionToken.uaFormFactor || null,
           lastAccessTime: sessionToken.lastAccessTime,
           // device information
           deviceId: deviceInfo.id || null,
@@ -613,7 +610,6 @@ module.exports = function (log, error) {
     item.uaOS = sessionTokens[id].uaOS || null
     item.uaOSVersion = sessionTokens[id].uaOSVersion || null
     item.uaDeviceType = sessionTokens[id].uaDeviceType || null
-    item.uaFormFactor = sessionTokens[id].uaFormFactor || null
     item.lastAccessTime = sessionTokens[id].lastAccessTime
 
     var accountId = sessionTokens[id].uid.toString('hex')

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -192,9 +192,8 @@ module.exports = function (log, error) {
   // Insert : sessionTokens
   // Values : tokenId = $1, tokenData = $2, uid = $3, createdAt = $4,
   //          uaBrowser = $5, uaBrowserVersion = $6, uaOS = $7, uaOSVersion = $8,
-  //          uaDeviceType = $9, uaFormFactor = $10, tokenVerificationId = $11
-  //          mustVerify = $12
-  var CREATE_SESSION_TOKEN = 'CALL createSessionToken_5(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+  //          uaDeviceType = $9, tokenVerificationId = $10, mustVerify = $11
+  var CREATE_SESSION_TOKEN = 'CALL createSessionToken_6(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
 
   MySql.prototype.createSessionToken = function (tokenId, sessionToken) {
     return this.write(
@@ -209,7 +208,6 @@ module.exports = function (log, error) {
         sessionToken.uaOS,
         sessionToken.uaOSVersion,
         sessionToken.uaDeviceType,
-        sessionToken.uaFormFactor,
         sessionToken.tokenVerificationId,
         !! sessionToken.mustVerify
       ]
@@ -346,10 +344,9 @@ module.exports = function (log, error) {
   // Select : devices d, sessionTokens s, accounts a
   // Fields : d.uid, d.id, d.sessionTokenId, d.name, d.type, d.createdAt, d.callbackURL,
   //          d.callbackPublicKey, d.callbackAuthKey, s.uaBrowser, s.uaBrowserVersion,
-  //          s.uaOS, s.uaOSVersion, s.uaDeviceType, s.uaFormFactor, s.lastAccessTime,
-  //          a.email
+  //          s.uaOS, s.uaOSVersion, s.uaDeviceType, s.lastAccessTime, a.email
   // Where  : d.uid = $1
-  var ACCOUNT_DEVICES = 'CALL accountDevices_8(?)'
+  var ACCOUNT_DEVICES = 'CALL accountDevices_9(?)'
 
   MySql.prototype.accountDevices = function (uid) {
     return this.readOneFromFirstResult(ACCOUNT_DEVICES, [uid])
@@ -369,15 +366,15 @@ module.exports = function (log, error) {
 
   // Select : sessionTokens t, accounts a, devices d, unverifiedTokens ut
   // Fields : t.tokenData, t.uid, t.createdAt, t.uaBrowser, t.uaBrowserVersion, t.uaOS,
-  //          t.uaOSVersion, t.uaDeviceType, t.uaFormFactor, t.lastAccessTime, a.emailVerified,
-  //          a.email, a.emailCode, a.verifierSetAt, a.locale, a.createdAt AS accountCreatedAt,
+  //          t.uaOSVersion, t.uaDeviceType, t.lastAccessTime, a.emailVerified, a.email,
+  //          a.emailCode, a.verifierSetAt, a.locale, a.createdAt AS accountCreatedAt,
   //          d.id AS deviceId, d.name AS deviceName, d.type AS deviceType, d.createdAt
   //          AS deviceCreatedAt, d.callbackURL AS deviceCallbackURL, d.callbackPublicKey
   //          AS deviceCallbackPublicKey, d.callbackAuthKey AS deviceCallbackAuthKey,
   //          ut.tokenVerificationId, ut.mustVerify
   // Where  : t.tokenId = $1 AND t.uid = a.uid AND t.tokenId = d.sessionTokenId AND
   //          t.uid = d.uid AND t.tokenId = u.tokenId
-  var SESSION_DEVICE = 'CALL sessionWithDevice_6(?)'
+  var SESSION_DEVICE = 'CALL sessionWithDevice_7(?)'
 
   MySql.prototype.sessionWithDevice = function (id) {
     return this.readFirstResult(SESSION_DEVICE, [id])
@@ -385,12 +382,12 @@ module.exports = function (log, error) {
 
   // Select : sessionTokens
   // Fields : tokenId, uid, createdAt, uaBrowser, uaBrowserVersion,
-  //          uaOS, uaOSVersion, uaDeviceType, uaFormFactor, lastAccessTime,
+  //          uaOS, uaOSVersion, uaDeviceType, lastAccessTime,
   //          deviceId, deviceName, deviceType, deviceCreatedAt, deviceCallbackURL,
   //          deviceCallbackPublicKey, deviceCallbackAuthKey
   // Where  : t.uid = $1 AND t.tokenId = d.sessionTokenId AND
   //          t.uid = d.uid AND t.tokenId = u.tokenId
-  var SESSIONS = 'CALL sessions_3(?)'
+  var SESSIONS = 'CALL sessions_4(?)'
 
   MySql.prototype.sessions = function (uid) {
     return this.readOneFromFirstResult(SESSIONS, [uid])
@@ -398,11 +395,11 @@ module.exports = function (log, error) {
 
   // Select : sessionTokens t, accounts a
   // Fields : t.tokenData, t.uid, t.createdAt, t.uaBrowser, t.uaBrowserVersion,
-  //          t.uaOS, t.uaOSVersion, t.uaDeviceType, t.uaFormFactor, t.lastAccessTime,
+  //          t.uaOS, t.uaOSVersion, t.uaDeviceType, t.lastAccessTime,
   //          a.emailVerified, a.email, a.emailCode, a.verifierSetAt, a.locale,
   //          a.createdAt AS accountCreatedAt
   // Where  : t.tokenId = $1 AND t.uid = a.uid
-  var SESSION_TOKEN = 'CALL sessionToken_5(?)'
+  var SESSION_TOKEN = 'CALL sessionToken_6(?)'
 
   MySql.prototype.sessionToken = function (id) {
     return this.readFirstResult(SESSION_TOKEN, [id])
@@ -410,11 +407,11 @@ module.exports = function (log, error) {
 
   // Select : sessionTokens t, accounts a, unverifiedTokens ut
   // Fields : t.tokenData, t.uid, t.createdAt, t.uaBrowser, t.uaBrowserVersion,
-  //          t.uaOS, t.uaOSVersion, t.uaDeviceType, t.uaFormFactor, t.lastAccessTime,
+  //          t.uaOS, t.uaOSVersion, t.uaDeviceType, t.lastAccessTime,
   //          a.emailVerified, a.email, a.emailCode, a.verifierSetAt, a.locale,
   //          a.createdAt AS accountCreatedAt, ut.tokenVerificationId, ut.mustVerify
   // Where  : t.tokenId = $1 AND t.uid = a.uid AND t.tokenId = ut.tokenId
-  var SESSION_TOKEN_VERIFIED = 'CALL sessionTokenWithVerificationStatus_4(?)'
+  var SESSION_TOKEN_VERIFIED = 'CALL sessionTokenWithVerificationStatus_5(?)'
 
   MySql.prototype.sessionTokenWithVerificationStatus = function (tokenId) {
     return this.readFirstResult(SESSION_TOKEN_VERIFIED, [tokenId])

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 59
+module.exports.level = 60

--- a/lib/db/schema/patch-059-060.sql
+++ b/lib/db/schema/patch-059-060.sql
@@ -1,0 +1,232 @@
+CREATE PROCEDURE `createSessionToken_6` (
+  IN `tokenId` BINARY(32),
+  IN `tokenData` BINARY(32),
+  IN `uid` BINARY(16),
+  IN `createdAt` BIGINT UNSIGNED,
+  IN `uaBrowser` VARCHAR(255),
+  IN `uaBrowserVersion` VARCHAR(255),
+  IN `uaOS` VARCHAR(255),
+  IN `uaOSVersion` VARCHAR(255),
+  IN `uaDeviceType` VARCHAR(255),
+  IN `tokenVerificationId` BINARY(16),
+  IN `mustVerify` BOOLEAN
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  INSERT INTO sessionTokens(
+    tokenId,
+    tokenData,
+    uid,
+    createdAt,
+    uaBrowser,
+    uaBrowserVersion,
+    uaOS,
+    uaOSVersion,
+    uaDeviceType,
+    lastAccessTime
+  )
+  VALUES(
+    tokenId,
+    tokenData,
+    uid,
+    createdAt,
+    uaBrowser,
+    uaBrowserVersion,
+    uaOS,
+    uaOSVersion,
+    uaDeviceType,
+    createdAt
+  );
+
+  IF tokenVerificationId IS NOT NULL THEN
+    INSERT INTO unverifiedTokens(
+      tokenId,
+      tokenVerificationId,
+      uid,
+      mustVerify
+    )
+    VALUES(
+      tokenId,
+      tokenVerificationId,
+      uid,
+      mustVerify
+    );
+  END IF;
+
+  COMMIT;
+END;
+
+CREATE PROCEDURE `sessionToken_6` (
+  IN `tokenIdArg` BINARY(32)
+)
+BEGIN
+  SELECT
+    t.tokenData,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.lastAccessTime,
+    e.isVerified AS emailVerified,
+    e.email,
+    e.emailCode,
+    a.verifierSetAt,
+    a.locale,
+    a.createdAt AS accountCreatedAt
+  FROM sessionTokens AS t
+  LEFT JOIN accounts AS a
+    ON t.uid = a.uid
+  LEFT JOIN emails AS e
+    ON t.uid = e.uid
+    AND e.isPrimary = true
+  WHERE t.tokenId = tokenIdArg;
+END;
+
+CREATE PROCEDURE `sessionTokenWithVerificationStatus_5` (
+  IN `tokenIdArg` BINARY(32)
+)
+BEGIN
+  SELECT
+    t.tokenData,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.lastAccessTime,
+    e.isVerified AS emailVerified,
+    e.email,
+    e.emailCode,
+    a.verifierSetAt,
+    a.locale,
+    a.createdAt AS accountCreatedAt,
+    ut.tokenVerificationId,
+    ut.mustVerify
+  FROM sessionTokens AS t
+  LEFT JOIN accounts AS a
+    ON t.uid = a.uid
+  LEFT JOIN emails AS e
+    ON t.uid = e.uid
+    AND e.isPrimary = true
+  LEFT JOIN unverifiedTokens AS ut
+    ON t.tokenId = ut.tokenId
+  WHERE t.tokenId = tokenIdArg;
+END;
+
+CREATE PROCEDURE `sessionWithDevice_7` (
+  IN `tokenIdArg` BINARY(32)
+)
+BEGIN
+  SELECT
+    t.tokenData,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.lastAccessTime,
+    e.isVerified AS emailVerified,
+    e.email,
+    e.emailCode,
+    a.verifierSetAt,
+    a.locale,
+    a.createdAt AS accountCreatedAt,
+    d.id AS deviceId,
+    d.name AS deviceName,
+    d.type AS deviceType,
+    d.createdAt AS deviceCreatedAt,
+    d.callbackURL AS deviceCallbackURL,
+    d.callbackPublicKey AS deviceCallbackPublicKey,
+    d.callbackAuthKey AS deviceCallbackAuthKey,
+    ut.tokenVerificationId,
+    ut.mustVerify
+  FROM sessionTokens AS t
+  LEFT JOIN accounts AS a
+    ON t.uid = a.uid
+  LEFT JOIN emails AS e
+    ON t.uid = e.uid
+    AND e.isPrimary = true
+  LEFT JOIN devices AS d
+    ON (t.tokenId = d.sessionTokenId AND t.uid = d.uid)
+  LEFT JOIN unverifiedTokens AS ut
+    ON t.tokenId = ut.tokenId
+  WHERE t.tokenId = tokenIdArg;
+END;
+
+CREATE PROCEDURE `sessions_4` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  SELECT
+    t.tokenId,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.lastAccessTime,
+    d.id AS deviceId,
+    d.name AS deviceName,
+    d.type AS deviceType,
+    d.createdAt AS deviceCreatedAt,
+    d.callbackURL AS deviceCallbackURL,
+    d.callbackPublicKey AS deviceCallbackPublicKey,
+    d.callbackAuthKey AS deviceCallbackAuthKey
+  FROM sessionTokens AS t
+  LEFT JOIN devices AS d
+    ON (t.tokenId = d.sessionTokenId AND t.uid = d.uid)
+  WHERE t.uid = uidArg;
+END;
+
+CREATE PROCEDURE `accountDevices_9` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  SELECT
+    d.uid,
+    d.id,
+    d.sessionTokenId,
+    d.name,
+    d.type,
+    d.createdAt,
+    d.callbackURL,
+    d.callbackPublicKey,
+    d.callbackAuthKey,
+    s.uaBrowser,
+    s.uaBrowserVersion,
+    s.uaOS,
+    s.uaOSVersion,
+    s.uaDeviceType,
+    s.lastAccessTime,
+    e.email
+  FROM devices AS d
+  INNER JOIN sessionTokens AS s
+    ON d.sessionTokenId = s.tokenId
+  INNER JOIN emails AS e
+    ON d.uid = e.uid
+    AND e.isPrimary = true
+  WHERE d.uid = uidArg;
+END;
+
+ALTER TABLE `sessionTokens`
+DROP COLUMN `uaFormFactor`,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+UPDATE dbMetadata SET value = '60' WHERE name = 'schema-patch-level';
+

--- a/lib/db/schema/patch-059-060.sql
+++ b/lib/db/schema/patch-059-060.sql
@@ -12,15 +12,7 @@ CREATE PROCEDURE `createSessionToken_6` (
   IN `mustVerify` BOOLEAN
 )
 BEGIN
-  DECLARE EXIT HANDLER FOR SQLEXCEPTION
-  BEGIN
-    ROLLBACK;
-    RESIGNAL;
-  END;
-
-  START TRANSACTION;
-
-  INSERT INTO sessionTokens(
+  CALL createSessionToken_4(
     tokenId,
     tokenData,
     uid,
@@ -30,198 +22,44 @@ BEGIN
     uaOS,
     uaOSVersion,
     uaDeviceType,
-    lastAccessTime
-  )
-  VALUES(
-    tokenId,
-    tokenData,
-    uid,
-    createdAt,
-    uaBrowser,
-    uaBrowserVersion,
-    uaOS,
-    uaOSVersion,
-    uaDeviceType,
-    createdAt
+    tokenVerificationId,
+    mustVerify
   );
-
-  IF tokenVerificationId IS NOT NULL THEN
-    INSERT INTO unverifiedTokens(
-      tokenId,
-      tokenVerificationId,
-      uid,
-      mustVerify
-    )
-    VALUES(
-      tokenId,
-      tokenVerificationId,
-      uid,
-      mustVerify
-    );
-  END IF;
-
-  COMMIT;
 END;
 
 CREATE PROCEDURE `sessionToken_6` (
   IN `tokenIdArg` BINARY(32)
 )
 BEGIN
-  SELECT
-    t.tokenData,
-    t.uid,
-    t.createdAt,
-    t.uaBrowser,
-    t.uaBrowserVersion,
-    t.uaOS,
-    t.uaOSVersion,
-    t.uaDeviceType,
-    t.lastAccessTime,
-    e.isVerified AS emailVerified,
-    e.email,
-    e.emailCode,
-    a.verifierSetAt,
-    a.locale,
-    a.createdAt AS accountCreatedAt
-  FROM sessionTokens AS t
-  LEFT JOIN accounts AS a
-    ON t.uid = a.uid
-  LEFT JOIN emails AS e
-    ON t.uid = e.uid
-    AND e.isPrimary = true
-  WHERE t.tokenId = tokenIdArg;
+  CALL sessionToken_4(tokenIdArg);
 END;
 
 CREATE PROCEDURE `sessionTokenWithVerificationStatus_5` (
   IN `tokenIdArg` BINARY(32)
 )
 BEGIN
-  SELECT
-    t.tokenData,
-    t.uid,
-    t.createdAt,
-    t.uaBrowser,
-    t.uaBrowserVersion,
-    t.uaOS,
-    t.uaOSVersion,
-    t.uaDeviceType,
-    t.lastAccessTime,
-    e.isVerified AS emailVerified,
-    e.email,
-    e.emailCode,
-    a.verifierSetAt,
-    a.locale,
-    a.createdAt AS accountCreatedAt,
-    ut.tokenVerificationId,
-    ut.mustVerify
-  FROM sessionTokens AS t
-  LEFT JOIN accounts AS a
-    ON t.uid = a.uid
-  LEFT JOIN emails AS e
-    ON t.uid = e.uid
-    AND e.isPrimary = true
-  LEFT JOIN unverifiedTokens AS ut
-    ON t.tokenId = ut.tokenId
-  WHERE t.tokenId = tokenIdArg;
+  CALL sessionTokenWithVerificationStatus_3(tokenIdArg);
 END;
 
 CREATE PROCEDURE `sessionWithDevice_7` (
   IN `tokenIdArg` BINARY(32)
 )
 BEGIN
-  SELECT
-    t.tokenData,
-    t.uid,
-    t.createdAt,
-    t.uaBrowser,
-    t.uaBrowserVersion,
-    t.uaOS,
-    t.uaOSVersion,
-    t.uaDeviceType,
-    t.lastAccessTime,
-    e.isVerified AS emailVerified,
-    e.email,
-    e.emailCode,
-    a.verifierSetAt,
-    a.locale,
-    a.createdAt AS accountCreatedAt,
-    d.id AS deviceId,
-    d.name AS deviceName,
-    d.type AS deviceType,
-    d.createdAt AS deviceCreatedAt,
-    d.callbackURL AS deviceCallbackURL,
-    d.callbackPublicKey AS deviceCallbackPublicKey,
-    d.callbackAuthKey AS deviceCallbackAuthKey,
-    ut.tokenVerificationId,
-    ut.mustVerify
-  FROM sessionTokens AS t
-  LEFT JOIN accounts AS a
-    ON t.uid = a.uid
-  LEFT JOIN emails AS e
-    ON t.uid = e.uid
-    AND e.isPrimary = true
-  LEFT JOIN devices AS d
-    ON (t.tokenId = d.sessionTokenId AND t.uid = d.uid)
-  LEFT JOIN unverifiedTokens AS ut
-    ON t.tokenId = ut.tokenId
-  WHERE t.tokenId = tokenIdArg;
+  CALL sessionWithDevice_5(tokenIdArg);
 END;
 
 CREATE PROCEDURE `sessions_4` (
   IN `uidArg` BINARY(16)
 )
 BEGIN
-  SELECT
-    t.tokenId,
-    t.uid,
-    t.createdAt,
-    t.uaBrowser,
-    t.uaBrowserVersion,
-    t.uaOS,
-    t.uaOSVersion,
-    t.uaDeviceType,
-    t.lastAccessTime,
-    d.id AS deviceId,
-    d.name AS deviceName,
-    d.type AS deviceType,
-    d.createdAt AS deviceCreatedAt,
-    d.callbackURL AS deviceCallbackURL,
-    d.callbackPublicKey AS deviceCallbackPublicKey,
-    d.callbackAuthKey AS deviceCallbackAuthKey
-  FROM sessionTokens AS t
-  LEFT JOIN devices AS d
-    ON (t.tokenId = d.sessionTokenId AND t.uid = d.uid)
-  WHERE t.uid = uidArg;
+  CALL sessions_2(uidArg);
 END;
 
 CREATE PROCEDURE `accountDevices_9` (
   IN `uidArg` BINARY(16)
 )
 BEGIN
-  SELECT
-    d.uid,
-    d.id,
-    d.sessionTokenId,
-    d.name,
-    d.type,
-    d.createdAt,
-    d.callbackURL,
-    d.callbackPublicKey,
-    d.callbackAuthKey,
-    s.uaBrowser,
-    s.uaBrowserVersion,
-    s.uaOS,
-    s.uaOSVersion,
-    s.uaDeviceType,
-    s.lastAccessTime,
-    e.email
-  FROM devices AS d
-  INNER JOIN sessionTokens AS s
-    ON d.sessionTokenId = s.tokenId
-  INNER JOIN emails AS e
-    ON d.uid = e.uid
-    AND e.isPrimary = true
-  WHERE d.uid = uidArg;
+  CALL accountDevices_7(uidArg);
 END;
 
 ALTER TABLE `sessionTokens`

--- a/lib/db/schema/patch-060-059.sql
+++ b/lib/db/schema/patch-060-059.sql
@@ -1,0 +1,13 @@
+--DROP PROCEDURE `accountDevices_9`;
+--DROP PROCEDURE `sessions_4`;
+--DROP PROCEDURE `sessionWithDevice_7`;
+--DROP PROCEDURE `sessionTokenWithVerificationStatus_5`;
+--DROP PROCEDURE `sessionToken_6`;
+--DROP PROCEDURE `createSessionToken_6`;
+
+--ALTER TABLE `sessionTokens`
+--ADD COLUMN `uaFormFactor` VARCHAR(255),
+--ALGORITHM = INPLACE, LOCK = NONE;
+
+--UPDATE dbMetadata SET value = '59' WHERE name = 'schema-patch-level';
+


### PR DESCRIPTION
As per discussion in the deployment bug, we have too many records in the `sessionTokens` table to add a new column in prod. This PR reverts train-91 to the previous state, but done as a forward migration with incremented stored procedures for the benefit of the patcher script.

An auth server patch will also be required, I'll write that one in a jiffy.

@vbudhram r?
