### PR TITLE
fix(db): prune session tokens without using filesort

### DIFF
--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -1087,7 +1087,7 @@ module.exports = function (log, error) {
   // exposed for testing only
   MySql.prototype.retryable_ = retryable
 
-  const PRUNE = 'CALL prune_4(?)'
+  const PRUNE = 'CALL prune_5(?)'
   MySql.prototype.pruneTokens = function () {
     log.info('MySql.pruneTokens')
 

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 65
+module.exports.level = 66

--- a/lib/db/schema/patch-065-066.sql
+++ b/lib/db/schema/patch-065-066.sql
@@ -57,9 +57,9 @@ BEGIN
 
     DELETE ut
     FROM unverifiedTokens AS ut
-    LEFT JOIN sessionTokens AS st
-      ON ut.tokenId = st.tokenId
-    WHERE st.tokenId IS NULL;
+    LEFT JOIN sessionTokens AS st ON ut.tokenId = st.tokenId
+    LEFT JOIN keyFetchTokens AS kt ON ut.tokenId = kt.tokenId
+    WHERE st.tokenId IS NULL AND kt.tokenId IS NULL;
 
     -- Jiggery-pokery #3: Tell following iterations how far we got.
     UPDATE dbMetadata

--- a/lib/db/schema/patch-065-066.sql
+++ b/lib/db/schema/patch-065-066.sql
@@ -1,0 +1,83 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- Add an index on sessionTokens::createdAt to fix pruning filesort.
+CREATE INDEX `sessionTokens_createdAt`
+ON `sessionTokens` (`createdAt`)
+ALGORITHM=INPLACE
+LOCK=NONE;
+
+-- Used to prevent session token pruning from doing a full table scan
+-- as it proceeds further and further through the (very long) backlog
+-- of pruning candidates.
+INSERT INTO dbMetadata (name, value)
+VALUES ('sessionTokensPrunedUntil', 0);
+
+-- Update the prune stored procedure with assorted jiggery-pokery to
+-- make session token pruning faster.
+CREATE PROCEDURE `prune_5` (IN `olderThan` BIGINT UNSIGNED)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  SELECT @lockAcquired := GET_LOCK('fxa-auth-server.prune-lock', 3);
+
+  IF @lockAcquired THEN
+    DELETE FROM accountResetTokens WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+    DELETE FROM passwordForgotTokens WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+    DELETE FROM passwordChangeTokens WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+    DELETE FROM unblockCodes WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+    DELETE FROM signinCodes WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+
+    START TRANSACTION;
+
+    -- Jiggery-pokery #1: Find out how far we got on previous iterations.
+    SELECT @newerThan := value FROM dbMetadata WHERE name = 'sessionTokensPrunedUntil';
+
+    -- Jiggery-pokery #2: Store the pruned session tokens in a temporary table
+    --                    ahead of time, so we can refer to createdAt post-facto.
+    CREATE TEMPORARY TABLE prunedSessionTokens (
+      tokenId BINARY(32) PRIMARY KEY,
+      createdAt BIGINT UNSIGNED NOT NULL,
+      INDEX prunedSessionTokens_createdAt (createdAt)
+    ) AS
+      SELECT tokenId, createdAt FROM sessionTokens
+      WHERE createdAt >= @newerThan AND createdAt < olderThan
+      AND NOT EXISTS (
+        SELECT sessionTokenId FROM devices
+        WHERE sessionTokenId = sessionTokens.tokenId
+      )
+      ORDER BY createdAt
+      LIMIT 10000;
+
+    DELETE FROM sessionTokens
+    WHERE tokenId IN (
+      SELECT tokenId FROM prunedSessionTokens
+    );
+
+    DELETE ut
+    FROM unverifiedTokens AS ut
+    LEFT JOIN sessionTokens AS st
+      ON ut.tokenId = st.tokenId
+    WHERE st.tokenId IS NULL;
+
+    -- Jiggery-pokery #3: Tell following iterations how far we got.
+    SELECT @prunedUntil := MAX(createdAt) FROM prunedSessionTokens;
+
+    UPDATE dbMetadata
+    SET value = @prunedUntil
+    WHERE name = 'sessionTokensPrunedUntil';
+
+    -- Jiggery-pokery #4: Tidy up.
+    DROP TABLE prunedSessionTokens;
+
+    COMMIT;
+
+    SELECT RELEASE_LOCK('fxa-auth-server.prune-lock');
+  END IF;
+END;
+
+UPDATE dbMetadata SET value = '66' WHERE name = 'schema-patch-level';
+

--- a/lib/db/schema/patch-066-065.sql
+++ b/lib/db/schema/patch-066-065.sql
@@ -1,0 +1,12 @@
+-- DROP INDEX `sessionTokens_createdAt`
+-- ON `sessionTokens`
+-- ALGORITHM=INPLACE
+-- LOCK=NONE;
+
+-- DELETE FROM dbMetadata
+-- WHERE name = 'sessionTokensPrunedUntil';
+
+-- DROP PROCEDURE `prune_5`;
+
+-- UPDATE dbMetadata SET value = '65' WHERE name = 'schema-patch-level';
+


### PR DESCRIPTION
Fixes #278.

Once again, please let me know if there is a better way to do this.

Essentially this PR attempts to implement the approach outlined by @rfk in https://github.com/mozilla/fxa-auth-db-mysql/issues/278#issuecomment-329104531. To wit:

* The missing index on `createdAt` is added. This prevents the prune stored procedure from using a filesort on `sessionTokens`.

* A new value called `sessionTokensPrunedUntil` is added to `dbMetadata`. This signals how far previous iterations of the prune loop have got through the `sessionTokens` table and prevents the subquery from needlessly running against a whole bunch of records that were already processed.

* ~~Pruned `sessionTokens` are added to a temporary table before being deleted. This is so we can set `dbMetadata::sessionTokensPrunedUntil` to `MAX(createdAt)` after the delete has happened.~~

I also expanded the prune tests a little bit to include assertions against a session token that should not be pruned because its `createdAt` is less than `dbMetadata::sessionTokensPrunedUntil`.

What do you guys think, am I on the right track or is there a better way?

@mozilla/fxa-devs r?

/cc @jbuck @jrgm