### PR TITLE
chore(email): Remove emailRecord depreciation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -298,9 +298,6 @@ Returns:
 
 ## .emailRecord(emailBuffer) ##
 
-Note: Using this method will emit a deprecation warning, please use `.accountRecord` instead.
-This method only reads from the account table whereas `.accountRecord` checks the emails table and returns correct account record.
-
 Gets the account record related to this (normalized) email address. The email is provided in a Buffer.
 
 Parameters:

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -9,7 +9,6 @@ const extend = require('util')._extend
 const ip = require('ip')
 const dbUtil = require('./util')
 const config = require('../../config')
-const nodeUtil = require('util')
 
 // our data stores
 var accounts = {}
@@ -537,13 +536,13 @@ module.exports = function (log, error) {
   // Returns:
   //   - the account if found
   //   - throws 'notFound' if not found
-  Memory.prototype.emailRecord = nodeUtil.deprecate(function (email) {
+  Memory.prototype.emailRecord = function (email) {
     email = email.toString('utf8').toLowerCase()
     return getAccountByUid(uidByNormalizedEmail[email])
       .then(function (account) {
         return filterAccount(account)
       })
-  }, 'DeprecationWarning for mem.emailRecord: Use mem.accountRecord')
+  }
 
   Memory.prototype.sessions = function (uid) {
     return this.accountDevices(uid).then(function (devices) {

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -11,7 +11,6 @@ const P = require('../promise')
 
 const patch = require('./patch')
 const dbUtil = require('./util')
-const nodeUtil = require('util')
 
 // http://dev.mysql.com/doc/refman/5.5/en/error-messages-server.html
 const ER_TOO_MANY_CONNECTIONS = 1040
@@ -467,9 +466,9 @@ module.exports = function (log, error) {
   // Where  : accounts.normalizedEmail = LOWER($1)
   var EMAIL_RECORD = 'CALL emailRecord_4(?)'
 
-  MySql.prototype.emailRecord = nodeUtil.deprecate(function (emailBuffer) {
+  MySql.prototype.emailRecord = function (emailBuffer) {
     return this.readFirstResult(EMAIL_RECORD, [emailBuffer.toString('utf8')])
-  }, 'DeprecationWarning for mysql.emailRecord: Use mysql.accountRecord')
+  }
 
   // Select : accounts
   // Fields : uid, email, normalizedEmail, emailVerified, emailCode, kA, wrapWrapKb, verifierVersion, authSalt, verifierSetAt, createdAt, locale, lockedAt


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-auth-server/issues/1999.

Unfortunately, I don't have any solid plans to get this method depreciated and it might not be possible to do without breaking backwards compatibility on user's accounts. This PR drops the deprecation warnings.

@mozilla/fxa-devs r?