### PR TITLE
feat(codes): add support for verifying token short code

### DIFF
--- a/fxa-auth-db-server/index.js
+++ b/fxa-auth-db-server/index.js
@@ -41,6 +41,12 @@ function createServer(db) {
     })
   }
 
+  function withParamsAndBody(fn) {
+    return reply(function (params, body, query) {
+      return fn.call(db, params, body)
+    })
+  }
+
   var api = restify.createServer({
     formatters: {
       'application/json; q=0.9': safeJsonFormatter
@@ -120,6 +126,7 @@ function createServer(db) {
   api.get('/sessionToken/:id/verified', withIdAndBody(db.sessionTokenWithVerificationStatus))
   api.get('/keyFetchToken/:id/verified', withIdAndBody(db.keyFetchTokenWithVerificationStatus))
   api.post('/tokens/:id/verify', withIdAndBody(db.verifyTokens))
+  api.post('/tokens/:code/verifyCode', withParamsAndBody(db.verifyTokenCode))
 
   api.get('/accountResetToken/:id', withIdAndBody(db.accountResetToken))
   api.del('/accountResetToken/:id', withIdAndBody(db.deleteAccountResetToken))

--- a/fxa-auth-db-server/lib/error.js
+++ b/fxa-auth-db-server/lib/error.js
@@ -61,6 +61,17 @@ AppError.cannotDeletePrimaryEmail = function () {
   )
 }
 
+AppError.expiredTokenVerificationCode = function () {
+  return new AppError(
+    {
+      code: 400,
+      error: 'Bad request',
+      errno: 137,
+      message: 'Expired token verification code'
+    }
+  )
+}
+
 AppError.wrap = function (err) {
   return new AppError(
     {

--- a/fxa-auth-db-server/test/fake.js
+++ b/fxa-auth-db-server/test/fake.js
@@ -59,7 +59,9 @@ module.exports.newUserDataHex = function() {
     uaDeviceType: 'fake device type',
     uaFormFactor: 'fake form factor',
     mustVerify: true,
-    tokenVerificationId: hex16()
+    tokenVerificationId: hex16(),
+    tokenVerificationCode: crypto.randomBytes(4).toString('hex'),
+    tokenVerificationCodeExpiresAt: Date.now() + 20000
   }
 
   // device

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 67
+module.exports.level = 68

--- a/lib/db/schema/patch-067-068.sql
+++ b/lib/db/schema/patch-067-068.sql
@@ -1,0 +1,168 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+ALTER TABLE `unverifiedTokens`
+ADD COLUMN `tokenVerificationCodeHash` BINARY(32) DEFAULT NULL,
+ADD COLUMN `tokenVerificationCodeExpiresAt` BIGINT UNSIGNED DEFAULT NULL,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+CREATE UNIQUE INDEX `unverifiedTokens_tokenVerificationCodeHash_uid`
+ON `unverifiedTokens` (`tokenVerificationCodeHash`, `uid`)
+ALGORITHM = INPLACE LOCK=NONE;
+
+CREATE PROCEDURE `verifyTokenCode_1` (
+  IN `tokenVerificationCodeHashArg` BINARY(32),
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  SET @tokenVerificationId = NULL;
+  SELECT tokenVerificationId INTO @tokenVerificationId FROM unverifiedTokens
+    WHERE uid = uidArg
+    AND tokenVerificationCodeHash = tokenVerificationCodeHashArg
+    AND tokenVerificationCodeExpiresAt >= (UNIX_TIMESTAMP(NOW(3)) * 1000);
+
+  IF @tokenVerificationId IS NULL THEN
+    SET @expiredCount = 0;
+    SELECT COUNT(*) INTO @expiredCount FROM unverifiedTokens
+      WHERE uid = uidArg
+      AND tokenVerificationCodeHash = tokenVerificationCodeHashArg
+      AND tokenVerificationCodeExpiresAt < (UNIX_TIMESTAMP(NOW(3)) * 1000);
+
+    IF @expiredCount > 0 THEN
+      SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 2101, MESSAGE_TEXT = 'Expired token verification code.';
+    END IF;
+  END IF;
+
+  START TRANSACTION;
+    UPDATE securityEvents
+    SET verified = true
+    WHERE tokenVerificationId = @tokenVerificationId
+    AND uid = uidArg;
+
+    DELETE FROM unverifiedTokens
+    WHERE tokenVerificationId = @tokenVerificationId
+    AND uid = uidArg;
+
+    SET @updateCount = (SELECT ROW_COUNT());
+  COMMIT;
+
+  SELECT @updateCount;
+END;
+
+CREATE PROCEDURE `createSessionToken_8` (
+  IN `tokenId` BINARY(32),
+  IN `tokenData` BINARY(32),
+  IN `uid` BINARY(16),
+  IN `createdAt` BIGINT UNSIGNED,
+  IN `uaBrowser` VARCHAR(255),
+  IN `uaBrowserVersion` VARCHAR(255),
+  IN `uaOS` VARCHAR(255),
+  IN `uaOSVersion` VARCHAR(255),
+  IN `uaDeviceType` VARCHAR(255),
+  IN `uaFormFactor` VARCHAR(255),
+  IN `tokenVerificationId` BINARY(16),
+  IN `mustVerify` BOOLEAN,
+  IN `tokenVerificationCodeHash` BINARY(32),
+  IN `tokenVerificationCodeExpiresAt` BIGINT UNSIGNED
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  INSERT INTO sessionTokens(
+    tokenId,
+    tokenData,
+    uid,
+    createdAt,
+    uaBrowser,
+    uaBrowserVersion,
+    uaOS,
+    uaOSVersion,
+    uaDeviceType,
+    uaFormFactor,
+    lastAccessTime
+  )
+  VALUES(
+    tokenId,
+    tokenData,
+    uid,
+    createdAt,
+    uaBrowser,
+    uaBrowserVersion,
+    uaOS,
+    uaOSVersion,
+    uaDeviceType,
+    uaFormFactor,
+    createdAt
+  );
+
+  IF tokenVerificationId IS NOT NULL THEN
+    INSERT INTO unverifiedTokens(
+      tokenId,
+      tokenVerificationId,
+      uid,
+      mustVerify,
+      tokenVerificationCodeHash,
+      tokenVerificationCodeExpiresAt
+    )
+    VALUES(
+      tokenId,
+      tokenVerificationId,
+      uid,
+      mustVerify,
+      tokenVerificationCodeHash,
+      tokenVerificationCodeExpiresAt
+    );
+  END IF;
+
+  COMMIT;
+END;
+
+CREATE PROCEDURE `sessionTokenWithVerificationStatus_7` (
+  IN `tokenIdArg` BINARY(32)
+)
+BEGIN
+  SELECT
+    t.tokenData,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.uaFormFactor,
+    t.lastAccessTime,
+    e.isVerified AS emailVerified,
+    e.email,
+    e.emailCode,
+    a.verifierSetAt,
+    a.locale,
+    a.createdAt AS accountCreatedAt,
+    ut.tokenVerificationId,
+    ut.mustVerify,
+    ut.tokenVerificationCodeHash,
+    ut.tokenVerificationCodeExpiresAt
+  FROM sessionTokens AS t
+  LEFT JOIN accounts AS a
+    ON t.uid = a.uid
+  LEFT JOIN emails AS e
+    ON t.uid = e.uid
+    AND e.isPrimary = true
+  LEFT JOIN unverifiedTokens AS ut
+    ON t.tokenId = ut.tokenId
+  WHERE t.tokenId = tokenIdArg;
+END;
+
+UPDATE dbMetadata SET value = '68' WHERE name = 'schema-patch-level';
+

--- a/lib/db/schema/patch-068-067.sql
+++ b/lib/db/schema/patch-068-067.sql
@@ -1,0 +1,13 @@
+-- DROP INDEX unverifiedTokens_tokenVerificationCodeHash_uid;
+
+-- ALTER TABLE `unverifiedTokens`
+-- DROP COLUMN `tokenVerificationCode` BINARY(32),
+-- DROP COLUMN `tokenVerificationCodeExpiresAt` BIGINT UNSIGNED,
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- DROP PROCEDURE `sessionTokenWithVerificationStatus_7`;
+-- DROP PROCEDURE `createSessionToken_8`;
+-- DROP PROCEDURE `verifyTokenCode_1`;
+
+-- UPDATE dbMetadata SET value = '67' WHERE name = 'schema-patch-level';
+

--- a/lib/db/util.js
+++ b/lib/db/util.js
@@ -51,10 +51,10 @@ module.exports = {
 
   createHash () {
     const hash = crypto.createHash('sha256')
-    // Use ...rest operator and forEach when we're on node 6
-    for (let i = 0; i < arguments.length; ++i) {
-      hash.update(arguments[i])
-    }
+    const args = [...arguments]
+    args.forEach((arg) => {
+      hash.update(arg)
+    })
     return hash.digest()
   }
 }

--- a/lib/db/util.js
+++ b/lib/db/util.js
@@ -4,6 +4,7 @@
 
 'use strict'
 
+const crypto = require('crypto')
 
 const BOUNCE_TYPES = new Map([
   ['__fxa__unmapped', 0], // a bounce type we don't yet recognize
@@ -46,6 +47,14 @@ module.exports = {
     } else {
       return BOUNCE_SUB_TYPES.get(val) || 0
     }
-  }
+  },
 
+  createHash () {
+    const hash = crypto.createHash('sha256')
+    // Use ...rest operator and forEach when we're on node 6
+    for (let i = 0; i < arguments.length; ++i) {
+      hash.update(arguments[i])
+    }
+    return hash.digest()
+  }
 }


### PR DESCRIPTION
This PR exposes new APIs to create and verify sessionTokens using a short code. Couple notes

- Each code has an expiration date
- Codes are stored as hashes in database
- Support for resending (aka regenerating) a code to come in later PR.
- New endpoint `verifyTokensShortCode` used to explicitly verify shortCodes. 

Connects with https://github.com/mozilla/fxa-auth-server/pull/2218

Feature doc: https://docs.google.com/document/d/1xQtCGBJ9XZuF1q9faZV3YIiOnxomQMHKiTP62YSf3v8/edit

@mozilla/fxa-devs r?

