### PR TITLE
fix(tokens): revert session-token pruning

### DIFF
--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 65
+module.exports.level = 66

--- a/lib/db/schema/patch-065-066.sql
+++ b/lib/db/schema/patch-065-066.sql
@@ -1,0 +1,20 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- Reinstate the code from prune_3
+CREATE PROCEDURE `prune_5` (IN `olderThan` BIGINT UNSIGNED)
+BEGIN
+  SELECT @lockAcquired := GET_LOCK('fxa-auth-server.prune-lock', 3);
+
+  IF @lockAcquired THEN
+    DELETE FROM accountResetTokens WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+    DELETE FROM passwordForgotTokens WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+    DELETE FROM passwordChangeTokens WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+    DELETE FROM unblockCodes WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+    DELETE FROM signinCodes WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+
+    SELECT RELEASE_LOCK('fxa-auth-server.prune-lock');
+  END IF;
+END;
+
+UPDATE dbMetadata SET value = '66' WHERE name = 'schema-patch-level';
+

--- a/lib/db/schema/patch-066-065.sql
+++ b/lib/db/schema/patch-066-065.sql
@@ -1,0 +1,4 @@
+-- DROP PROCEDURE `prune_5`;
+
+-- UPDATE dbMetadata SET value = '65' WHERE name = 'schema-patch-level';
+

--- a/test/local/prune_tokens.js
+++ b/test/local/prune_tokens.js
@@ -47,7 +47,6 @@ describe('prune tokens', () => {
           return P.all([
             db.createPasswordForgotToken(user.passwordForgotTokenId, user.passwordForgotToken),
             db.createUnblockCode(user.accountId, unblockCode),
-            db.createSessionToken(user.sessionTokenId, user.sessionToken),
             db.createSigninCode(signinCode, user.accountId, Date.now() - TOKEN_PRUNE_AGE)
           ])
         })
@@ -56,13 +55,11 @@ describe('prune tokens', () => {
           const sql = {
             accountResetToken: 'UPDATE accountResetTokens SET createdAt = createdAt - ? WHERE tokenId = ?',
             passwordForgotToken: 'UPDATE passwordForgotTokens SET createdAt = createdAt - ? WHERE tokenId = ?',
-            sessionToken: 'UPDATE sessionTokens SET createdAt = createdAt - ? WHERE tokenId = ?',
             unblockCode: 'UPDATE unblockCodes SET createdAt = createdAt - ? WHERE uid = ?'
           }
           return P.all([
             db.write(sql.accountResetToken, [TOKEN_PRUNE_AGE, user.accountResetTokenId]),
             db.write(sql.passwordForgotToken, [TOKEN_PRUNE_AGE, user.passwordForgotTokenId]),
-            db.write(sql.sessionToken, [TOKEN_PRUNE_AGE, user.sessionTokenId]),
             db.write(sql.unblockCode, [TOKEN_PRUNE_AGE, user.accountId])
           ])
         })
@@ -70,8 +67,7 @@ describe('prune tokens', () => {
         .then(() => {
           return P.all([
             db.accountResetToken(user.accountResetTokenId),
-            db.passwordForgotToken(user.passwordForgotTokenId),
-            db.sessionToken(user.sessionTokenId)
+            db.passwordForgotToken(user.passwordForgotTokenId)
           ])
         })
         .then(function() {
@@ -113,18 +109,6 @@ describe('prune tokens', () => {
             assert.equal(err.error, 'Not Found', 'passwordForgotToken() fails with the correct error')
             assert.equal(err.message, 'Not Found', 'passwordForgotToken() fails with the correct message')
           })
-        })
-        .then(() => {
-          return db.sessionToken(user.sessionTokenId)
-            .then(
-              () => assert(false, 'db.sessionToken should have failed'),
-              err => {
-                assert.equal(err.code, 404, 'db.sessionToken returned correct err.code')
-                assert.equal(err.errno, 116, 'db.sessionToken returned correct err.errno')
-                assert.equal(err.error, 'Not Found', 'db.sessionToken returned correct err.error')
-                assert.equal(err.message, 'Not Found', 'db.sessionToken returned correct err.message')
-              }
-            )
         })
         .then(function() {
           var sql = 'SELECT * FROM unblockCodes WHERE uid = ?'


### PR DESCRIPTION
Fixes #278 (in a manner of speaking).

Reinstates the old behaviour from `prune_3`, so that token pruning can be enabled for train 96. See #279 for discussions of the failed attempt(s) to fix session-token pruning. The original problematic code was introduced by #275.

@mozilla/fxa-devs r?