### PR TITLE
fix(db): call latest version of the prune stored procedure

### DIFF
--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -1087,7 +1087,7 @@ module.exports = function (log, error) {
   // exposed for testing only
   MySql.prototype.retryable_ = retryable
 
-  const PRUNE = 'CALL prune_4(?)'
+  const PRUNE = 'CALL prune_5(?)'
   MySql.prototype.pruneTokens = function () {
     log.info('MySql.pruneTokens')
 


### PR DESCRIPTION
When I reverted session token pruning, I failed to update the procedure version in `lib/db/mysql.js`. This went undetected by the tests because nothing was there to assert that session tokens *weren't* being pruned. I've added that test here to go with the fix.

@mozilla/fxa-devs r?