### PR TITLE
feat(schema): add a pushEndpointExpired column to devices

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -611,7 +611,9 @@ The deviceCallbackPublicKey and deviceCallbackAuthKey fields are urlsafe-base64 
                  d.name AS deviceName, d.type AS deviceType,
                  d.createdAt AS deviceCreatedAt, d.callbackURL AS deviceCallbackURL,
                  d.callbackPublicKey AS deviceCallbackPublicKey,
-                 d.callbackAuthKey AS deviceCallbackAuthKey, ut.mustVerify, ut.tokenVerificationId
+                 d.callbackAuthKey AS deviceCallbackAuthKey,
+                 d.callbackIsExpired AS deviceCallbackIsExpired,
+                 ut.mustVerify, ut.tokenVerificationId
 
 ## .createVerificationReminder(body) ##
 

--- a/fxa-auth-db-server/docs/API.md
+++ b/fxa-auth-db-server/docs/API.md
@@ -657,6 +657,7 @@ Content-Type: application/json
         "callbackURL": "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef",
         "callbackPublicKey": "BCp93zru09_hab2Bg37LpTNG__Pw6eMPEP2hrQpwuytoj3h4chXpGc-3qqdKyqjuvAiEupsnOd_RLyc7erJHWgA",
         "callbackAuthKey": "w3b14Zjc-Afj2SDOLOyong",
+        "callbackIsExpired": false,
         "uaBrowser": "Firefox",
         "uaBrowserVersion": "42",
         "uaOS": "Android",
@@ -713,7 +714,8 @@ Content-Type: application/json
     "createdAt": 1437992394186,
     "callbackURL": "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef",
     "callbackPublicKey": "BCp93zru09_hab2Bg37LpTNG__Pw6eMPEP2hrQpwuytoj3h4chXpGc-3qqdKyqjuvAiEupsnOd_RLyc7erJHWgA",
-    "callbackAuthKey": "w3b14Zjc-Afj2SDOLOyong"
+    "callbackAuthKey": "w3b14Zjc-Afj2SDOLOyong",
+    "callbackIsExpired": false
 }
 ```
 
@@ -747,7 +749,8 @@ curl \
       "createdAt": 1437992394186,
       "callbackURL": "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef",
       "callbackPublicKey": "BCp93zru09_hab2Bg37LpTNG__Pw6eMPEP2hrQpwuytoj3h4chXpGc-3qqdKyqjuvAiEupsnOd_RLyc7erJHWgA",
-      "callbackAuthKey": "w3b14Zjc-Afj2SDOLOyong"
+      "callbackAuthKey": "w3b14Zjc-Afj2SDOLOyong",
+      "callbackIsExpired": false
     }'
 ```
 
@@ -790,7 +793,8 @@ curl \
       "createdAt": 1437992394186,
       "callbackURL": "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef",
       "callbackPublicKey": "BCp93zru09_hab2Bg37LpTNG__Pw6eMPEP2hrQpwuytoj3h4chXpGc-3qqdKyqjuvAiEupsnOd_RLyc7erJHWgA",
-      "callbackAuthKey": "w3b14Zjc-Afj2SDOLOyong"
+      "callbackAuthKey": "w3b14Zjc-Afj2SDOLOyong",
+      "callbackIsExpired": false
     }'
 ```
 
@@ -1003,6 +1007,7 @@ Content-Length: 285
     "deviceCreatedAt":1460548810011,
     "deviceCallbackURL":null,
     "deviceCallbackPublicKey":null,
+    "deviceCallbackIsExpired":false,
     "mustVerify":true,
     "tokenVerificationId":"12c41fac80fd6149f3f695e188b5f846"
 }

--- a/fxa-auth-db-server/test/backend/db_tests.js
+++ b/fxa-auth-db-server/test/backend/db_tests.js
@@ -280,7 +280,7 @@ module.exports = function(config, DB) {
           })
           .then(function (sessions) {
             assert.equal(sessions.length, 1, 'sessions contains one item')
-            assert.equal(Object.keys(sessions[0]).length, 17, 'session has correct properties')
+            assert.equal(Object.keys(sessions[0]).length, 18, 'session has correct properties')
             assert.equal(sessions[0].tokenId.toString('hex'), SESSION_TOKEN_ID.toString('hex'), 'tokenId is correct')
             assert.equal(sessions[0].uid.toString('hex'), ACCOUNT.uid.toString('hex'), 'uid is correct')
             assert.equal(sessions[0].createdAt, SESSION_TOKEN.createdAt, 'createdAt is correct')
@@ -506,7 +506,8 @@ module.exports = function(config, DB) {
               createdAt: Date.now(),
               callbackURL: 'https://push.server',
               callbackPublicKey: 'foo',
-              callbackAuthKey: 'bar'
+              callbackAuthKey: 'bar',
+              callbackIsExpired: false
             })
           })
           .then(function() {
@@ -534,6 +535,7 @@ module.exports = function(config, DB) {
             assert.equal(sessions[0].deviceCallbackURL, 'https://push.server')
             assert.equal(sessions[0].deviceCallbackPublicKey, 'foo')
             assert.equal(sessions[0].deviceCallbackAuthKey, 'bar')
+            assert.equal(sessions[0].deviceCallbackIsExpired, false)
             assert.equal(sessions[1].deviceId, null)
             assert.equal(sessions[2].deviceId, null)
 
@@ -1121,7 +1123,8 @@ module.exports = function(config, DB) {
           type: 'mobile',
           callbackURL: 'https://foo/bar',
           callbackPublicKey: base64_65(),
-          callbackAuthKey: base64_16()
+          callbackAuthKey: base64_16(),
+          callbackIsExpired: false
         }
         var newDeviceId = newUuid()
         var newSessionTokenId = hex32()
@@ -1178,6 +1181,7 @@ module.exports = function(config, DB) {
             assert.equal(device.callbackURL, null, 'callbackURL')
             assert.equal(device.callbackPublicKey, null, 'callbackPublicKey')
             assert.equal(device.callbackAuthKey, null, 'callbackAuthKey')
+            assert.equal(device.callbackIsExpired, false, 'callbackIsExpired')
             assert(device.lastAccessTime > 0, 'has a lastAccessTime')
             assert.equal(device.email, ACCOUNT.email, 'email should be account email')
 
@@ -1193,6 +1197,7 @@ module.exports = function(config, DB) {
                   assert.equal(s.deviceCallbackURL, device.callbackURL, 'callbackURL')
                   assert.equal(s.deviceCallbackPublicKey, device.callbackPublicKey, 'callbackPublicKey')
                   assert.equal(s.deviceCallbackAuthKey, device.callbackAuthKey, 'callbackAuthKey')
+                  assert.equal(s.deviceCallbackIsExpired, device.callbackIsExpired, 'callbackIsExpired')
                   assert.equal(!! s.mustVerify, !! SESSION_TOKEN.mustVerify, 'mustVerify is correct')
                   assert.deepEqual(s.tokenVerificationId, SESSION_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
                 },
@@ -1235,6 +1240,7 @@ module.exports = function(config, DB) {
             assert.equal(device.callbackURL, deviceInfo.callbackURL, 'callbackURL')
             assert.equal(device.callbackPublicKey, deviceInfo.callbackPublicKey, 'callbackPublicKey')
             assert.equal(device.callbackAuthKey, deviceInfo.callbackAuthKey, 'callbackAuthKey')
+            assert.equal(device.callbackIsExpired, deviceInfo.callbackIsExpired, 'callbackIsExpired')
             assert(device.lastAccessTime > 0, 'has a lastAccessTime')
             assert.equal(device.email, ACCOUNT.email, 'email should be account email')
 
@@ -1264,13 +1270,15 @@ module.exports = function(config, DB) {
             assert.equal(device.callbackURL, deviceInfo.callbackURL, 'callbackURL unchanged')
             assert.equal(device.callbackPublicKey, deviceInfo.callbackPublicKey, 'callbackPublicKey unchanged')
             assert.equal(device.callbackAuthKey, deviceInfo.callbackAuthKey, 'callbackAuthKey unchanged')
+            assert.equal(device.callbackIsExpired, deviceInfo.callbackIsExpired, 'callbackIsExpired unchanged')
 
             // Update the device type and callback params
             return db.updateDevice(ACCOUNT.uid, deviceId, {
               type: 'desktop',
               callbackURL: '',
               callbackPublicKey: '',
-              callbackAuthKey: ''
+              callbackAuthKey: '',
+              callbackIsExpired: true
             })
           })
           .then(function (result) {
@@ -1288,6 +1296,7 @@ module.exports = function(config, DB) {
             assert.equal(device.callbackURL, '', 'callbackURL updated')
             assert.equal(device.callbackPublicKey, '', 'callbackPublicKey updated')
             assert.equal(device.callbackAuthKey, '', 'callbackAuthKey updated')
+            assert.equal(device.callbackIsExpired, true, 'callbackIsExpired updated')
 
             // Make the device a zombie, by giving it a non-existent session token
             return db.updateDevice(ACCOUNT.uid, deviceId, {
@@ -1321,7 +1330,8 @@ module.exports = function(config, DB) {
               type: 'desktop',
               callbackURL: 'https://foo/bar',
               callbackPublicKey: base64_65(),
-              callbackAuthKey: base64_16()
+              callbackAuthKey: base64_16(),
+              callbackIsExpired: false
             })
             .then(function () {
               assert(false, 'adding a second device should have failed when the session token is already registered')
@@ -1345,7 +1355,8 @@ module.exports = function(config, DB) {
               type: 'desktop',
               callbackURL: 'https://foo/bar',
               callbackPublicKey: base64_65(),
-              callbackAuthKey: base64_16()
+              callbackAuthKey: base64_16(),
+              callbackIsExpired: false
             })
             .then(function () {
             }, function (err) {

--- a/fxa-auth-db-server/test/backend/remote.js
+++ b/fxa-auth-db-server/test/backend/remote.js
@@ -345,7 +345,7 @@ module.exports = function(cfg, makeServer) {
             respOk(r)
             var sessions = r.obj
             assert.equal(sessions.length, 1, 'sessions contains one item')
-            assert.equal(Object.keys(sessions[0]).length, 17, 'session has correct properties')
+            assert.equal(Object.keys(sessions[0]).length, 18, 'session has correct properties')
             assert.equal(sessions[0].tokenId, user.sessionTokenId, 'tokenId is correct')
             assert.equal(sessions[0].uid, user.accountId, 'uid is correct')
             assert.equal(sessions[0].createdAt, user.sessionToken.createdAt, 'createdAt is correct')
@@ -581,6 +581,7 @@ module.exports = function(cfg, makeServer) {
             assert.equal(s.deviceCallbackAuthKey.length, 22)
             assert(s.deviceCallbackPublicKey)
             assert.equal(s.deviceCallbackURL, 'fake callback URL')
+            assert.equal(s.deviceCallbackIsExpired, false)
             assert(s.deviceCreatedAt)
             assert(s.deviceId)
             assert.equal(s.deviceName, 'fake device name')
@@ -660,7 +661,7 @@ module.exports = function(cfg, makeServer) {
             respOk(r)
             var devices = r.obj
             assert.equal(devices.length, 1, 'devices contains one item')
-            assert.equal(Object.keys(devices[0]).length, 17, 'device has seventeen properties')
+            assert.equal(Object.keys(devices[0]).length, 18, 'device has eighteen properties')
             assert.equal(devices[0].uid, user.accountId, 'uid is correct')
             assert.equal(devices[0].id, user.deviceId, 'id is correct')
             assert.equal(devices[0].sessionTokenId, user.sessionTokenId, 'sessionTokenId is correct')
@@ -670,6 +671,7 @@ module.exports = function(cfg, makeServer) {
             assert.equal(devices[0].callbackURL, user.device.callbackURL, 'callbackURL is correct')
             assert.equal(devices[0].callbackPublicKey, user.device.callbackPublicKey, 'callbackPublicKey is correct')
             assert.equal(devices[0].callbackAuthKey, user.device.callbackAuthKey, 'callbackAuthKey is correct')
+            assert.equal(devices[0].callbackIsExpired, user.device.callbackIsExpired, 'callbackIsExpired is correct')
             assert.equal(devices[0].uaBrowser, user.sessionToken.uaBrowser, 'uaBrowser is correct')
             assert.equal(devices[0].uaBrowserVersion, user.sessionToken.uaBrowserVersion, 'uaBrowserVersion is correct')
             assert.equal(devices[0].uaOS, user.sessionToken.uaOS, 'uaOS is correct')
@@ -692,13 +694,15 @@ module.exports = function(cfg, makeServer) {
             assert.equal(device.callbackURL, user.device.callbackURL, 'callbackURL is correct')
             assert.equal(device.callbackPublicKey, user.device.callbackPublicKey, 'callbackPublicKey is correct')
             assert.equal(device.callbackAuthKey, user.device.callbackAuthKey, 'callbackAuthKey is correct')
+            assert.equal(device.callbackIsExpired, user.device.callbackIsExpired, 'callbackIsExpired is correct')
 
             return client.postThen('/account/' + user.accountId + '/device/' + user.deviceId + '/update', {
               name: 'wibble',
               type: 'mobile',
               callbackURL: '',
               callbackPublicKey: null,
-              callbackAuthKey: null
+              callbackAuthKey: null,
+              callbackIsExpired: null
             })
           })
           .then(function(r) {
@@ -718,6 +722,7 @@ module.exports = function(cfg, makeServer) {
             assert.equal(devices[0].callbackURL, '', 'callbackURL is correct')
             assert.equal(devices[0].callbackPublicKey, user.device.callbackPublicKey, 'callbackPublicKey is correct')
             assert.equal(devices[0].callbackAuthKey, user.device.callbackAuthKey, 'callbackAuthKey is correct')
+            assert.equal(devices[0].callbackIsExpired, false, 'callbackIsExpired is correct')
             assert.equal(devices[0].uaBrowser, user.sessionToken.uaBrowser, 'uaBrowser is correct')
             assert.equal(devices[0].uaBrowserVersion, user.sessionToken.uaBrowserVersion, 'uaBrowserVersion is correct')
             assert.equal(devices[0].uaOS, user.sessionToken.uaOS, 'uaOS is correct')

--- a/fxa-auth-db-server/test/fake.js
+++ b/fxa-auth-db-server/test/fake.js
@@ -72,7 +72,8 @@ module.exports.newUserDataHex = function() {
     type: 'fake device type',
     callbackURL: 'fake callback URL',
     callbackPublicKey: base64_65(),
-    callbackAuthKey: base64_16()
+    callbackAuthKey: base64_16(),
+    callbackIsExpired: false
   }
 
   // keyFetchToken

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -33,7 +33,8 @@ var DEVICE_FIELDS = [
   'createdAt',
   'callbackURL',
   'callbackPublicKey',
-  'callbackAuthKey'
+  'callbackAuthKey',
+  'callbackIsExpired'
 ]
 
 var SESSION_FIELDS = [
@@ -207,6 +208,7 @@ module.exports = function (log, error) {
             uid: uid,
             id: deviceId
           }
+          deviceInfo.callbackIsExpired = false // mimic the db behavior assigning a default false value
           account.devices[deviceKey] = updateDeviceRecord(device, deviceInfo, deviceKey)
           return {}
         }
@@ -482,6 +484,7 @@ module.exports = function (log, error) {
             callbackURL: device.callbackURL,
             callbackPublicKey: device.callbackPublicKey,
             callbackAuthKey: device.callbackAuthKey,
+            callbackIsExpired: device.callbackIsExpired
           })
         }
       )
@@ -507,6 +510,7 @@ module.exports = function (log, error) {
                   session.deviceCallbackURL = device.callbackURL
                   session.deviceCallbackPublicKey = device.callbackPublicKey
                   session.deviceCallbackAuthKey = device.callbackAuthKey
+                  session.deviceCallbackIsExpired = device.callbackIsExpired
                 }
                 return session
               }
@@ -581,6 +585,7 @@ module.exports = function (log, error) {
           deviceCallbackURL: deviceInfo.callbackURL || null,
           deviceCallbackPublicKey: deviceInfo.callbackPublicKey || null,
           deviceCallbackAuthKey: deviceInfo.callbackAuthKey || null,
+          deviceCallbackIsExpired: deviceInfo.callbackIsExpired !== undefined ? deviceInfo.callbackIsExpired : null,
         }
 
         return session

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -302,7 +302,7 @@ module.exports = function (log, error) {
     )
   }
 
-  var UPDATE_DEVICE = 'CALL updateDevice_3(?, ?, ?, ?, ?, ?, ?, ?, ?)'
+  var UPDATE_DEVICE = 'CALL updateDevice_4(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
 
   MySql.prototype.updateDevice = function (uid, deviceId, deviceInfo) {
     return this.write(
@@ -316,7 +316,8 @@ module.exports = function (log, error) {
         deviceInfo.type,
         deviceInfo.callbackURL,
         deviceInfo.callbackPublicKey,
-        deviceInfo.callbackAuthKey
+        deviceInfo.callbackAuthKey,
+        deviceInfo.callbackIsExpired
       ],
       function (result) {
         if (result.affectedRows === 0) {
@@ -360,11 +361,11 @@ module.exports = function (log, error) {
 
   // Select : devices d, sessionTokens s, accounts a
   // Fields : d.uid, d.id, d.sessionTokenId, d.name, d.type, d.createdAt, d.callbackURL,
-  //          d.callbackPublicKey, d.callbackAuthKey, s.uaBrowser, s.uaBrowserVersion,
-  //          s.uaOS, s.uaOSVersion, s.uaDeviceType, s.uaFormFactor, s.lastAccessTime,
-  //          a.email
+  //          d.callbackPublicKey, d.callbackAuthKey, d.callbackIsExpired,
+  //          s.uaBrowser, s.uaBrowserVersion, s.uaOS, s.uaOSVersion, s.uaDeviceType,
+  //          s.uaFormFactor, s.lastAccessTime, a.email
   // Where  : d.uid = $1
-  var ACCOUNT_DEVICES = 'CALL accountDevices_10(?)'
+  var ACCOUNT_DEVICES = 'CALL accountDevices_11(?)'
 
   MySql.prototype.accountDevices = function (uid) {
     return this.readOneFromFirstResult(ACCOUNT_DEVICES, [uid])
@@ -373,10 +374,11 @@ module.exports = function (log, error) {
   // Select : devices d, unverifiedTokens u
   // Fields : d.id AS deviceId, d.name AS deviceName, d.type AS deviceType, d.createdAt
   //          AS deviceCreatedAt, d.callbackURL AS deviceCallbackURL, d.callbackPublicKey
-  //          AS deviceCallbackPublicKey, d.callbackAuthKey AS deviceCallbackAuthKey
+  //          AS deviceCallbackPublicKey, d.callbackAuthKey AS deviceCallbackAuthKey,
+  //          d.callbackIsExpired AS deviceCallbackIsExpired
   // Where  : u.uid = $1 AND u.tokenVerificationId = $2 AND
   //          u.tokenId = d.sessionTokenId AND u.uid = d.uid
-  var DEVICE_FROM_TOKEN_VERIFICATION_ID = 'CALL deviceFromTokenVerificationId_1(?, ?)'
+  var DEVICE_FROM_TOKEN_VERIFICATION_ID = 'CALL deviceFromTokenVerificationId_2(?, ?)'
 
   MySql.prototype.deviceFromTokenVerificationId = function (uid, tokenVerificationId) {
     return this.readFirstResult(DEVICE_FROM_TOKEN_VERIFICATION_ID, [uid, tokenVerificationId])
@@ -389,10 +391,11 @@ module.exports = function (log, error) {
   //          d.id AS deviceId, d.name AS deviceName, d.type AS deviceType, d.createdAt
   //          AS deviceCreatedAt, d.callbackURL AS deviceCallbackURL, d.callbackPublicKey
   //          AS deviceCallbackPublicKey, d.callbackAuthKey AS deviceCallbackAuthKey,
+  //          d.callbackIsExpired AS deviceCallbackIsExpired,
   //          ut.tokenVerificationId, ut.mustVerify
   // Where  : t.tokenId = $1 AND t.uid = a.uid AND t.tokenId = d.sessionTokenId AND
   //          t.uid = d.uid AND t.tokenId = u.tokenId
-  var SESSION_DEVICE = 'CALL sessionWithDevice_8(?)'
+  var SESSION_DEVICE = 'CALL sessionWithDevice_9(?)'
 
   MySql.prototype.sessionWithDevice = function (id) {
     return this.readFirstResult(SESSION_DEVICE, [id])
@@ -402,10 +405,10 @@ module.exports = function (log, error) {
   // Fields : tokenId, uid, createdAt, uaBrowser, uaBrowserVersion,
   //          uaOS, uaOSVersion, uaDeviceType, uaFormFactor, lastAccessTime,
   //          deviceId, deviceName, deviceType, deviceCreatedAt, deviceCallbackURL,
-  //          deviceCallbackPublicKey, deviceCallbackAuthKey
+  //          deviceCallbackPublicKey, deviceCallbackAuthKey, deviceCallbackIsExpired
   // Where  : t.uid = $1 AND t.tokenId = d.sessionTokenId AND
   //          t.uid = d.uid AND t.tokenId = u.tokenId
-  var SESSIONS = 'CALL sessions_5(?)'
+  var SESSIONS = 'CALL sessions_6(?)'
 
   MySql.prototype.sessions = function (uid) {
     return this.readOneFromFirstResult(SESSIONS, [uid])

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 62
+module.exports.level = 63

--- a/lib/db/schema/patch-062-063.sql
+++ b/lib/db/schema/patch-062-063.sql
@@ -1,0 +1,155 @@
+ALTER TABLE devices
+ADD COLUMN callbackIsExpired BOOLEAN NOT NULL DEFAULT FALSE AFTER callbackAuthKey,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+CREATE PROCEDURE `updateDevice_4` (
+  IN `inUid` BINARY(16),
+  IN `inId` BINARY(16),
+  IN `inSessionTokenId` BINARY(32),
+  IN `inName` VARCHAR(255),
+  IN `inNameUtf8` VARCHAR(255),
+  IN `inType` VARCHAR(16),
+  IN `inCallbackURL` VARCHAR(255),
+  IN `inCallbackPublicKey` CHAR(88),
+  IN `inCallbackAuthKey` CHAR(24),
+  IN `inCallbackIsExpired` BOOLEAN
+)
+BEGIN
+  UPDATE devices
+  SET sessionTokenId = COALESCE(inSessionTokenId, sessionTokenId),
+    name = COALESCE(inName, name),
+    nameUtf8 = COALESCE(inNameUtf8, nameUtf8),
+    type = COALESCE(inType, type),
+    callbackURL = COALESCE(inCallbackURL, callbackURL),
+    callbackPublicKey = COALESCE(inCallbackPublicKey, callbackPublicKey),
+    callbackAuthKey = COALESCE(inCallbackAuthKey, callbackAuthKey),
+    callbackIsExpired = COALESCE(inCallbackIsExpired, callbackIsExpired)
+  WHERE uid = inUid AND id = inId;
+END;
+
+CREATE PROCEDURE `sessionWithDevice_9` (
+  IN `tokenIdArg` BINARY(32)
+)
+BEGIN
+  SELECT
+    t.tokenData,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.uaFormFactor,
+    t.lastAccessTime,
+    e.isVerified AS emailVerified,
+    e.email,
+    e.emailCode,
+    a.verifierSetAt,
+    a.locale,
+    a.createdAt AS accountCreatedAt,
+    d.id AS deviceId,
+    d.name AS deviceName,
+    d.type AS deviceType,
+    d.createdAt AS deviceCreatedAt,
+    d.callbackURL AS deviceCallbackURL,
+    d.callbackPublicKey AS deviceCallbackPublicKey,
+    d.callbackAuthKey AS deviceCallbackAuthKey,
+    d.callbackIsExpired AS deviceCallbackIsExpired,
+    ut.tokenVerificationId,
+    ut.mustVerify
+  FROM sessionTokens AS t
+  LEFT JOIN accounts AS a
+    ON t.uid = a.uid
+  LEFT JOIN emails AS e
+    ON t.uid = e.uid
+    AND e.isPrimary = true
+  LEFT JOIN devices AS d
+    ON (t.tokenId = d.sessionTokenId AND t.uid = d.uid)
+  LEFT JOIN unverifiedTokens AS ut
+    ON t.tokenId = ut.tokenId
+  WHERE t.tokenId = tokenIdArg;
+END;
+
+CREATE PROCEDURE `sessions_6` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  SELECT
+    t.tokenId,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.uaFormFactor,
+    t.lastAccessTime,
+    d.id AS deviceId,
+    d.name AS deviceName,
+    d.type AS deviceType,
+    d.createdAt AS deviceCreatedAt,
+    d.callbackURL AS deviceCallbackURL,
+    d.callbackPublicKey AS deviceCallbackPublicKey,
+    d.callbackAuthKey AS deviceCallbackAuthKey,
+    d.callbackIsExpired AS deviceCallbackIsExpired
+  FROM sessionTokens AS t
+  LEFT JOIN devices AS d
+    ON (t.tokenId = d.sessionTokenId AND t.uid = d.uid)
+  WHERE t.uid = uidArg;
+END;
+
+CREATE PROCEDURE `accountDevices_11` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  SELECT
+    d.uid,
+    d.id,
+    d.sessionTokenId,
+    d.name,
+    d.type,
+    d.createdAt,
+    d.callbackURL,
+    d.callbackPublicKey,
+    d.callbackAuthKey,
+    d.callbackIsExpired,
+    s.uaBrowser,
+    s.uaBrowserVersion,
+    s.uaOS,
+    s.uaOSVersion,
+    s.uaDeviceType,
+    s.uaFormFactor,
+    s.lastAccessTime,
+    e.email
+  FROM devices AS d
+  INNER JOIN sessionTokens AS s
+    ON d.sessionTokenId = s.tokenId
+  INNER JOIN emails AS e
+    ON d.uid = e.uid
+    AND e.isPrimary = true
+  WHERE d.uid = uidArg;
+END;
+
+CREATE PROCEDURE `deviceFromTokenVerificationId_2` (
+    IN inUid BINARY(16),
+    IN inTokenVerificationId BINARY(16)
+)
+BEGIN
+    SELECT
+        d.id,
+        d.name,
+        d.type,
+        d.createdAt,
+        d.callbackURL,
+        d.callbackPublicKey,
+        d.callbackAuthKey,
+        d.callbackIsExpired
+    FROM unverifiedTokens AS u
+    INNER JOIN devices AS d
+        ON (u.tokenId = d.sessionTokenId AND u.uid = d.uid)
+    WHERE u.uid = inUid AND u.tokenVerificationId = inTokenVerificationId;
+END;
+
+UPDATE dbMetadata SET value = '63' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-063-062.sql
+++ b/lib/db/schema/patch-063-062.sql
@@ -1,0 +1,13 @@
+--ALTER TABLE `devices`
+--DROP COLUMN `callbackIsExpired`,
+--ALGORITHM = INPLACE, LOCK = NONE;
+
+-- -- Drop new stored procedures
+-- DROP PROCEDURE `updateDevice_4`;
+-- DROP PROCEDURE `sessionWithDevice_9`;
+-- DROP PROCEDURE `sessions_6`;
+-- DROP PROCEDURE `accountDevices_11`;
+-- DROP PROCEDURE `deviceFromTokenVerificationId_2`;
+
+-- UPDATE dbMetadata SET value = '62' WHERE name = 'schema-patch-level';
+


### PR DESCRIPTION
This connects to https://github.com/mozilla/fxa-auth-server/issues/1873.
The `createDevices` procedure is not modified, `pushEndpointExpired` is set by default to `FALSE`.