### PR TITLE
fix(travis): run tests with 6 and current stable (failure not allowed anymore)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 
 node_js:
  - "6"
- - "stable"
+ - "8"
 
 dist: trusty
 
@@ -41,8 +41,3 @@ script:
   - COVERALLS_REPO_TOKEN=mlOESL8slkePkodJpcvhF1AUKUH3llXi8 npm run test-travis
   # memory tests are separate to avoid being included into coverage because they run through the same code
   - npm run test-mem
-
-matrix:
-  allow_failures:
-    - node_js: "stable"
-  fast_finish: true

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "fxa-auth-db-mysql": "bin/db_patcher.js"
   },
   "scripts": {
-    "outdated": "npm outdated --depth 0",
+    "outdated": "npm outdated --depth 0 || exit 0",
     "shrink": "npmshrink",
     "start": "node ./bin/db_patcher.js >/dev/null && node ./bin/server.js",
     "start-mem": "node ./bin/mem",


### PR DESCRIPTION
run on 6 and 8, and removes the matrix that allowed "stable" to fail. Both must pass.

This repo was running `npm outdated`. With npm < 5, it would exit 0; with npm >= 5, it now exits 1. I just made it behave like before, but not sure what it's trying to do (just show what is outdated?).

r? - @rfk 