### PR TITLE
fix(tokens): prune old session tokens that have no device record

### DIFF
--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -1089,7 +1089,7 @@ module.exports = function (log, error) {
   // exposed for testing only
   MySql.prototype.retryable_ = retryable
 
-  var PRUNE = 'CALL prune_3(?)'
+  const PRUNE = 'CALL prune_4(?)'
   MySql.prototype.pruneTokens = function () {
     log.info('MySql.pruneTokens')
 

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 63
+module.exports.level = 64

--- a/lib/db/schema/patch-063-064.sql
+++ b/lib/db/schema/patch-063-064.sql
@@ -1,0 +1,33 @@
+CREATE PROCEDURE `prune_4` (IN `olderThan` BIGINT UNSIGNED)
+BEGIN
+  SELECT @lockAcquired := GET_LOCK('fxa-auth-server.prune-lock', 3);
+
+  IF @lockAcquired THEN
+    DELETE FROM accountResetTokens WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+    DELETE FROM passwordForgotTokens WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+    DELETE FROM passwordChangeTokens WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+    DELETE FROM unblockCodes WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+    DELETE FROM signinCodes WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+
+    DELETE FROM sessionTokens
+    WHERE createdAt < olderThan
+    AND NOT EXISTS (
+      SELECT d.sessionTokenId
+      FROM devices AS d
+      WHERE d.sessionTokenId = sessionTokens.tokenId
+    )
+    ORDER BY createdAt
+    LIMIT 10000;
+
+    DELETE ut
+    FROM unverifiedTokens AS ut
+    LEFT JOIN sessionTokens AS st
+      ON ut.tokenId = st.tokenId
+    WHERE st.tokenId IS NULL;
+
+    SELECT RELEASE_LOCK('fxa-auth-server.prune-lock');
+  END IF;
+END;
+
+UPDATE dbMetadata SET value = '64' WHERE name = 'schema-patch-level';
+

--- a/lib/db/schema/patch-064-063.sql
+++ b/lib/db/schema/patch-064-063.sql
@@ -1,0 +1,4 @@
+-- DROP PROCEDURE `prune_4`;
+
+-- UPDATE dbMetadata SET value = '63' WHERE name = 'schema-patch-level';
+


### PR DESCRIPTION
Fixes #263. Supercedes #274.

Please let me know if there is a better way to do this.

Initially I tried to do it all in one query, with a `LEFT JOIN` between `sessionTokens` and `devices` and an `INNER JOIN` between `sessionTokens` and `unverifiedTokens`. But that doesn't work because, [as per the docs](https://dev.mysql.com/doc/refman/5.7/en/delete.html#idm140189111263328):

> You cannot use `ORDER BY` or `LIMIT` in a multiple-table `DELETE`.

So instead, I've broken it down to two queries. The first uses `NOT EXISTS` and a subquery to deselect session tokens with device records, which allows us to sanely delete from `sessionTokens` with `ORDER BY` and `LIMIT`. Then the second one just mops up any zombies left behind in `unverifiedTokens`, which we don't/shouldn't need to worry about limiting.

I wasn't sure whether the two queries should be run together in a transaction. I've put them in one to be on the safe side but fwiw I don't *think* they need to be. `unverifiedTokens` is only ever used as the rhs of a `LEFT JOIN` with `sessionTokens`, so it should never matter if they exist after their associated session token has been deleted. And they're getting pruned regularly so it's not like they're going to pile up.

@mozilla/fxa-devs r?

/cc @jrgm, @jbuck