### PR TITLE
feat(db): prune session tokens (again)

### DIFF
--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -1087,7 +1087,7 @@ module.exports = function (log, error) {
   // exposed for testing only
   MySql.prototype.retryable_ = retryable
 
-  const PRUNE = 'CALL prune_5(?)'
+  const PRUNE = 'CALL prune_6(?)'
   MySql.prototype.pruneTokens = function () {
     log.info('MySql.pruneTokens')
 

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 66
+module.exports.level = 67

--- a/lib/db/schema/patch-066-067.sql
+++ b/lib/db/schema/patch-066-067.sql
@@ -1,0 +1,81 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- Add an index on sessionTokens::createdAt to make pruning faster.
+CREATE INDEX `sessionTokens_createdAt`
+ON `sessionTokens` (`createdAt`)
+ALGORITHM=INPLACE
+LOCK=NONE;
+
+-- Used to prevent session token pruning from doing a full table scan
+-- as it proceeds further and further through the (very long) backlog
+-- of pruning candidates.
+INSERT INTO dbMetadata (name, value)
+VALUES ('sessionTokensPrunedUntil', 0);
+
+-- Update prune to delete sessionTokens and unverifiedTokens.
+CREATE PROCEDURE `prune_6` (IN `olderThan` BIGINT UNSIGNED)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  SELECT @lockAcquired := GET_LOCK('fxa-auth-server.prune-lock', 3);
+
+  IF @lockAcquired THEN
+    DELETE FROM accountResetTokens WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+    DELETE FROM passwordForgotTokens WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+    DELETE FROM passwordChangeTokens WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+    DELETE FROM unblockCodes WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+    DELETE FROM signinCodes WHERE createdAt < olderThan ORDER BY createdAt LIMIT 10000;
+
+    -- Pruning session tokens is more complicated because we can't
+    -- prune them if there is an associated device record.
+    START TRANSACTION;
+
+    -- Step 1: Find out how far we got on previous iterations.
+    SELECT @pruneFrom := value FROM dbMetadata WHERE name = 'sessionTokensPrunedUntil';
+
+    -- Step 2: Find out how far we will get on this iteration.
+    SELECT @pruneUntil := MAX(createdAt) FROM (
+      SELECT createdAt FROM sessionTokens
+      WHERE createdAt >= @pruneFrom AND createdAt < olderThan
+      AND NOT EXISTS (
+        SELECT sessionTokenId FROM devices
+        WHERE uid = sessionTokens.uid
+        AND sessionTokenId = sessionTokens.tokenId
+      )
+      ORDER BY createdAt
+      LIMIT 10000
+    ) AS prunees;
+
+    -- Step 3: Prune sessionTokens.
+    DELETE FROM sessionTokens
+    WHERE createdAt > @pruneFrom AND createdAt <= @pruneUntil
+    AND NOT EXISTS (
+      SELECT sessionTokenId FROM devices
+      WHERE uid = sessionTokens.uid
+      AND sessionTokenId = sessionTokens.tokenId
+    );
+
+    -- Step 4: Prune unverifiedTokens.
+    DELETE ut
+    FROM unverifiedTokens AS ut
+    LEFT JOIN sessionTokens AS st ON ut.tokenId = st.tokenId
+    LEFT JOIN keyFetchTokens AS kt ON ut.tokenId = kt.tokenId
+    WHERE st.tokenId IS NULL AND kt.tokenId IS NULL;
+
+    -- Step 5: Tell following iterations how far we got.
+    UPDATE dbMetadata
+    SET value = @pruneUntil
+    WHERE name = 'sessionTokensPrunedUntil';
+
+    COMMIT;
+
+    SELECT RELEASE_LOCK('fxa-auth-server.prune-lock');
+  END IF;
+END;
+
+UPDATE dbMetadata SET value = '67' WHERE name = 'schema-patch-level';
+

--- a/lib/db/schema/patch-067-066.sql
+++ b/lib/db/schema/patch-067-066.sql
@@ -1,0 +1,12 @@
+-- DROP INDEX `sessionTokens_createdAt`
+-- ON `sessionTokens`
+-- ALGORITHM=INPLACE
+-- LOCK=NONE;
+
+-- DELETE FROM dbMetadata
+-- WHERE name = 'sessionTokensPrunedUntil';
+
+-- DROP PROCEDURE `prune_6`;
+
+-- UPDATE dbMetadata SET value = '66' WHERE name = 'schema-patch-level';
+


### PR DESCRIPTION
Fixes #263.

Earlier on, @rfk was kind enough to point out that simply including `uid` in the `devices` join would allow MySQL to use the existing index on `devices` and make session token pruning fast. I tried it just now and, of course, he was dead right.

But don't take my word for it, here are the numbers:

```
mysql> select count(*) from sessionTokens;
+----------+
| count(*) |
+----------+
|  6000016 |
+----------+
1 row in set (1.49 sec)

mysql> select count(*)
    -> from sessionTokens as t
    -> left join devices as d
    -> on t.tokenId = d.sessionTokenId and t.uid = d.uid
    -> where d.id is null;
+----------+
| count(*) |
+----------+
|  1333348 |
+----------+
1 row in set (20.92 sec)

mysql> call prune_6(1505929326193);
+------------------------------------------------------------+
| @lockAcquired := GET_LOCK('fxa-auth-server.prune-lock', 3) |
+------------------------------------------------------------+
|                                                          1 |
+------------------------------------------------------------+
1 row in set (0.00 sec)

+----------------------+
| @pruneFrom := value  |
+----------------------+
| 0                    |
+----------------------+
1 row in set (0.00 sec)

+-------------------------------+
| @pruneUntil := MAX(createdAt) |
+-------------------------------+
|                 1505906643327 |
+-------------------------------+
1 row in set (4.45 sec)

+--------------------------------------------+
| RELEASE_LOCK('fxa-auth-server.prune-lock') |
+--------------------------------------------+
|                                          1 |
+--------------------------------------------+
1 row in set (6.52 sec)

Query OK, 0 rows affected (6.52 sec)

mysql> select count(*) from sessionTokens;
+----------+
| count(*) |
+----------+
|  5990016 |
+----------+
1 row in set (1.49 sec)

mysql> select count(*)
    -> from sessionTokens as t
    -> left join devices as d
    -> on t.tokenId = d.sessionTokenId and t.uid = d.uid
    -> where d.id is null;
+----------+
| count(*) |
+----------+
|  1323348 |
+----------+
1 row in set (20.92 sec)
```

(so using almost an identical set-up to https://github.com/mozilla/fxa-auth-db-mysql/pull/279#issuecomment-329853042)

And then, just to prove it wasn't a fluke, the next iteration:

```
mysql> call prune_6(1505929326193);
+------------------------------------------------------------+
| @lockAcquired := GET_LOCK('fxa-auth-server.prune-lock', 3) |
+------------------------------------------------------------+
|                                                          1 |
+------------------------------------------------------------+
1 row in set (0.00 sec)

+----------------------+
| @pruneFrom := value  |
+----------------------+
| 1505906643327        |
+----------------------+
1 row in set (0.00 sec)

+-------------------------------+
| @pruneUntil := MAX(createdAt) |
+-------------------------------+
|                 1505906675789 |
+-------------------------------+
1 row in set (0.99 sec)

+--------------------------------------------+
| RELEASE_LOCK('fxa-auth-server.prune-lock') |
+--------------------------------------------+
|                                          1 |
+--------------------------------------------+
1 row in set (2.79 sec)

Query OK, 0 rows affected (2.79 sec)

mysql> select count(*) from sessionTokens;
+----------+
| count(*) |
+----------+
|  5980016 |
+----------+
1 row in set (1.93 sec)

mysql> select count(*)
    -> from sessionTokens as t
    -> left join devices as d
    -> on t.tokenId = d.sessionTokenId and t.uid = d.uid
    -> where d.id is null;
+----------+
| count(*) |
+----------+
|  1313348 |
+----------+
1 row in set (15.45 sec)
```

@mozilla/fxa-devs r?