### PR TITLE
feat(tests): make tests more independent

### DIFF
--- a/db-server/test/backend/db_tests.js
+++ b/db-server/test/backend/db_tests.js
@@ -5,7 +5,6 @@
 
 const assert = require('insist')
 const crypto = require('crypto')
-const base64url = require('base64url')
 const P = require('bluebird')
 
 const zeroBuffer16 = Buffer.from('00000000000000000000000000000000', 'hex')
@@ -33,9 +32,10 @@ function createAccount() {
     wrapWrapKb: zeroBuffer32,
     verifierSetAt: now,
     createdAt: now,
-    locale : 'en_US',
+    locale: 'en_US',
   }
   account.normalizedEmail = account.email.toLowerCase()
+  account.emailBuffer = Buffer(account.email)
   return account
 }
 
@@ -54,1938 +54,1315 @@ function createEmail(data) {
   return email
 }
 
-
-const ACCOUNT = createAccount()
-
 function hex(len) {
   return Buffer(crypto.randomBytes(len).toString('hex'), 'hex')
 }
 function hex6() { return hex(6) }
-function hex16() { return hex(16) }
-function hex32() { return hex(32) }
+function hex16() {
+  return hex(16)
+}
+function hex32() {
+  return hex(32)
+}
 // function hex64() { return hex(64) }
-function hex96() { return hex(96) }
-
-function base64(len) {
-  return base64url(crypto.randomBytes(len))
+function hex96() {
+  return hex(96)
 }
 
-function base64_16() { return base64(16) }
-function base64_65() { return base64(65) }
-
-const SESSION_TOKEN_ID = hex32()
-const SESSION_TOKEN = {
-  data : hex32(),
-  uid : ACCOUNT.uid,
-  createdAt : now + 1,
-  uaBrowser : 'mock browser',
-  uaBrowserVersion : 'mock browser version',
-  uaOS : 'mock OS',
-  uaOSVersion : 'mock OS version',
-  uaDeviceType : 'mock device type',
-  uaFormFactor : 'mock form factor',
-  mustVerify: true,
-  tokenVerificationId : hex16()
-}
-
-const KEY_FETCH_TOKEN_ID = hex32()
-const KEY_FETCH_TOKEN = {
-  authKey : hex32(),
-  uid : ACCOUNT.uid,
-  keyBundle : hex96(),
-  createdAt : now + 2,
-  tokenVerificationId : hex16()
-}
-
-const PASSWORD_FORGOT_TOKEN_ID = hex32()
-const PASSWORD_FORGOT_TOKEN = {
-  data : hex32(),
-  uid : ACCOUNT.uid,
-  passCode : hex16(),
-  tries : 1,
-  createdAt: now + 3
-}
-
-const PASSWORD_CHANGE_TOKEN_ID = hex32()
-const PASSWORD_CHANGE_TOKEN = {
-  data : hex32(),
-  uid : ACCOUNT.uid,
-  createdAt: now + 4
-}
-
-const ACCOUNT_RESET_TOKEN_ID = hex32()
-const ACCOUNT_RESET_TOKEN = {
-  tokenId : ACCOUNT_RESET_TOKEN_ID,
-  data : hex32(),
-  uid : ACCOUNT.uid,
-  createdAt: now + 5
-}
-
-function makeMockSessionToken(uid) {
-  var sessionToken = {
-    data : hex32(),
-    uid : uid,
-    createdAt : now + 1,
-    uaBrowser : 'mock browser',
-    uaBrowserVersion : 'mock browser version',
-    uaOS : 'mock OS',
-    uaOSVersion : 'mock OS version',
-    uaDeviceType : 'mock device type',
-    mustVerify: true,
-    tokenVerificationId : hex16(),
+function makeMockSessionToken(uid, mustVerify) {
+  const sessionToken = {
+    tokenId: hex32(),
+    data: hex32(),
+    uid: uid,
+    createdAt: Date.now(),
+    uaBrowser: 'mock browser',
+    uaBrowserVersion: 'mock browser version',
+    uaOS: 'mock OS',
+    uaOSVersion: 'mock OS version',
+    uaDeviceType: 'mock device type',
+    mustVerify: mustVerify,
+    tokenVerificationId: hex16(),
     tokenVerificationCode: unblockCode(),
     tokenVerificationCodeExpiresAt: Date.now() + 20000
   }
-
   return sessionToken
+}
+
+function makeMockDevice(tokenId) {
+  const device = {
+    sessionTokenId: tokenId,
+    name: 'Test Device',
+    type: 'mobile',
+    createdAt: Date.now(),
+    callbackURL: 'https://push.server',
+    callbackPublicKey: 'foo',
+    callbackAuthKey: 'bar',
+    callbackIsExpired: false
+  }
+  device.deviceId = newUuid()
+  return device
+}
+
+function makeMockForgotPasswordToken(uid) {
+  const token = {
+    data: hex32(),
+    tokenId: hex32(),
+    uid: uid,
+    passCode: hex16(),
+    tries: 1,
+    createdAt: Date.now()
+  }
+  return token
+}
+
+function makeMockKeyFetchToken(uid, verified) {
+  const keyFetchToken = {
+    authKey: hex32(),
+    uid: uid,
+    keyBundle: hex96(),
+    createdAt: now + 2,
+    tokenVerificationId: verified ? undefined : hex16()
+  }
+  keyFetchToken.tokenId = hex32()
+  return keyFetchToken
+}
+
+function makeMockChangePasswordToken(uid) {
+  const token = {
+    data: hex32(),
+    uid: uid,
+    createdAt: Date.now()
+  }
+  token.tokenId = hex32()
+  return token
+}
+
+function makeMockAccountResetToken(uid, tokenId) {
+  const token = {
+    tokenId: tokenId || hex32(),
+    data: hex32(),
+    uid: uid,
+    createdAt: now + 5
+  }
+  return token
 }
 
 // To run these tests from a new backend, pass the config and an already created
 // DB API for them to be run against.
-module.exports = function(config, DB) {
+module.exports = function (config, DB) {
   describe('db_tests', () => {
 
-    let db
+    let db, accountData
     before(() => {
-      return DB.connect(config).then(db_ => {
-        db = db_
-        return db.ping()
+      return DB.connect(config)
+        .then(db_ => {
+          db = db_
+          return db.ping()
+        })
+        .then(() => {
+          accountData = createAccount()
+          return db.createAccount(accountData.uid, accountData)
+        })
+    })
+
+    describe('account', () => {
+      let accountData
+      beforeEach(() => {
+        accountData = createAccount()
+        return db.accountExists(accountData.emailBuffer)
+          .then(() => assert.fail, (err) => assert.equal(err.code, 404, 'Not found'))
+          .then(() => db.createAccount(accountData.uid, accountData))
+      })
+
+      describe('db.createAccount', () => {
+        it('should create account', () => {
+          accountData = createAccount()
+          return db.accountExists(accountData.emailBuffer)
+            .then(() => assert.fail, (err) => assert.equal(err.code, 404, 'Not found'))
+            .then(() => db.createAccount(accountData.uid, accountData))
+            .then((account) => {
+              assert.deepEqual(account, {}, 'Returned an empty object on account creation')
+              return db.accountExists(Buffer(accountData.email))
+                .then((exists) => assert(exists, 'account exists for this email address'), assert.fail)
+            })
+        })
+
+        it('fails with duplicate account', () => {
+          return db.createAccount(accountData.uid, accountData)
+            .then(assert.fail, (err) => {
+              assert(err, 'trying to create the same account produces an error')
+              assert.equal(err.code, 409, 'error code')
+              assert.equal(err.errno, 101, 'error errno')
+              assert.equal(err.message, 'Record already exists', 'message')
+              assert.equal(err.error, 'Conflict', 'error')
+            })
+        })
+      })
+
+      describe('db.account', () => {
+        it('should return account', () => {
+          return db.account(accountData.uid)
+            .then((account) => {
+              assert.deepEqual(account.uid, accountData.uid, 'uid')
+              assert.equal(account.email, accountData.email, 'email')
+              assert.deepEqual(account.emailCode, accountData.emailCode, 'emailCode')
+              assert.equal(!! account.emailVerified, accountData.emailVerified, 'emailVerified')
+              assert.deepEqual(account.kA, accountData.kA, 'kA')
+              assert.deepEqual(account.wrapWrapKb, accountData.wrapWrapKb, 'wrapWrapKb')
+              assert(! account.verifyHash, 'verifyHash field should be absent')
+              assert.deepEqual(account.authSalt, accountData.authSalt, 'authSalt')
+              assert.equal(account.verifierVersion, accountData.verifierVersion, 'verifierVersion')
+              assert.equal(account.createdAt, accountData.createdAt, 'createdAt')
+              assert.equal(account.verifierSetAt, accountData.createdAt, 'verifierSetAt has been set to the same as createdAt')
+              assert.equal(account.locale, accountData.locale, 'locale')
+            })
+        })
+      })
+
+      describe('db.emailRecord', () => {
+        it('should return email record', () => {
+          return db.emailRecord(accountData.emailBuffer)
+            .then((account) => {
+              assert.deepEqual(account.uid, accountData.uid, 'uid')
+              assert.equal(account.email, accountData.email, 'email')
+              assert.deepEqual(account.emailCode, accountData.emailCode, 'emailCode')
+              assert.equal(!! account.emailVerified, accountData.emailVerified, 'emailVerified')
+              assert.deepEqual(account.kA, accountData.kA, 'kA')
+              assert.deepEqual(account.wrapWrapKb, accountData.wrapWrapKb, 'wrapWrapKb')
+              assert(! account.verifyHash, 'verifyHash field should be absent')
+              assert.deepEqual(account.authSalt, accountData.authSalt, 'authSalt')
+              assert.equal(account.verifierVersion, accountData.verifierVersion, 'verifierVersion')
+              assert.equal(account.verifierSetAt, accountData.verifierSetAt, 'verifierSetAt')
+              // locale not returned with .emailRecord() (unlike .account() when it is)
+            })
+        })
+      })
+
+    })
+
+    describe('db.checkPassword', () => {
+      let accountData
+      beforeEach(() => {
+        accountData = createAccount()
+        return db.createAccount(accountData.uid, accountData)
+      })
+
+      it('should fail with incorrect password', () => {
+        return db.checkPassword(accountData.uid, {verifyHash: Buffer(crypto.randomBytes(32))})
+          .then(assert.fail, (err) => {
+            assert(err, 'incorrect password produces an error')
+            assert.equal(err.code, 400, 'error code')
+            assert.equal(err.errno, 103, 'error errno')
+            assert.equal(err.message, 'Incorrect password', 'message')
+            assert.equal(err.error, 'Bad request', 'error')
+            return db.checkPassword(accountData.uid, {verifyHash: zeroBuffer32})
+          })
+      })
+
+      it('should be successful with correct password', () => {
+        return db.checkPassword(accountData.uid, {verifyHash: zeroBuffer32})
+          .then((account) => {
+            assert.deepEqual(account.uid, account.uid, 'uid')
+            assert.equal(Object.keys(account).length, 1, 'Only one field (uid) was returned, nothing else')
+          })
       })
     })
 
-    it(
-      'account creation and password checking',
-      () => {
-        var emailBuffer = Buffer(ACCOUNT.email)
-        return db.accountExists(emailBuffer)
-        .then(function(exists) {
-          assert(false, 'account should not yet exist for this email address')
-        }, function(err) {
-          // ok, account could not be found'
+    describe('session token handling', () => {
+      let accountData, sessionTokenData
+      beforeEach(() => {
+        accountData = createAccount()
+        sessionTokenData = makeMockSessionToken(accountData.uid, false)
+        return P.all([db.createAccount(accountData.uid, accountData), db.createSessionToken(sessionTokenData.tokenId, sessionTokenData)])
+      })
+
+      describe('db.sessions', () => {
+        it('should get sessions', () => {
+          return db.sessions(accountData.uid)
+            .then((sessions) => {
+              assert(Array.isArray(sessions), 'sessions is an array')
+              assert.equal(sessions.length, 1, 'sessions has one item')
+
+              assert.equal(Object.keys(sessions[0]).length, 18, 'session has correct properties')
+              assert.equal(sessions[0].tokenId.toString('hex'), sessionTokenData.tokenId.toString('hex'), 'tokenId is correct')
+              assert.equal(sessions[0].uid.toString('hex'), accountData.uid.toString('hex'), 'uid is correct')
+              assert.equal(sessions[0].createdAt, sessionTokenData.createdAt, 'createdAt is correct')
+              assert.equal(sessions[0].uaBrowser, sessionTokenData.uaBrowser, 'uaBrowser is correct')
+              assert.equal(sessions[0].uaBrowserVersion, sessionTokenData.uaBrowserVersion, 'uaBrowserVersion is correct')
+              assert.equal(sessions[0].uaOS, sessionTokenData.uaOS, 'uaOS is correct')
+              assert.equal(sessions[0].uaOSVersion, sessionTokenData.uaOSVersion, 'uaOSVersion is correct')
+              assert.equal(sessions[0].uaDeviceType, sessionTokenData.uaDeviceType, 'uaDeviceType is correct')
+              assert.equal(sessions[0].uaFormFactor, sessionTokenData.uaFormFactor, 'uaFormFactor is correct')
+              assert.equal(sessions[0].lastAccessTime, sessionTokenData.createdAt, 'lastAccessTime is correct')
+            })
         })
-        .then(function() {
-          return db.createAccount(ACCOUNT.uid, ACCOUNT)
+      })
+
+      describe('db.createSessionToken', () => {
+        it('should creates session', () => {
+          accountData = createAccount()
+          sessionTokenData = makeMockSessionToken(accountData.uid, false)
+          return db.createAccount(accountData.uid, accountData)
+            .then(() => db.createSessionToken(sessionTokenData.tokenId, sessionTokenData))
+            .then((result) => {
+              assert.deepEqual(result, {}, 'Returned an empty object on session token creation')
+              return db.sessions(accountData.uid)
+            })
+            .then((sessions) => {
+              assert(Array.isArray(sessions), 'sessions is an array')
+              assert.equal(sessions.length, 1, 'sessions has one item')
+            })
         })
-        .then(function(account) {
-          assert.deepEqual(account, {}, 'Returned an empty object on account creation')
-          var emailBuffer = Buffer(ACCOUNT.email)
-          return db.accountExists(emailBuffer)
+      })
+
+      describe('db.sessionToken', () => {
+        it('should get token', () => {
+          return db.sessionToken(sessionTokenData.tokenId)
+            .then((token) => {
+              // tokenId is not returned from db.sessionToken()
+              assert.deepEqual(token.tokenData, sessionTokenData.data, 'token data matches')
+              assert.deepEqual(token.uid, accountData.uid, 'token belongs to this account')
+              assert.equal(token.createdAt, sessionTokenData.createdAt, 'createdAt is correct')
+              assert.equal(token.uaBrowser, sessionTokenData.uaBrowser, 'uaBrowser is correct')
+              assert.equal(token.uaBrowserVersion, sessionTokenData.uaBrowserVersion, 'uaBrowserVersion is correct')
+              assert.equal(token.uaOS, sessionTokenData.uaOS, 'uaOS is correct')
+              assert.equal(token.uaOSVersion, sessionTokenData.uaOSVersion, 'uaOSVersion is correct')
+              assert.equal(token.uaDeviceType, sessionTokenData.uaDeviceType, 'uaDeviceType is correct')
+              assert.equal(token.uaFormFactor, sessionTokenData.uaFormFactor, 'uaFormFactor is correct')
+              assert.equal(token.lastAccessTime, sessionTokenData.createdAt, 'lastAccessTime was set')
+              assert.equal(!! token.emailVerified, accountData.emailVerified, 'token emailVerified is same as account emailVerified')
+              assert.equal(token.email, accountData.email, 'token email same as account email')
+              assert.deepEqual(token.emailCode, accountData.emailCode, 'token emailCode same as account emailCode')
+              assert.equal(token.verifierSetAt, accountData.verifierSetAt, 'verifierSetAt is correct')
+              assert.equal(token.accountCreatedAt, accountData.createdAt, 'accountCreatedAt is correct')
+            })
         })
-        .then(function(exists) {
-          assert(exists, 'account exists for this email address')
-        })
-        .then(function() {
-          return db.account(ACCOUNT.uid)
-        })
-        .then(function(account) {
-          assert.deepEqual(account.uid, ACCOUNT.uid, 'uid')
-          assert.equal(account.email, ACCOUNT.email, 'email')
-          assert.deepEqual(account.emailCode, ACCOUNT.emailCode, 'emailCode')
-          assert.equal(!! account.emailVerified, ACCOUNT.emailVerified, 'emailVerified')
-          assert.deepEqual(account.kA, ACCOUNT.kA, 'kA')
-          assert.deepEqual(account.wrapWrapKb, ACCOUNT.wrapWrapKb, 'wrapWrapKb')
-          assert(! account.verifyHash, 'verifyHash field should be absent')
-          assert.deepEqual(account.authSalt, ACCOUNT.authSalt, 'authSalt')
-          assert.equal(account.verifierVersion, ACCOUNT.verifierVersion, 'verifierVersion')
-          assert.equal(account.createdAt, ACCOUNT.createdAt, 'createdAt')
-          assert.equal(account.verifierSetAt, account.createdAt, 'verifierSetAt has been set to the same as createdAt')
-          assert.equal(account.locale, ACCOUNT.locale, 'locale')
-        })
-        .then(function() {
-          return db.checkPassword(ACCOUNT.uid, {verifyHash: Buffer(crypto.randomBytes(32))})
-        })
-        .then(function() {
-          assert(false, 'password check should fail')
-        }, function(err) {
-          assert(err, 'incorrect password produces an error')
-          assert.equal(err.code, 400, 'error code')
-          assert.equal(err.errno, 103, 'error errno')
-          assert.equal(err.message, 'Incorrect password', 'message')
-          assert.equal(err.error, 'Bad request', 'error')
-        })
-        .then(function() {
-          return db.checkPassword(ACCOUNT.uid, {verifyHash: zeroBuffer32})
-        })
-        .then(function(account) {
-          assert.deepEqual(account.uid, ACCOUNT.uid, 'uid')
-          assert.equal(Object.keys(account).length, 1, 'Only one field (uid) was returned, nothing else')
-        })
-        .then(function() {
-          var emailBuffer = Buffer(ACCOUNT.email)
-          return db.emailRecord(emailBuffer)
-        })
-        .then(function(account) {
-          assert.deepEqual(account.uid, ACCOUNT.uid, 'uid')
-          assert.equal(account.email, ACCOUNT.email, 'email')
-          assert.deepEqual(account.emailCode, ACCOUNT.emailCode, 'emailCode')
-          assert.equal(!! account.emailVerified, ACCOUNT.emailVerified, 'emailVerified')
-          assert.deepEqual(account.kA, ACCOUNT.kA, 'kA')
-          assert.deepEqual(account.wrapWrapKb, ACCOUNT.wrapWrapKb, 'wrapWrapKb')
-          assert(! account.verifyHash, 'verifyHash field should be absent')
-          assert.deepEqual(account.authSalt, ACCOUNT.authSalt, 'authSalt')
-          assert.equal(account.verifierVersion, ACCOUNT.verifierVersion, 'verifierVersion')
-          assert.equal(account.verifierSetAt, ACCOUNT.verifierSetAt, 'verifierSetAt')
-          // locale not returned with .emailRecord() (unlike .account() when it is)
-        })
-        // and we piggyback some duplicate query error handling here...
-        .then(function() {
-          return db.createAccount(ACCOUNT.uid, ACCOUNT)
-        })
-        .then(
-          function() {
-            assert(false, 'this should have resulted in a duplicate account error')
-          },
-          function(err) {
-            assert(err, 'trying to create the same account produces an error')
-            assert.equal(err.code, 409, 'error code')
-            assert.equal(err.errno, 101, 'error errno')
-            assert.equal(err.message, 'Record already exists', 'message')
-            assert.equal(err.error, 'Conflict', 'error')
+      })
+
+      describe('db.updateSessionToken', () => {
+        it('should update token', () => {
+          const sessionTokenUpdates = {
+            uaBrowser: 'foo',
+            uaBrowserVersion: '1',
+            uaOS: 'bar',
+            uaOSVersion: '2',
+            uaDeviceType: 'baz',
+            lastAccessTime: 42
           }
-        )
-      }
-    )
-
-    it(
-      'session token handling',
-      () => {
-        var VERIFIED_SESSION_TOKEN_ID = hex32()
-        var UNVERIFIED_SESSION_TOKEN_ID = hex32()
-        var UNVERIFIED_SESSION_TOKEN = {
-          data: hex32(),
-          uid: ACCOUNT.uid,
-          createdAt: Date.now(),
-          uaBrowser: 'foo',
-          uaBrowserVersion: 'bar',
-          uaOS: 'baz',
-          uaOSVersion: 'qux',
-          uaDeviceType: 'wibble',
-          uaFormFactor: 'blee',
-          mustVerify: false,
-          tokenVerificationId: hex16()
-        }
-        var DEVICE_ID = newUuid()
-
-        // Fetch all of the sessions tokens for the account
-        return db.sessions(ACCOUNT.uid)
-          .then(function(sessions) {
-            assert(Array.isArray(sessions), 'sessions is an array')
-            assert.equal(sessions.length, 0, 'sessions is empty')
-            // Create a session token
-            return db.createSessionToken(SESSION_TOKEN_ID, SESSION_TOKEN)
-          })
-          .then(function(result) {
-            assert.deepEqual(result, {}, 'Returned an empty object on session token creation')
-
-            // Fetch all of the sessions tokens for the account
-            return db.sessions(ACCOUNT.uid)
-          })
-          .then(function (sessions) {
-            assert.equal(sessions.length, 1, 'sessions contains one item')
-            assert.equal(Object.keys(sessions[0]).length, 18, 'session has correct properties')
-            assert.equal(sessions[0].tokenId.toString('hex'), SESSION_TOKEN_ID.toString('hex'), 'tokenId is correct')
-            assert.equal(sessions[0].uid.toString('hex'), ACCOUNT.uid.toString('hex'), 'uid is correct')
-            assert.equal(sessions[0].createdAt, SESSION_TOKEN.createdAt, 'createdAt is correct')
-            assert.equal(sessions[0].uaBrowser, SESSION_TOKEN.uaBrowser, 'uaBrowser is correct')
-            assert.equal(sessions[0].uaBrowserVersion, SESSION_TOKEN.uaBrowserVersion, 'uaBrowserVersion is correct')
-            assert.equal(sessions[0].uaOS, SESSION_TOKEN.uaOS, 'uaOS is correct')
-            assert.equal(sessions[0].uaOSVersion, SESSION_TOKEN.uaOSVersion, 'uaOSVersion is correct')
-            assert.equal(sessions[0].uaDeviceType, SESSION_TOKEN.uaDeviceType, 'uaDeviceType is correct')
-            assert.equal(sessions[0].uaFormFactor, SESSION_TOKEN.uaFormFactor, 'uaFormFactor is correct')
-            assert.equal(sessions[0].lastAccessTime, SESSION_TOKEN.createdAt, 'lastAccessTime is correct')
-
-            // Fetch the session token
-            return db.sessionToken(SESSION_TOKEN_ID)
-          })
-          .then(function(token) {
-            // tokenId is not returned from db.sessionToken()
-            assert.deepEqual(token.tokenData, SESSION_TOKEN.data, 'token data matches')
-            assert.deepEqual(token.uid, ACCOUNT.uid, 'token belongs to this account')
-            assert.equal(token.createdAt, SESSION_TOKEN.createdAt, 'createdAt is correct')
-            assert.equal(token.uaBrowser, SESSION_TOKEN.uaBrowser, 'uaBrowser is correct')
-            assert.equal(token.uaBrowserVersion, SESSION_TOKEN.uaBrowserVersion, 'uaBrowserVersion is correct')
-            assert.equal(token.uaOS, SESSION_TOKEN.uaOS, 'uaOS is correct')
-            assert.equal(token.uaOSVersion, SESSION_TOKEN.uaOSVersion, 'uaOSVersion is correct')
-            assert.equal(token.uaDeviceType, SESSION_TOKEN.uaDeviceType, 'uaDeviceType is correct')
-            assert.equal(token.uaFormFactor, SESSION_TOKEN.uaFormFactor, 'uaFormFactor is correct')
-            assert.equal(token.lastAccessTime, SESSION_TOKEN.createdAt, 'lastAccessTime was set')
-            assert.equal(!! token.emailVerified, ACCOUNT.emailVerified, 'token emailVerified is same as account emailVerified')
-            assert.equal(token.email, ACCOUNT.email, 'token email same as account email')
-            assert.deepEqual(token.emailCode, ACCOUNT.emailCode, 'token emailCode same as account emailCode')
-            assert.equal(token.verifierSetAt, ACCOUNT.verifierSetAt, 'verifierSetAt is correct')
-            assert.equal(token.accountCreatedAt, ACCOUNT.createdAt, 'accountCreatedAt is correct')
-
-            // Update the session token
-            return db.updateSessionToken(SESSION_TOKEN_ID, {
-              uaBrowser: 'foo',
-              uaBrowserVersion: '1',
-              uaOS: 'bar',
-              uaOSVersion: '2',
-              uaDeviceType: 'baz',
-              lastAccessTime: 42
+          return db.updateSessionToken(sessionTokenData.tokenId, sessionTokenUpdates)
+            .then((result) => {
+              assert.deepEqual(result, {}, 'Returned an empty object on session token update')
+              return db.sessionToken(sessionTokenData.tokenId)
             })
-          })
-          .then(function(result) {
-            assert.deepEqual(result, {}, 'Returned an empty object on session token update')
-
-            // Fetch all of the sessions tokens for the account
-            return db.sessions(ACCOUNT.uid)
-          })
-          .then(function (sessions) {
-            assert.equal(sessions.length, 1, 'sessions still contains one item')
-            assert.equal(sessions[0].tokenId.toString('hex'), SESSION_TOKEN_ID.toString('hex'), 'tokenId is correct')
-            assert.equal(sessions[0].uid.toString('hex'), ACCOUNT.uid.toString('hex'), 'uid is correct')
-            assert.equal(sessions[0].createdAt, SESSION_TOKEN.createdAt, 'createdAt is correct')
-            assert.equal(sessions[0].uaBrowser, 'foo', 'uaBrowser is correct')
-            assert.equal(sessions[0].uaBrowserVersion, '1', 'uaBrowserVersion is correct')
-            assert.equal(sessions[0].uaOS, 'bar', 'uaOS is correct')
-            assert.equal(sessions[0].uaOSVersion, '2', 'uaOSVersion is correct')
-            assert.equal(sessions[0].uaDeviceType, 'baz', 'uaDeviceType is correct')
-            assert.equal(sessions[0].uaFormFactor, SESSION_TOKEN.uaFormFactor, 'uaFormFactor is correct')
-            assert.equal(sessions[0].lastAccessTime, 42, 'lastAccessTime is correct')
-
-            // Fetch the session token
-            return db.sessionToken(SESSION_TOKEN_ID)
-          })
-          .then(function(token) {
-            assert.deepEqual(token.tokenData, SESSION_TOKEN.data, 'token data matches')
-            assert.deepEqual(token.uid, ACCOUNT.uid, 'token belongs to this account')
-            assert.equal(token.createdAt, SESSION_TOKEN.createdAt, 'createdAt is correct')
-            assert.equal(token.uaBrowser, 'foo', 'uaBrowser is correct')
-            assert.equal(token.uaBrowserVersion, '1', 'uaBrowserVersion is correct')
-            assert.equal(token.uaOS, 'bar', 'uaOS is correct')
-            assert.equal(token.uaOSVersion, '2', 'uaOSVersion is correct')
-            assert.equal(token.uaDeviceType, 'baz', 'uaDeviceType is correct')
-            assert.equal(token.uaFormFactor, SESSION_TOKEN.uaFormFactor, 'uaFormFactor is correct')
-            assert.equal(token.lastAccessTime, 42, 'lastAccessTime is correct')
-            assert.equal(!! token.emailVerified, ACCOUNT.emailVerified, 'token emailVerified is same as account emailVerified')
-            assert.equal(token.email, ACCOUNT.email, 'token email same as account email')
-            assert.deepEqual(token.emailCode, ACCOUNT.emailCode, 'token emailCode same as account emailCode')
-            assert.equal(token.verifierSetAt, ACCOUNT.verifierSetAt, 'verifierSetAt is correct')
-            assert.equal(token.accountCreatedAt, ACCOUNT.createdAt, 'accountCreatedAt is correct')
-            assert.equal(token.mustVerify, undefined, 'mustVerify is undefined')
-            assert.equal(token.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
-
-            // Fetch the session token with its verification state
-            return db.sessionTokenWithVerificationStatus(SESSION_TOKEN_ID)
-          })
-          .then(function (token) {
-            assert.deepEqual(token.tokenData, SESSION_TOKEN.data, 'token data matches')
-            assert.deepEqual(token.uid, ACCOUNT.uid, 'token belongs to this account')
-            assert.equal(token.createdAt, SESSION_TOKEN.createdAt, 'createdAt is correct')
-            assert.equal(token.uaBrowser, 'foo', 'uaBrowser is correct')
-            assert.equal(token.uaBrowserVersion, '1', 'uaBrowserVersion is correct')
-            assert.equal(token.uaOS, 'bar', 'uaOS is correct')
-            assert.equal(token.uaOSVersion, '2', 'uaOSVersion is correct')
-            assert.equal(token.uaDeviceType, 'baz', 'uaDeviceType is correct')
-            assert.equal(token.uaFormFactor, SESSION_TOKEN.uaFormFactor, 'uaFormFactor is correct')
-            assert.equal(token.lastAccessTime, 42, 'lastAccessTime is correct')
-            assert.equal(!! token.emailVerified, ACCOUNT.emailVerified, 'token emailVerified is same as account emailVerified')
-            assert.equal(token.email, ACCOUNT.email, 'token email same as account email')
-            assert.deepEqual(token.emailCode, ACCOUNT.emailCode, 'token emailCode same as account emailCode')
-            assert.equal(token.verifierSetAt, ACCOUNT.verifierSetAt, 'verifierSetAt is correct')
-            assert.equal(token.accountCreatedAt, ACCOUNT.createdAt, 'accountCreatedAt is correct')
-            assert.equal(!! token.mustVerify, !! SESSION_TOKEN.mustVerify, 'mustVerify is correct')
-            assert.deepEqual(token.tokenVerificationId, SESSION_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
-
-            // Create a verified session token
-            return db.createSessionToken(VERIFIED_SESSION_TOKEN_ID, {
-              data: hex32(),
-              uid: ACCOUNT.uid,
-              createdAt: Date.now(),
-              uaBrowser: 'a',
-              uaBrowserVersion: 'b',
-              uaOS: 'c',
-              uaOSVersion: 'd',
-              uaDeviceType: 'e',
-              uaFormFactor: 'f'
+            .then((token) => {
+              assert.deepEqual(token.tokenData, sessionTokenData.data, 'token data matches')
+              assert.deepEqual(token.uid, accountData.uid, 'token belongs to this account')
+              assert.equal(token.createdAt, sessionTokenData.createdAt, 'createdAt is correct')
+              assert.equal(token.uaBrowser, 'foo', 'uaBrowser is correct')
+              assert.equal(token.uaBrowserVersion, '1', 'uaBrowserVersion is correct')
+              assert.equal(token.uaOS, 'bar', 'uaOS is correct')
+              assert.equal(token.uaOSVersion, '2', 'uaOSVersion is correct')
+              assert.equal(token.uaDeviceType, 'baz', 'uaDeviceType is correct')
+              assert.equal(token.uaFormFactor, sessionTokenData.uaFormFactor, 'uaFormFactor is correct')
+              assert.equal(token.lastAccessTime, 42, 'lastAccessTime is correct')
+              assert.equal(!! token.emailVerified, accountData.emailVerified, 'token emailVerified is same as account emailVerified')
+              assert.equal(token.email, accountData.email, 'token email same as account email')
+              assert.deepEqual(token.emailCode, accountData.emailCode, 'token emailCode same as account emailCode')
+              assert.equal(token.verifierSetAt, accountData.verifierSetAt, 'verifierSetAt is correct')
+              assert.equal(token.accountCreatedAt, accountData.createdAt, 'accountCreatedAt is correct')
+              assert.equal(token.mustVerify, undefined, 'mustVerify is undefined')
+              assert.equal(token.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
             })
-          })
-          .then(function (result) {
-            assert.deepEqual(result, {}, 'Returned an empty object on session token creation')
+        })
+      })
 
-            // Fetch all of the sessions tokens for the account
-            return db.sessions(ACCOUNT.uid)
-          })
-          .then(function (sessions) {
-            assert.equal(sessions.length, 2, 'sessions contains one item')
-            var index = 0
-            if (sessions[0].tokenId.toString('hex') === SESSION_TOKEN_ID.toString('hex')) {
-              index = 1
-            }
-            assert.equal(sessions[index].tokenId.toString('hex'), VERIFIED_SESSION_TOKEN_ID.toString('hex'), 'tokenId is correct')
-            assert.equal(sessions[index].uid.toString('hex'), ACCOUNT.uid.toString('hex'), 'uid is correct')
-            assert.equal(sessions[index].uaBrowser, 'a', 'uaBrowser is correct')
-            assert.equal(sessions[index].uaBrowserVersion, 'b', 'uaBrowserVersion is correct')
-            assert.equal(sessions[index].uaOS, 'c', 'uaOS is correct')
-            assert.equal(sessions[index].uaOSVersion, 'd', 'uaOSVersion is correct')
-            assert.equal(sessions[index].uaDeviceType, 'e', 'uaDeviceType is correct')
-            assert.equal(sessions[index].uaFormFactor, 'f', 'uaFormFactor is correct')
+      describe('db.sessionTokenWithVerificationStatus', () => {
+        it('should get verification state', () => {
+          return db.sessionTokenWithVerificationStatus(sessionTokenData.tokenId)
+            .then((token) => {
+              assert.deepEqual(token.tokenData, sessionTokenData.data, 'token data matches')
+              assert.deepEqual(token.uid, accountData.uid, 'token belongs to this account')
+              assert.equal(token.createdAt, sessionTokenData.createdAt, 'createdAt is correct')
+              assert.equal(token.uaBrowser, sessionTokenData.uaBrowser, 'uaBrowser is correct')
+              assert.equal(token.uaBrowserVersion, sessionTokenData.uaBrowserVersion, 'uaBrowserVersion is correct')
+              assert.equal(token.uaOS, sessionTokenData.uaOS, 'uaOS is correct')
+              assert.equal(token.uaOSVersion, sessionTokenData.uaOSVersion, 'uaOSVersion is correct')
+              assert.equal(token.uaDeviceType, sessionTokenData.uaDeviceType, 'uaDeviceType is correct')
+              assert.equal(token.uaFormFactor, sessionTokenData.uaFormFactor, 'uaFormFactor is correct')
+              assert.equal(token.lastAccessTime, sessionTokenData.createdAt, 'lastAccessTime was set')
+              assert.equal(!! token.emailVerified, accountData.emailVerified, 'token emailVerified is same as account emailVerified')
+              assert.equal(token.email, accountData.email, 'token email same as account email')
+              assert.deepEqual(token.emailCode, accountData.emailCode, 'token emailCode same as account emailCode')
+              assert.equal(token.verifierSetAt, accountData.verifierSetAt, 'verifierSetAt is correct')
+              assert.equal(token.accountCreatedAt, accountData.createdAt, 'accountCreatedAt is correct')
+              assert.equal(!! token.mustVerify, !! sessionTokenData.mustVerify, 'mustVerify is correct')
+              assert.deepEqual(token.tokenVerificationId, sessionTokenData.tokenVerificationId, 'tokenVerificationId is correct')
 
-            // Fetch the verified session token
-            return db.sessionToken(VERIFIED_SESSION_TOKEN_ID)
-          })
-          .then(function(token) {
-            assert.deepEqual(token.uid, ACCOUNT.uid, 'token belongs to this account')
-            assert.equal(token.uaBrowser, 'a', 'uaBrowser is correct')
-            assert.equal(token.uaBrowserVersion, 'b', 'uaBrowserVersion is correct')
-            assert.equal(token.uaOS, 'c', 'uaOS is correct')
-            assert.equal(token.uaOSVersion, 'd', 'uaOSVersion is correct')
-            assert.equal(token.uaDeviceType, 'e', 'uaDeviceType is correct')
-            assert.equal(token.uaFormFactor, 'f', 'uaFormFactor is correct')
-            assert.equal(!! token.emailVerified, ACCOUNT.emailVerified, 'token emailVerified is same as account emailVerified')
-            assert.equal(token.mustVerify, undefined, 'mustVerify is undefined')
-            assert.equal(token.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
-
-            // Fetch the verified session token with its verification state
-            return db.sessionTokenWithVerificationStatus(VERIFIED_SESSION_TOKEN_ID)
-          })
-          .then(function (token) {
-            assert.equal(token.mustVerify, null, 'mustVerify is null')
-            assert.equal(token.tokenVerificationId, null, 'tokenVerificationId is null')
-
-            // Attempt to verify session token with invalid tokenVerificationId
-            return db.verifyTokens(hex16(), { uid: ACCOUNT.uid })
-          })
-          .then(function () {
-            assert(false, 'Verifying session token with invalid tokenVerificationId should have failed')
-          }, function (err) {
-            assert.equal(err.errno, 116, 'err.errno is correct')
-            assert.equal(err.code, 404, 'err.code is correct')
-          })
-          .then(function() {
-            // Fetch the unverified session token with its verification state
-            return db.sessionTokenWithVerificationStatus(SESSION_TOKEN_ID)
-          })
-          .then(function (token) {
-            assert.equal(!! token.mustVerify, !! SESSION_TOKEN.mustVerify, 'mustVerify is correct')
-            assert.deepEqual(token.tokenVerificationId, SESSION_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
-
-            // Attempt to verify session token with invalid uid
-            return db.verifyTokens(SESSION_TOKEN.tokenVerificationId, { uid: hex16() })
-          })
-          .then(function () {
-            assert(false, 'Verifying session token with invalid uid should have failed')
-          }, function (err) {
-            assert.equal(err.errno, 116, 'err.errno is correct')
-            assert.equal(err.code, 404, 'err.code is correct')
-          })
-          .then(function() {
-            // Fetch the unverified session token with its verification state
-            return db.sessionTokenWithVerificationStatus(SESSION_TOKEN_ID)
-          })
-          .then(function (token) {
-            assert.equal(!! token.mustVerify, !! SESSION_TOKEN.mustVerify, 'mustVerify is correct')
-            assert.deepEqual(token.tokenVerificationId, SESSION_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
-
-            // Verify the session token
-            return db.verifyTokens(SESSION_TOKEN.tokenVerificationId, { uid: ACCOUNT.uid })
-          })
-          .then(function() {
-            // Fetch the newly verified session token
-            return db.sessionToken(SESSION_TOKEN_ID)
-          })
-          .then(function(token) {
-            assert.equal(token.mustVerify, undefined, 'mustVerify is undefined')
-            assert.equal(token.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
-
-            // Fetch the newly verified session token with its verification state
-            return db.sessionTokenWithVerificationStatus(SESSION_TOKEN_ID)
-          })
-          .then(function (token) {
-            assert.equal(token.mustVerify, null, 'mustVerify is null')
-            assert.equal(token.tokenVerificationId, null, 'tokenVerificationId is null')
-
-            // Create an unverified session token
-            return db.createSessionToken(UNVERIFIED_SESSION_TOKEN_ID, UNVERIFIED_SESSION_TOKEN)
-          })
-          .then(function() {
-            // Create a device
-            return db.createDevice(ACCOUNT.uid, DEVICE_ID, {
-              sessionTokenId: SESSION_TOKEN_ID,
-              name: 'Test Device',
-              type: 'mobile',
-              createdAt: Date.now(),
-              callbackURL: 'https://push.server',
-              callbackPublicKey: 'foo',
-              callbackAuthKey: 'bar',
-              callbackIsExpired: false
             })
-          })
-          .then(function() {
-            // Fetch devices for the account
-            return db.accountDevices(ACCOUNT.uid)
-          })
-          .then(function(results) {
-            assert.equal(results.length, 1, 'Account has one device')
+        })
+      })
 
-            // Fetch devices for the account
-            return db.sessions(ACCOUNT.uid)
-          })
-          .then(function(sessions) {
-            // by default sessions are not sorted
-            sessions.sort(function(s1, s2) {
-              return s1.createdAt - s2.createdAt
+      describe('db.verifyTokens', () => {
+        it('should fail for invalid tokenId', () => {
+          return db.verifyTokens(hex16(), accountData)
+            .then(assert.fail, (err) => {
+              assert.equal(err.errno, 116, 'err.errno is correct')
+              assert.equal(err.code, 404, 'err.code is correct')
+
+              return db.sessionTokenWithVerificationStatus(sessionTokenData.tokenId)
             })
+            .then((token) => {
+              assert.equal(!! token.mustVerify, !! sessionTokenData.mustVerify, 'mustVerify is correct')
+              assert.deepEqual(token.tokenVerificationId, sessionTokenData.tokenVerificationId, 'tokenVerificationId is correct')
+            })
+        })
 
-            assert.equal(sessions.length, 3, 'sessions contains correct number of items')
-            // the next session has a device attached to it
-            assert.equal(sessions[0].deviceId.toString('hex'), DEVICE_ID.toString('hex'))
-            assert.equal(sessions[0].deviceName, 'Test Device')
-            assert.equal(sessions[0].deviceType, 'mobile')
-            assert(sessions[0].deviceCreatedAt)
-            assert.equal(sessions[0].deviceCallbackURL, 'https://push.server')
-            assert.equal(sessions[0].deviceCallbackPublicKey, 'foo')
-            assert.equal(sessions[0].deviceCallbackAuthKey, 'bar')
-            assert.equal(sessions[0].deviceCallbackIsExpired, false)
-            assert.equal(sessions[1].deviceId, null)
-            assert.equal(sessions[2].deviceId, null)
+        it('should fail for invalid uid', () => {
+          return db.verifyTokens(sessionTokenData.tokenVerificationId, {uid: hex16()})
+            .then(assert.fail, (err) => {
+              assert.equal(err.errno, 116, 'err.errno is correct')
+              assert.equal(err.code, 404, 'err.code is correct')
 
-            // Delete all three session tokens
-            return P.all([
-              db.deleteSessionToken(SESSION_TOKEN_ID),
-              db.deleteSessionToken(VERIFIED_SESSION_TOKEN_ID),
-              db.deleteSessionToken(UNVERIFIED_SESSION_TOKEN_ID)
-            ])
-          })
-          .then(function(results) {
-            assert.equal(results.length, 3)
-            results.forEach(function (result) {
+              return db.sessionTokenWithVerificationStatus(sessionTokenData.tokenId)
+            })
+            .then((token) => {
+              assert.equal(!! token.mustVerify, !! sessionTokenData.mustVerify, 'mustVerify is correct')
+              assert.deepEqual(token.tokenVerificationId, sessionTokenData.tokenVerificationId, 'tokenVerificationId is correct')
+            })
+        })
+
+        it('should verify token', () => {
+          return db.verifyTokens(sessionTokenData.tokenVerificationId, accountData)
+            .then(() => {
+              return db.sessionTokenWithVerificationStatus(sessionTokenData.tokenId)
+            }, assert.fail)
+            .then((token) => {
+              assert.equal(token.mustVerify, null, 'mustVerify is null')
+              assert.equal(token.tokenVerificationId, null, 'tokenVerificationId is null')
+            })
+        })
+      })
+
+      describe('db.accountDevices', () => {
+        let deviceData
+        beforeEach(() => {
+          deviceData = makeMockDevice(sessionTokenData.tokenId)
+          return db.createDevice(accountData.uid, deviceData.deviceId, deviceData)
+        })
+
+        it('should get device count', () => {
+          return db.accountDevices(accountData.uid)
+            .then((results) => {
+              assert.equal(results.length, 1, 'Account has one device')
+            })
+        })
+
+        it('db.sessions should contain device data', () => {
+          return db.sessions(accountData.uid)
+            .then((sessions) => {
+              assert.equal(sessions.length, 1, 'sessions contains correct number of items')
+              // the next session has a device attached to it
+              assert.equal(sessions[0].deviceId.toString('hex'), deviceData.deviceId.toString('hex'))
+              assert.equal(sessions[0].deviceName, 'Test Device')
+              assert.equal(sessions[0].deviceType, 'mobile')
+              assert(sessions[0].deviceCreatedAt)
+              assert.equal(sessions[0].deviceCallbackURL, 'https://push.server')
+              assert.equal(sessions[0].deviceCallbackPublicKey, 'foo')
+              assert.equal(sessions[0].deviceCallbackAuthKey, 'bar')
+              assert.equal(sessions[0].deviceCallbackIsExpired, false)
+            })
+        })
+
+        it('db.deleteSessionToken should delete device', () => {
+          return db.accountDevices(accountData.uid)
+            .then((results) => {
+              assert.equal(results.length, 1, 'Account has one device')
+              return db.deleteSessionToken(sessionTokenData.tokenId)
+            })
+            .then(() => db.accountDevices(accountData.uid))
+            .then((results) => {
+              assert.equal(results.length, 0, 'Account has no devices')
+            })
+        })
+      })
+
+      describe('db.deleteSessionToken', () => {
+        beforeEach(() => {
+          return db.deleteSessionToken(sessionTokenData.tokenId)
+            .then((result) => {
               assert.deepEqual(result, {}, 'Returned an empty object on forgot session token deletion')
+            }, assert.fail)
+        })
+
+        it('should delete session', () => {
+          return db.sessionToken(sessionTokenData.tokenId)
+            .then(assert.fail, (err) => {
+              assert.equal(err.errno, 116, 'err.errno is correct')
+              assert.equal(err.code, 404, 'err.code is correct')
             })
+        })
 
-            // Fetch devices for the account
-            return db.accountDevices(ACCOUNT.uid)
-          })
-          .then(function(results) {
-            assert.equal(results.length, 0, 'Account has no devices')
-
-            // Attempt to verify deleted unverified session token
-            return db.verifyTokens(UNVERIFIED_SESSION_TOKEN.tokenVerificationId, { uid: ACCOUNT.uid })
-          })
-          .then(function () {
-            assert(false, 'Verifying deleted unverified session token should have failed')
-          }, function (err) {
-            assert.equal(err.errno, 116, 'err.errno is correct')
-            assert.equal(err.code, 404, 'err.code is correct')
-          })
-          .then(function() {
-            // Fetch all of the sessions tokens for the account
-            return db.sessions(ACCOUNT.uid)
-          })
-          .then(function (sessions) {
-            assert.equal(sessions.length, 0, 'sessions is empty')
-
-            // Attempt to fetch a deleted session token
-            return db.sessionToken(SESSION_TOKEN_ID)
-              .then(
-                () => assert(false, 'Session Token should no longer exist'),
-                () => assert('Session token was deleted successfully')
-              )
-          })
-      }
-    )
-
-    it(
-      'key fetch token handling',
-      () => {
-        var VERIFIED_KEY_FETCH_TOKEN_ID = hex32()
-
-        // Create a key fetch token
-        return db.createKeyFetchToken(KEY_FETCH_TOKEN_ID, KEY_FETCH_TOKEN)
-          .then(function(result) {
-            assert.deepEqual(result, {}, 'Returned an empty object on key fetch token creation')
-
-            // Fetch the key fetch token
-            return db.keyFetchToken(KEY_FETCH_TOKEN_ID)
-          })
-          .then(function(token) {
-            // tokenId is not returned
-            assert.deepEqual(token.authKey, KEY_FETCH_TOKEN.authKey, 'authKey matches')
-            assert.deepEqual(token.uid, ACCOUNT.uid, 'token belongs to this account')
-            assert.equal(token.createdAt, KEY_FETCH_TOKEN.createdAt, 'createdAt is ok')
-            assert.equal(!! token.emailVerified, ACCOUNT.emailVerified, 'emailVerified is correct')
-            // email is not returned
-            // emailCode is not returned
-            assert.equal(token.verifierSetAt, ACCOUNT.verifierSetAt, 'verifierSetAt is correct')
-            assert.equal(token.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
-
-            // Fetch the key fetch token with its verification state
-            return db.keyFetchTokenWithVerificationStatus(KEY_FETCH_TOKEN_ID)
-          })
-          .then(function(token) {
-            assert.deepEqual(token.authKey, KEY_FETCH_TOKEN.authKey, 'authKey matches')
-            assert.deepEqual(token.uid, ACCOUNT.uid, 'token belongs to this account')
-            assert.equal(token.createdAt, KEY_FETCH_TOKEN.createdAt, 'createdAt is ok')
-            assert.equal(!! token.emailVerified, ACCOUNT.emailVerified, 'emailVerified is correct')
-            assert.equal(token.verifierSetAt, ACCOUNT.verifierSetAt, 'verifierSetAt is correct')
-            assert.deepEqual(token.tokenVerificationId, KEY_FETCH_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
-
-            // Attempt to verify key fetch token with invalid tokenVerificationId
-            return db.verifyTokens(hex16(), { uid: KEY_FETCH_TOKEN.uid })
-          })
-          .then(function () {
-            assert(false, 'Verifying key fetch token with invalid tokenVerificationId should have failed')
-          }, function () {
-            // Verifying key fetch token with invalid tokenVerificationId failed as expected
-          })
-          .then(function() {
-            // Fetch the key fetch token with its verification state
-            return db.keyFetchTokenWithVerificationStatus(KEY_FETCH_TOKEN_ID)
-          })
-          .then(function (token) {
-            assert.deepEqual(token.tokenVerificationId, KEY_FETCH_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
-
-            // Attempt to verify key fetch token with invalid uid
-            return db.verifyTokens(KEY_FETCH_TOKEN.tokenVerificationId, { uid: hex16() })
-          })
-          .then(function () {
-            assert(false, 'Verifying key fetch token with invalid uid should have failed')
-          }, function () {
-            // 'Verifying key fetch token with invalid uid failed as expected'
-          })
-          .then(function() {
-            // Fetch the key fetch token with its verification state
-            return db.keyFetchTokenWithVerificationStatus(KEY_FETCH_TOKEN_ID)
-          })
-          .then(function (token) {
-            assert.deepEqual(token.tokenVerificationId, KEY_FETCH_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
-
-            // Verify the key fetch token
-            return db.verifyTokens(KEY_FETCH_TOKEN.tokenVerificationId, { uid: SESSION_TOKEN.uid })
-          })
-          .then(function() {
-            // Fetch the key fetch token
-            return db.keyFetchToken(KEY_FETCH_TOKEN_ID)
-          })
-          .then(function(token) {
-            assert.equal(token.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
-
-            // Fetch the key fetch token with its verification state
-            return db.keyFetchTokenWithVerificationStatus(KEY_FETCH_TOKEN_ID)
-          })
-          .then(function(token) {
-            assert.equal(token.tokenVerificationId, null, 'tokenVerificationId is null')
-
-            // Create a verified key fetch token
-            return db.createKeyFetchToken(VERIFIED_KEY_FETCH_TOKEN_ID, {
-              authKey: hex32(),
-              uid: ACCOUNT.uid,
-              keyBundle: hex96(),
-              createdAt: Date.now()
+        it('should fail to verify deleted session', () => {
+          return db.verifyTokens(sessionTokenData.tokenVerificationId, accountData)
+            .then(assert.fail, (err) => {
+              assert.equal(err.errno, 116, 'err.errno is correct')
+              assert.equal(err.code, 404, 'err.code is correct')
             })
-          })
-          .then(function() {
-            // Fetch the verified key fetch token
-            return db.keyFetchToken(VERIFIED_KEY_FETCH_TOKEN_ID)
-          })
-          .then(function(token) {
-            assert.equal(token.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
-
-            // Fetch the verified key fetch token with its verification state
-            return db.keyFetchTokenWithVerificationStatus(VERIFIED_KEY_FETCH_TOKEN_ID)
-          })
-          .then(function(token) {
-            assert.equal(token.tokenVerificationId, null, 'tokenVerificationId is null')
-
-            // Delete both key fetch tokens
-            return P.all([
-              db.deleteKeyFetchToken(KEY_FETCH_TOKEN_ID),
-              db.deleteKeyFetchToken(VERIFIED_KEY_FETCH_TOKEN_ID)
-            ])
-          })
-          .then(function(result) {
-            assert.deepEqual(result, [{}, {}], 'Returned empty objects on forgot key fetch token deletion')
-
-            // Attempt to fetch a deleted key fetch token
-            return db.keyFetchToken(KEY_FETCH_TOKEN_ID)
-          })
-          .then(function(token) {
-            assert(false, 'Key Fetch Token should no longer exist')
-          }, function(err) {
-            // Key Fetch Token deleted successfully
-          })
-      }
-    )
-
-    it(
-      'forgot password token handling',
-      () => {
-        var token
-        var THROWAWAY_PASSWORD_FORGOT_TOKEN_ID = hex32()
-        var THROWAWAY_PASSWORD_FORGOT_TOKEN = {
-          data : hex32(),
-          uid : ACCOUNT.uid, // same account uid
-          passCode : hex16(),
-          tries : 1,
-          createdAt: Date.now()
-        }
-
-        return db.createPasswordForgotToken(PASSWORD_FORGOT_TOKEN_ID, PASSWORD_FORGOT_TOKEN)
-          .then(function(result) {
-            assert.deepEqual(result, {}, 'Returned an empty object on forgot password token creation')
-            return db.passwordForgotToken(PASSWORD_FORGOT_TOKEN_ID)
-          })
-          .then(function(newToken) {
-            token = newToken
-            // tokenId is not returned
-            assert.deepEqual(token.tokenData, PASSWORD_FORGOT_TOKEN.data, 'token data matches')
-            assert.deepEqual(token.uid, ACCOUNT.uid, 'token belongs to this account')
-            assert.equal(token.createdAt, PASSWORD_FORGOT_TOKEN.createdAt, 'createdAt same')
-            assert.deepEqual(token.passCode, PASSWORD_FORGOT_TOKEN.passCode, 'token passCode same')
-            assert.equal(token.tries, PASSWORD_FORGOT_TOKEN.tries, 'Tries is correct')
-            assert.equal(token.email, ACCOUNT.email, 'token email same as account email')
-            assert.equal(token.verifierSetAt, ACCOUNT.verifierSetAt, 'verifierSetAt is set correctly')
-          })
-          .then(function() {
-            return db.passwordForgotToken(PASSWORD_FORGOT_TOKEN_ID)
-          })
-          .then(function(newToken) {
-            token = newToken
-            // tokenId is not returned
-            assert.deepEqual(token.tokenData, PASSWORD_FORGOT_TOKEN.data, 'token data matches')
-            assert.deepEqual(token.uid, ACCOUNT.uid, 'token belongs to this account')
-            assert.equal(token.createdAt, PASSWORD_FORGOT_TOKEN.createdAt, 'createdAt is correct')
-            assert.deepEqual(token.passCode, PASSWORD_FORGOT_TOKEN.passCode, 'token passCode same')
-            assert.equal(token.tries, PASSWORD_FORGOT_TOKEN.tries, 'Tries is correct')
-            assert.equal(token.email, ACCOUNT.email, 'token email same as account email')
-            assert.equal(token.verifierSetAt, ACCOUNT.verifierSetAt, 'verifierSetAt is correct')
-          })
-          .then(function() {
-            // just update the tries
-            token.tries = 9
-            return db.updatePasswordForgotToken(PASSWORD_FORGOT_TOKEN_ID, token)
-          })
-          .then(function(result) {
-            assert.deepEqual(result, {}, 'The returned object from the token update is empty')
-            // re-fetch the updated token
-            return db.passwordForgotToken(PASSWORD_FORGOT_TOKEN_ID)
-          })
-          .then(function(newToken) {
-            assert.deepEqual(newToken.uid, ACCOUNT.uid, 'token belongs to this account')
-            assert.equal(newToken.tries, 9, 'token now has had 9 tries')
-            return db.deletePasswordForgotToken(PASSWORD_FORGOT_TOKEN_ID)
-          })
-          .then(function(result) {
-            assert.deepEqual(result, {}, 'Returned an empty object on forgot password token deletion')
-            return db.passwordForgotToken(PASSWORD_FORGOT_TOKEN_ID)
-          })
-          .then(function(newToken /* unused */) {
-            assert(false, 'Password Forgot Token should no longer exist')
-          }, function(err) {
-            // Password Forgot Token deleted successfully
-          })
-          .then(function() {
-            // insert a throwaway token
-            return db.createPasswordForgotToken(THROWAWAY_PASSWORD_FORGOT_TOKEN_ID, THROWAWAY_PASSWORD_FORGOT_TOKEN)
-          })
-          .then(function(result) {
-            assert.deepEqual(result, {}, 'Returned an empty object on forgot password token creation')
-            // and we should be able to retrieve it as usual
-            return db.passwordForgotToken(THROWAWAY_PASSWORD_FORGOT_TOKEN_ID)
-          })
-          .then(function(token) {
-            // just check that the tokenData is what we expect (complete tests are above)
-            assert.deepEqual(token.tokenData, THROWAWAY_PASSWORD_FORGOT_TOKEN.data, 'token data matches')
-            // now, let's insert a different passwordForgotToken with the same uid
-            return db.createPasswordForgotToken(PASSWORD_FORGOT_TOKEN_ID, PASSWORD_FORGOT_TOKEN)
-          })
-          .then(function(result) {
-            assert.deepEqual(result, {}, 'Returned an empty object on forgot password token creation (when overwriting another)')
-            // if we retrieve the throwaway one, we should fail
-            return db.passwordForgotToken(THROWAWAY_PASSWORD_FORGOT_TOKEN_ID)
-          })
-          .then(function(newToken /* unused */) {
-            assert(false, 'Throwaway Password Forgot Token should no longer exist')
-          }, function(err) {
-            // but the new one is still there
-            return db.passwordForgotToken(PASSWORD_FORGOT_TOKEN_ID)
-          })
-          .then(function(token) {
-            // just check that the tokenData is what we expect (complete tests are above)
-            assert.deepEqual(token.tokenData, PASSWORD_FORGOT_TOKEN.data, 'token data matches')
-          }, function(err) {
-            assert(false, 'We should have been able to retrieve the new password forgot token')
-          })
-          .then(function() {
-            return db.deletePasswordForgotToken(PASSWORD_FORGOT_TOKEN_ID)
-          })
-      }
-    )
-
-    it(
-      'change password token handling',
-      () => {
-        var THROWAWAY_PASSWORD_CHANGE_TOKEN_ID = hex32()
-        var THROWAWAY_PASSWORD_CHANGE_TOKEN = {
-          data : hex32(),
-          uid : ACCOUNT.uid, // same account uid
-          createdAt: Date.now()
-        }
-
-        return db.createPasswordChangeToken(PASSWORD_CHANGE_TOKEN_ID, PASSWORD_CHANGE_TOKEN)
-          .then(function(result) {
-            assert.deepEqual(result, {}, 'Returned an empty object on change password token creation')
-            return db.passwordChangeToken(PASSWORD_CHANGE_TOKEN_ID)
-          })
-          .then(function(token) {
-            // tokenId is not returned
-            assert.deepEqual(token.tokenData, PASSWORD_CHANGE_TOKEN.data, 'token data matches')
-            assert.deepEqual(token.uid, ACCOUNT.uid, 'token belongs to this account')
-            assert.equal(token.createdAt, PASSWORD_CHANGE_TOKEN.createdAt, 'createdAt is correct')
-            assert.equal(token.verifierSetAt, ACCOUNT.verifierSetAt, 'verifierSetAt is set correctly')
-            assert.equal(token.email, ACCOUNT.email, 'email is set correctly')
-          })
-          .then(function() {
-            return db.deletePasswordChangeToken(PASSWORD_CHANGE_TOKEN_ID)
-          })
-          .then(function(result) {
-            assert.deepEqual(result, {}, 'Returned an empty object on forgot password change deletion')
-            return db.passwordChangeToken(PASSWORD_CHANGE_TOKEN_ID)
-          })
-          .then(function(token) {
-            assert(false, 'Password Change Token should no longer exist')
-          }, function(err) {
-            // Password Change Token deleted successfully
-          })
-          .then(function() {
-            // insert a throwaway token
-            return db.createPasswordChangeToken(THROWAWAY_PASSWORD_CHANGE_TOKEN_ID, THROWAWAY_PASSWORD_CHANGE_TOKEN)
-          })
-          .then(function(result) {
-            assert.deepEqual(result, {}, 'Returned an empty object on change password token creation')
-            // and we should be able to retrieve it as usual
-            return db.passwordChangeToken(THROWAWAY_PASSWORD_CHANGE_TOKEN_ID)
-          })
-          .then(function(token) {
-            // just check that the tokenData is what we expect (complete tests are above)
-            assert.deepEqual(token.tokenData, THROWAWAY_PASSWORD_CHANGE_TOKEN.data, 'token data matches')
-            // now, let's insert a different passwordChangeToken with the same uid
-            return db.createPasswordChangeToken(PASSWORD_CHANGE_TOKEN_ID, PASSWORD_CHANGE_TOKEN)
-          })
-          .then(function(result) {
-            assert.deepEqual(result, {}, 'Returned an empty object on change password token creation (when overwriting another)')
-            // if we retrieve the throwaway one, we should fail
-            return db.passwordChangeToken(THROWAWAY_PASSWORD_CHANGE_TOKEN_ID)
-          })
-          .then(function(newToken /* unused */) {
-            assert(false, 'Throwaway Password Change Token should no longer exist')
-          }, function(err) {
-            // but the new one is still there
-            return db.passwordChangeToken(PASSWORD_CHANGE_TOKEN_ID)
-          })
-          .then(function(token) {
-            // just check that the tokenData is what we expect (complete tests are above)
-            assert.deepEqual(token.tokenData, PASSWORD_CHANGE_TOKEN.data, 'token data matches')
-          }, function(err) {
-            assert(false, 'We should have been able to retrieve the new password change token')
-          })
-      }
-    )
-
-    it(
-      'email verification and locale change',
-      () => {
-        var emailBuffer = Buffer(ACCOUNT.email)
-        return db.emailRecord(emailBuffer)
-        .then(function(emailRecord) {
-          return db.verifyEmail(emailRecord.uid, emailRecord.emailCode)
         })
-        .then(function(result) {
-          assert.deepEqual(result, {}, 'Returned an empty object email verification')
-          return db.account(ACCOUNT.uid)
-        })
-        .then(function(account) {
-          assert(account.emailVerified, 'account should now be emailVerified (truthy)')
-          assert.equal(account.emailVerified, 1, 'account should now be emailVerified (1)')
+      })
+    })
 
-          account.locale = 'en_NZ'
-          return db.updateLocale(ACCOUNT.uid, account)
-        })
-        .then(function(result) {
-          assert.deepEqual(result, {}, 'Returned an empty object for updateLocale')
-          return db.account(ACCOUNT.uid)
-        })
-        .then(function(account) {
-          assert.equal(account.locale, 'en_NZ', 'account should now have new locale')
+    describe('key fetch token handling', () => {
+      let keyFetchTokenData
+      beforeEach(() => {
+        keyFetchTokenData = makeMockKeyFetchToken(accountData.uid, false)
+        return db.createKeyFetchToken(keyFetchTokenData.tokenId, keyFetchTokenData)
+      })
 
-          // test verifyEmail for a non-existant account
-          return db.verifyEmail(newUuid(), account.emailCode)
+      describe('db.createKeyFetchToken', () => {
+        it('should have created unverified key fetch token', () => {
+          keyFetchTokenData = makeMockKeyFetchToken(accountData.uid, false)
+          return db.createKeyFetchToken(keyFetchTokenData.tokenId, keyFetchTokenData)
+            .then((result) => {
+              assert.deepEqual(result, {}, 'Returned an empty object on key fetch token creation')
+              return db.keyFetchToken(keyFetchTokenData.tokenId)
+            })
+            .then((token) => {
+              assert.equal(token.tokenId, undefined, 'tokenId is not returned')
+              assert.deepEqual(token.authKey, keyFetchTokenData.authKey, 'authKey matches')
+              assert.deepEqual(token.uid, accountData.uid, 'token belongs to this account')
+              assert.equal(token.createdAt, keyFetchTokenData.createdAt, 'createdAt is ok')
+              assert.equal(!! token.emailVerified, accountData.emailVerified, 'emailVerified is correct')
+              assert.equal(token.email, undefined, 'tokenId is not returned')
+              assert.equal(token.emailCode, undefined, 'tokenId is not returned')
+              assert.equal(token.verifierSetAt, accountData.verifierSetAt, 'verifierSetAt is correct')
+              assert.equal(token.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
+            })
         })
-        .then(function(res) {
-          assert.deepEqual(res, {}, 'No matter what happens, we get an empty object back')
-        }, function(err) {
-          assert(false, 'We should not have failed this .verifyEmail() request')
-        })
-      }
-    )
 
-    it(
-      'account reset token handling',
-      () => {
-        return db.createPasswordForgotToken(PASSWORD_FORGOT_TOKEN_ID, PASSWORD_FORGOT_TOKEN)
-          .then(function(passwordForgotToken) {
-            return db.forgotPasswordVerified(PASSWORD_FORGOT_TOKEN_ID, ACCOUNT_RESET_TOKEN)
+        it('should have created verified key fetch token', () => {
+          keyFetchTokenData = makeMockKeyFetchToken(accountData.uid, true)
+          return db.createKeyFetchToken(keyFetchTokenData.tokenId, keyFetchTokenData)
+            .then((result) => {
+              assert.deepEqual(result, {}, 'Returned an empty object on key fetch token creation')
+              return db.keyFetchTokenWithVerificationStatus(keyFetchTokenData.tokenId)
+            })
+            .then((token) => {
+              assert.equal(token.tokenId, undefined, 'tokenId is not returned')
+              assert.deepEqual(token.authKey, keyFetchTokenData.authKey, 'authKey matches')
+              assert.deepEqual(token.uid, accountData.uid, 'token belongs to this account')
+              assert.equal(token.createdAt, keyFetchTokenData.createdAt, 'createdAt is ok')
+              assert.equal(!! token.emailVerified, accountData.emailVerified, 'emailVerified is correct')
+              assert.equal(token.email, undefined, 'tokenId is not returned')
+              assert.equal(token.emailCode, undefined, 'tokenId is not returned')
+              assert.equal(token.verifierSetAt, accountData.verifierSetAt, 'verifierSetAt is correct')
+              assert.equal(token.tokenVerificationId, keyFetchTokenData.tokenVerificationId, 'tokenVerificationId is undefined')
+            })
+        })
+      })
+
+      describe('db.keyFetchTokenWithVerificationStatus', () => {
+        it('should get verification status', () => {
+          return db.keyFetchTokenWithVerificationStatus(keyFetchTokenData.tokenId)
+            .then((token) => {
+              assert.deepEqual(token.authKey, keyFetchTokenData.authKey, 'authKey matches')
+              assert.deepEqual(token.uid, accountData.uid, 'token belongs to this account')
+              assert.equal(token.createdAt, keyFetchTokenData.createdAt, 'createdAt is ok')
+              assert.equal(!! token.emailVerified, accountData.emailVerified, 'emailVerified is correct')
+              assert.equal(token.verifierSetAt, accountData.verifierSetAt, 'verifierSetAt is correct')
+              assert.deepEqual(token.tokenVerificationId, keyFetchTokenData.tokenVerificationId, 'tokenVerificationId is correct')
+
+            })
+        })
+      })
+
+      describe('db.verifyTokens', () => {
+        it('fails for invalid tokenVerficationId', () => {
+          return db.verifyTokens(hex16(), accountData)
+            .then(assert.fail, (err) => {
+              assert.equal(err.errno, 116, 'err.errno is correct')
+              assert.equal(err.code, 404, 'err.code is correct')
+            })
+        })
+
+        it('fails for invalid uid', () => {
+          return db.verifyTokens(keyFetchTokenData.tokenVerificationId, {uid: hex16()})
+            .then(assert.fail, (err) => {
+              assert.equal(err.errno, 116, 'err.errno is correct')
+              assert.equal(err.code, 404, 'err.code is correct')
+            })
+        })
+
+        it('should verify token', () => {
+          return db.keyFetchTokenWithVerificationStatus(keyFetchTokenData.tokenId)
+            .then((token) => {
+              assert.deepEqual(token.tokenVerificationId, keyFetchTokenData.tokenVerificationId, 'tokenVerificationId is correct')
+              return db.verifyTokens(keyFetchTokenData.tokenVerificationId, accountData)
+            })
+            .then(() => {
+              return db.keyFetchTokenWithVerificationStatus(keyFetchTokenData.tokenId)
+            })
+            .then((token) => {
+              assert.equal(token.tokenVerificationId, null, 'tokenVerificationId is null')
+            })
+        })
+      })
+
+      describe('db.deleteKeyFetchToken', () => {
+        it('should delete key fetch token', () => {
+          return db.deleteKeyFetchToken(keyFetchTokenData.tokenId)
+            .then((result) => {
+              assert.deepEqual(result, {}, 'Returned an empty object on token delete')
+              return db.keyFetchToken(keyFetchTokenData.tokenVerificationId)
+                .then(assert.fail, (err) => {
+                  assert.equal(err.errno, 116, 'err.errno is correct')
+                  assert.equal(err.code, 404, 'err.code is correct')
+                })
+            })
+        })
+      })
+    })
+
+    describe('forgot password token handling', () => {
+      let forgotPasswordTokenData
+      beforeEach(() => {
+        forgotPasswordTokenData = makeMockForgotPasswordToken(accountData.uid)
+        return db.createPasswordForgotToken(forgotPasswordTokenData.tokenId, forgotPasswordTokenData)
+      })
+
+      describe('db.createPasswordForgotToken creates with correct data', () => {
+        it('should have created password forgot token', () => {
+          return db.passwordForgotToken(forgotPasswordTokenData.tokenId)
+            .then((token) => {
+              assert.deepEqual(token.tokenData, forgotPasswordTokenData.data, 'token data matches')
+              assert.deepEqual(token.uid, accountData.uid, 'token belongs to this account')
+              assert.equal(token.createdAt, forgotPasswordTokenData.createdAt, 'createdAt same')
+              assert.deepEqual(token.passCode, forgotPasswordTokenData.passCode, 'token passCode same')
+              assert.equal(token.tries, forgotPasswordTokenData.tries, 'Tries is correct')
+              assert.equal(token.email, accountData.email, 'token email same as account email')
+              assert.equal(token.verifierSetAt, accountData.verifierSetAt, 'verifierSetAt is set correctly')
+            })
+        })
+      })
+
+      describe('db.updatePasswordForgotToken updates token', () => {
+        it('should update token tries', () => {
+          forgotPasswordTokenData.tries = 9
+          return db.updatePasswordForgotToken(forgotPasswordTokenData.tokenId, forgotPasswordTokenData)
+            .then((result) => {
+              assert.deepEqual(result, {}, 'The returned object from the token update is empty')
+              return db.passwordForgotToken(forgotPasswordTokenData.tokenId)
+            })
+            .then((token) => {
+              assert.equal(token.tries, 9, 'token now has had 9 tries')
+            })
+        })
+      })
+
+      describe('db.deletePasswordForgotToken', () => {
+        it('should delete token', () => {
+          return db.deletePasswordForgotToken(forgotPasswordTokenData.tokenId)
+            .then((result) => {
+              assert.deepEqual(result, {}, 'The returned object from the token delete is empty')
+              return db.passwordForgotToken(forgotPasswordTokenData.tokenId)
+                .then(assert.fail, (err) => {
+                  assert.equal(err.errno, 116, 'err.errno is correct')
+                  assert.equal(err.code, 404, 'err.code is correct')
+                })
+            })
+        })
+      })
+    })
+
+    describe('change password token handling', () => {
+      let changePasswordTokenData
+      beforeEach(() => {
+        accountData = createAccount()
+        changePasswordTokenData = makeMockChangePasswordToken(accountData.uid)
+
+        return db.createAccount(accountData.uid, accountData)
+          .then(() => db.createPasswordChangeToken(changePasswordTokenData.tokenId, changePasswordTokenData))
+      })
+
+      describe('db.createPasswordChangeToken', () => {
+        it('should have created token', () => {
+          return db.passwordChangeToken(changePasswordTokenData.tokenId)
+            .then((token) => {
+              // tokenId is not returned
+              assert.deepEqual(token.tokenData, changePasswordTokenData.data, 'token data matches')
+              assert.deepEqual(token.uid, accountData.uid, 'token belongs to this account')
+              assert.equal(token.createdAt, changePasswordTokenData.createdAt, 'createdAt is correct')
+              assert.equal(token.verifierSetAt, accountData.verifierSetAt, 'verifierSetAt is set correctly')
+              assert.equal(token.email, accountData.email, 'email is set correctly')
+            })
+        })
+
+        it('should override change password token when creating with same uid', () => {
+          const anotherChangePasswordTokenData = makeMockChangePasswordToken(accountData.uid)
+          return db.createPasswordChangeToken(anotherChangePasswordTokenData.tokenId, anotherChangePasswordTokenData)
+            .then((result) => {
+              assert.deepEqual(result, {}, 'Returned an empty object on change password token creation')
+
+              // Fails to retrieve original change token since it was over written
+              return db.passwordChangeToken(changePasswordTokenData.tokenId)
+                .then(assert.fail, (err) => {
+                  assert.equal(err.errno, 116, 'err.errno is correct')
+                  assert.equal(err.code, 404, 'err.code is correct')
+                  return db.passwordChangeToken(anotherChangePasswordTokenData.tokenId)
+                })
+            })
+            .then((token) => {
+              assert.deepEqual(token.tokenData, anotherChangePasswordTokenData.data, 'token data matches')
+              assert.deepEqual(token.uid, accountData.uid, 'token belongs to this account')
+              assert.equal(token.createdAt, anotherChangePasswordTokenData.createdAt, 'createdAt is correct')
+              assert.equal(token.verifierSetAt, accountData.verifierSetAt, 'verifierSetAt is set correctly')
+              assert.equal(token.email, accountData.email, 'email is set correctly')
+            })
+        })
+      })
+
+      describe('db.deletePasswordChangeToken', () => {
+        it('should have deleted token', () => {
+          return db.deletePasswordChangeToken(changePasswordTokenData.tokenId, changePasswordTokenData)
+            .then((result) => {
+              assert.deepEqual(result, {}, 'Returned an empty object on forgot password change deletion')
+              return db.passwordChangeToken(changePasswordTokenData.tokenId)
+                .then(assert.fail, (err) => {
+                  assert.equal(err.errno, 116, 'err.errno is correct')
+                  assert.equal(err.code, 404, 'err.code is correct')
+                })
+            })
+        })
+      })
+    })
+
+    describe('db.verifyEmail - legacy', () => {
+      it('should verify account email', () => {
+        return db.emailRecord(accountData.emailBuffer)
+          .then((emailRecord) => {
+            assert.equal(emailRecord.emailVerified, false, 'account should be emailVerified false')
+            assert.equal(emailRecord.emailVerified, 0, 'account should be emailVerified (0)')
+            return db.verifyEmail(emailRecord.uid, emailRecord.emailCode)
           })
           .then(function(result) {
-            return db.accountResetToken(ACCOUNT_RESET_TOKEN_ID)
-          })
-          .then(function(token) {
-            // tokenId is not returned
-            assert.deepEqual(token.uid, ACCOUNT.uid, 'token belongs to this account')
-            assert.deepEqual(token.tokenData, ACCOUNT_RESET_TOKEN.data, 'token data matches')
-            assert.equal(token.createdAt, ACCOUNT_RESET_TOKEN.createdAt, 'createdAt is correct')
-            assert(token.verifierSetAt, 'verifierSetAt is set to a truthy value')
-          })
-          .then(function() {
-            return db.deleteAccountResetToken(ACCOUNT_RESET_TOKEN_ID)
-          })
-          .then(function(result) {
-            assert.deepEqual(result, {}, 'Returned an empty object on account reset deletion')
-            return db.accountResetToken(ACCOUNT_RESET_TOKEN_ID)
-          })
-          .then(function(token) {
-            assert(false, 'Account Reset Token should no longer exist')
-          }, function(err) {
-            // Account Reset Token deleted successfully
-          })
-      }
-    )
-
-    it(
-      'db.forgotPasswordVerified',
-      () => {
-        // for this test, we are creating a new account with a different email address
-        // so that we can check that emailVerified turns from false to true (since
-        // we already set it to true earlier)
-        var account = createAccount()
-        var PASSWORD_FORGOT_TOKEN_ID = hex32()
-        var PASSWORD_FORGOT_TOKEN = {
-          data : hex32(),
-          uid : account.uid,
-          passCode : hex16(),
-          tries : 1,
-          createdAt: now + 1
-        }
-        var THROWAWAY_PASSWORD_FORGOT_TOKEN_ID = hex32()
-        var THROWAWAY_PASSWORD_FORGOT_TOKEN = {
-          data : hex32(),
-          uid : account.uid,
-          passCode : hex16(),
-          tries : 1,
-          createdAt: now + 2
-        }
-        var ACCOUNT_RESET_TOKEN_ID = hex32()
-        var ACCOUNT_RESET_TOKEN = {
-          tokenId : ACCOUNT_RESET_TOKEN_ID,
-          data : hex32(),
-          uid : account.uid,
-          createdAt: now + 3
-        }
-        var THROWAWAY_ACCOUNT_RESET_TOKEN_ID = hex32()
-        var THROWAWAY_ACCOUNT_RESET_TOKEN = {
-          tokenId : THROWAWAY_ACCOUNT_RESET_TOKEN_ID,
-          data : hex32(),
-          uid : account.uid,
-          createdAt: now + 4
-        }
-
-        return db.createAccount(account.uid, account)
-          .then(function() {
-            return db.createPasswordForgotToken(THROWAWAY_PASSWORD_FORGOT_TOKEN_ID, THROWAWAY_PASSWORD_FORGOT_TOKEN)
-          })
-          .then(function(passwordForgotToken) {
-            // let's add a throwaway accountResetToken, which should be overwritten when
-            // we call passwordForgotToken() later.
-            return db.forgotPasswordVerified(THROWAWAY_PASSWORD_FORGOT_TOKEN_ID, THROWAWAY_ACCOUNT_RESET_TOKEN)
-          })
-          .then(function(result) {
-            // let's get it back out to make sure it is there
-            return db.accountResetToken(THROWAWAY_ACCOUNT_RESET_TOKEN_ID)
-          })
-          .then(function(token) {
-            // check a couple of fields
-            assert.deepEqual(token.uid, account.uid, 'token belongs to this account')
-            assert.deepEqual(token.tokenData, THROWAWAY_ACCOUNT_RESET_TOKEN.data, 'token data matches')
-            assert.equal(token.createdAt, THROWAWAY_ACCOUNT_RESET_TOKEN.createdAt, 'createdAt is correct')
-            assert(token.verifierSetAt, 'verifierSetAt is set to a truthy value')
-            // get this account out using emailRecord
-            var emailBuffer = Buffer(account.email)
-            return db.emailRecord(emailBuffer)
-          })
-          .then(function(result) {
-            return db.createPasswordForgotToken(PASSWORD_FORGOT_TOKEN_ID, PASSWORD_FORGOT_TOKEN)
-          })
-          .then(function(passwordForgotToken) {
-            return db.forgotPasswordVerified(PASSWORD_FORGOT_TOKEN_ID, ACCOUNT_RESET_TOKEN)
-          })
-          .then(function() {
-            // let's try and get the throwaway accountResetToken (shouldn't exist any longer)
-            return db.accountResetToken(THROWAWAY_ACCOUNT_RESET_TOKEN_ID)
-          })
-          .then(function(token) {
-            assert(false, 'Throwaway Account Reset Token should no longer exist')
-          }, function(err) {
-            // retrieve passwordForgotToken (shouldn't exist now)
-            return db.passwordForgotToken(PASSWORD_FORGOT_TOKEN_ID)
-          })
-          .then(function(token) {
-            assert(false, 'Password Forgot Token should no longer exist')
-          }, function(err) {
-            // Password Forgot Token deleted successfully
-          })
-          .then(function() {
-            return db.accountResetToken(ACCOUNT_RESET_TOKEN_ID)
-          })
-          .then(function(accountResetToken) {
-            // tokenId is not returned
-            assert.deepEqual(accountResetToken.uid, account.uid, 'token belongs to this account')
-            assert.deepEqual(accountResetToken.tokenData, ACCOUNT_RESET_TOKEN.data, 'token data matches')
-            assert.equal(accountResetToken.verifierSetAt, account.verifierSetAt, 'verifierSetAt is set correctly')
-          })
-          .then(function() {
-            return db.account(account.uid)
+            assert.deepEqual(result, {}, 'Returned an empty object email verification')
+            return db.account(accountData.uid)
           })
           .then(function(account) {
             assert(account.emailVerified, 'account should now be emailVerified (truthy)')
             assert.equal(account.emailVerified, 1, 'account should now be emailVerified (1)')
           })
-          .then(function() {
-            return db.deleteAccountResetToken(ACCOUNT_RESET_TOKEN_ID)
+      })
+    })
+
+    describe('db.updateLocale', () => {
+      it('should change account locale', () => {
+        return db.account(accountData.uid)
+          .then((account) => {
+            assert.equal(account.locale, 'en_US', 'correct locale set')
+            accountData.locale = 'en_NZ'
+            return db.updateLocale(accountData.uid, accountData)
           })
-          .then(function(result) {
+          .then(function (result) {
+            assert.deepEqual(result, {}, 'Returned an empty object on locale update')
+            return db.account(accountData.uid)
+          })
+          .then(function (account) {
+            assert.equal(account.locale, 'en_NZ', 'account should now have new locale')
+          })
+      })
+    })
+
+    describe('account reset token handling', () => {
+      let accountResetTokenData, forgotPasswordTokenData
+      beforeEach(() => {
+        forgotPasswordTokenData = makeMockForgotPasswordToken(accountData.uid)
+        accountResetTokenData = makeMockAccountResetToken(accountData.uid)
+        return db.createPasswordForgotToken(forgotPasswordTokenData.tokenId, forgotPasswordTokenData)
+          .then(function () {
+            return db.forgotPasswordVerified(forgotPasswordTokenData.tokenId, accountResetTokenData)
+          })
+      })
+
+      it('db.accountResetToken should create token', () => {
+        return db.accountResetToken(accountResetTokenData.tokenId)
+          .then((token) => {
+            // tokenId is not returned
+            assert.deepEqual(token.uid, accountData.uid, 'token belongs to this account')
+            assert.deepEqual(token.tokenData, accountResetTokenData.data, 'token data matches')
+            assert.equal(token.createdAt, accountResetTokenData.createdAt, 'createdAt is correct')
+            assert(token.verifierSetAt, 'verifierSetAt is set to a truthy value')
+          })
+      })
+
+      it('db.deleteAccountResetToken should delete token', () => {
+        return db.deleteAccountResetToken(accountResetTokenData.tokenId)
+          .then((result) => {
             assert.deepEqual(result, {}, 'Returned an empty object on account reset deletion')
-            return db.accountResetToken(ACCOUNT_RESET_TOKEN_ID)
+            return db.accountResetToken(accountResetTokenData.tokenId)
+              .then(assert.fail, (err) => {
+                assert.equal(err.errno, 116, 'err.errno is correct')
+                assert.equal(err.code, 404, 'err.code is correct')
+              })
           })
-          .then(function(token) {
-            assert(false, 'Account Reset Token should no longer exist')
-          }, function(err) {
-            // Account Reset Token deleted successfully
-          })
-      }
-    )
+      })
+    })
 
-    it(
-      'db.deviceFromTokenVerificationId',
-      () => {
-        var sessionTokenId = hex32()
-        var deviceId = newUuid()
-        var createdAt = Date.now()
-        var tokenVerificationId = SESSION_TOKEN.tokenVerificationId
-        var deviceName = 'test device'
-        return db.deviceFromTokenVerificationId(ACCOUNT.uid, hex16())
-          .then(function () {
-            assert(false, 'trying to retrieve a device from an unknown tokeenVerificationId should have failed')
-          }, function (err) {
+    describe('db.forgotPasswordVerified', () => {
+      let forgotPasswordTokenData, anotherForgotPasswordTokenData, accountResetTokenData, anotherAccountResetTokenData
+      beforeEach(() => {
+        forgotPasswordTokenData = makeMockForgotPasswordToken(accountData.uid)
+        accountResetTokenData = makeMockAccountResetToken(accountData.uid, forgotPasswordTokenData.tokenId)
+
+        anotherForgotPasswordTokenData = makeMockForgotPasswordToken(accountData.uid)
+        anotherAccountResetTokenData = makeMockAccountResetToken(accountData.uid, anotherForgotPasswordTokenData.tokenId)
+
+        return db.createPasswordForgotToken(anotherForgotPasswordTokenData.tokenId, anotherForgotPasswordTokenData)
+      })
+
+      it('should override accountResetToken when calling `db.forgotPasswordVerified`', () => {
+        return db.forgotPasswordVerified(anotherForgotPasswordTokenData.tokenId, anotherAccountResetTokenData)
+          .then(() => db.accountResetToken(anotherAccountResetTokenData.tokenId), assert.fail)
+          .then((token) => {
+            // check a couple of fields
+            assert.deepEqual(token.uid, accountData.uid, 'token belongs to this account')
+            assert.deepEqual(token.tokenData, anotherAccountResetTokenData.data, 'token data matches')
+            assert.equal(token.createdAt, anotherAccountResetTokenData.createdAt, 'createdAt is correct')
+            assert(token.verifierSetAt, 'verifierSetAt is set to a truthy value')
+
+            return db.createPasswordForgotToken(forgotPasswordTokenData.tokenId, forgotPasswordTokenData)
+          })
+          .then(() =>  db.forgotPasswordVerified(forgotPasswordTokenData.tokenId, forgotPasswordTokenData), assert.fail)
+          .then(() =>  db.accountResetToken(anotherAccountResetTokenData.tokenId))
+          .then(assert.fail, (err) => {
+            // throw away accountResetToken (shouldn't exist any longer)
+            assert.equal(err.errno, 116, 'err.errno is correct')
+            assert.equal(err.code, 404, 'err.code is correct')
+
+            return db.passwordForgotToken(forgotPasswordTokenData.tokenId)
+          })
+          .then(assert.fail, (err) => {
+            // throw away passwordForgotToken (shouldn't exist any longer)
+            assert.equal(err.errno, 116, 'err.errno is correct')
+            assert.equal(err.code, 404, 'err.code is correct')
+
+            return db.deleteAccountResetToken(accountResetTokenData.tokenId)
+          })
+          .then((result) => {
+            assert.deepEqual(result, {}, 'Returned an empty object on account reset deletion')
+            return db.accountResetToken(accountResetTokenData.tokenId)
+          })
+          .then(assert.fail, (err) => {
+            assert.equal(err.errno, 116, 'err.errno is correct')
+            assert.equal(err.code, 404, 'err.code is correct')
+          })
+
+      })
+    })
+
+    describe('db.deviceFromTokenVerificationId', () => {
+      let sessionTokenData
+      beforeEach(() => {
+        sessionTokenData = makeMockSessionToken(accountData.uid)
+        return db.createSessionToken(sessionTokenData.tokenId, sessionTokenData)
+      })
+
+      it('should fail for non-existing session', () => {
+        return db.deviceFromTokenVerificationId(accountData.uid, hex16())
+          .then(assert.fail, (err) => {
             assert.equal(err.code, 404, 'err.code')
             assert.equal(err.errno, 116, 'err.errno')
           })
-          .then(function () {
-            return db.createSessionToken(sessionTokenId, SESSION_TOKEN)
-          })
-          .then(function () {
-            return db.deviceFromTokenVerificationId(ACCOUNT.uid, tokenVerificationId)
-          })
-          .then(function () {
-            assert(false, 'no device should be associated with that session')
-          }, function (err) {
+      })
+
+      it('should fail for session with no device', () => {
+        return db.deviceFromTokenVerificationId(accountData.uid, sessionTokenData.tokenId)
+          .then(assert.fail, (err) => {
             assert.equal(err.code, 404, 'err.code')
             assert.equal(err.errno, 116, 'err.errno')
           })
-          .then(function () {
-            return db.createDevice(ACCOUNT.uid, deviceId, {
-              sessionTokenId: sessionTokenId,
-              createdAt: createdAt,
-              name: deviceName,
-              type: 'desktop'
-            })
-          })
-          .then(function () {
-            return db.deviceFromTokenVerificationId(ACCOUNT.uid, tokenVerificationId)
-          })
-          .then(function (deviceInfo) {
-            assert.deepEqual(deviceInfo.id, deviceId, 'We found our device id back')
-            assert.equal(deviceInfo.name, deviceName, 'We found our device name back')
-          })
-          .then(function () {
-            db.deleteDevice(ACCOUNT.uid, deviceId)
-          })
-      }
-    )
+      })
 
-    it(
-      'db.accountDevices',
-      () => {
-        var deviceId = newUuid()
-        var sessionTokenId = hex32()
-        var zombieSessionTokenId = hex32()
-        var createdAt = Date.now()
-        var deviceInfo = {
-          name: 'test device',
-          type: 'mobile',
-          callbackURL: 'https://foo/bar',
-          callbackPublicKey: base64_65(),
-          callbackAuthKey: base64_16(),
-          callbackIsExpired: false
-        }
-        var newDeviceId = newUuid()
-        var newSessionTokenId = hex32()
-        var newTokenVerificationId = hex16()
+      it('should return device', () => {
+        const deviceData = makeMockDevice(sessionTokenData.tokenId)
+        return db.createDevice(accountData.uid, deviceData.deviceId, deviceData)
+          .then(() => {
+            return db.deviceFromTokenVerificationId(accountData.uid, sessionTokenData.tokenVerificationId)
+          })
+          .then((deviceInfo) => {
+            assert.deepEqual(deviceInfo.id, deviceData.deviceId, 'We found our device id back')
+            assert.equal(deviceInfo.name, deviceData.name, 'We found our device name back')
+          })
+      })
+    })
 
-        // Attempt to update non-existent device
-        return db.updateDevice(ACCOUNT.uid, deviceId, deviceInfo)
-          .then(function () {
-            assert(false, 'updating a non-existent device should have failed')
-          }, function (err) {
-            assert.equal(err.code, 404, 'err.code')
-            assert.equal(err.errno, 116, 'err.errno')
-          })
-          .then(function () {
-            // Create a session token
-            return db.createSessionToken(sessionTokenId, SESSION_TOKEN)
-          })
-          .then(function (sessionToken) {
-            // Create a device
-            return db.createDevice(ACCOUNT.uid, deviceId, {
-              sessionTokenId: sessionTokenId,
-              createdAt: createdAt
-            })
-          })
-          .then(function (result) {
-            assert.deepEqual(result, {}, 'returned empty object')
+    describe('db.accountDevices', () => {
+      let deviceInfo, sessionTokenData
+      beforeEach(() => {
+        accountData = createAccount()
+        sessionTokenData = makeMockSessionToken(accountData.uid)
+        deviceInfo = makeMockDevice(sessionTokenData.tokenId)
 
-            // Attempt to create a duplicate device
-            return db.createDevice(ACCOUNT.uid, deviceId, {
-              sessionTokenId: newSessionTokenId,
-              createdAt: Date.now()
-            })
-            .then(function () {
-              assert(false, 'adding a duplicate device should have failed')
-            }, function (err) {
-              assert.equal(err.code, 409, 'err.code')
-              assert.equal(err.errno, 101, 'err.errno')
-            })
+        return db.createAccount(accountData.uid, accountData)
+          .then(() => db.createSessionToken(sessionTokenData.tokenId, sessionTokenData))
+          .then(() => db.createDevice(accountData.uid, deviceInfo.deviceId, deviceInfo))
+          .then((result) => assert.deepEqual(result, {}, 'returned empty object'))
+      })
+
+      it('should have created device', () => {
+        return db.sessionWithDevice(sessionTokenData.tokenId)
+          .then((s) => {
+            assert.deepEqual(s.deviceId, deviceInfo.deviceId, 'id')
+            assert.deepEqual(s.uid, sessionTokenData.uid, 'uid')
+            assert.equal(s.deviceName, deviceInfo.name, 'name')
+            assert.equal(s.deviceType, deviceInfo.type, 'type')
+            assert.equal(s.deviceCreatedAt, deviceInfo.createdAt, 'createdAt')
+            assert.equal(s.deviceCallbackURL, deviceInfo.callbackURL, 'callbackURL')
+            assert.equal(s.deviceCallbackPublicKey, deviceInfo.callbackPublicKey, 'callbackPublicKey')
+            assert.equal(s.deviceCallbackAuthKey, deviceInfo.callbackAuthKey, 'callbackAuthKey')
+            assert.equal(s.deviceCallbackIsExpired, deviceInfo.callbackIsExpired, 'callbackIsExpired')
+            assert.equal(!! s.mustVerify, !! sessionTokenData.mustVerify, 'mustVerify is correct')
+            assert.deepEqual(s.tokenVerificationId, sessionTokenData.tokenVerificationId, 'tokenVerificationId is correct')
           })
-          .then(function () {
-            // Fetch all of the devices for the account
-            return db.accountDevices(ACCOUNT.uid)
-          })
-          .then(function (devices) {
+      })
+
+      it('should get all devices', () => {
+        return db.accountDevices(accountData.uid)
+          .then((devices) => {
             assert.equal(devices.length, 1, 'devices length 1')
-            return devices[0]
-          })
-          .then(function (device) {
-            assert.deepEqual(device.sessionTokenId, sessionTokenId, 'sessionTokenId')
-            assert.equal(device.name, null, 'name')
-            assert.deepEqual(device.id, deviceId, 'id')
-            assert.equal(device.createdAt, createdAt, 'createdAt')
-            assert.equal(device.type, null, 'type')
-            assert.equal(device.callbackURL, null, 'callbackURL')
-            assert.equal(device.callbackPublicKey, null, 'callbackPublicKey')
-            assert.equal(device.callbackAuthKey, null, 'callbackAuthKey')
-            assert.equal(device.callbackIsExpired, false, 'callbackIsExpired')
-            assert(device.lastAccessTime > 0, 'has a lastAccessTime')
-            assert.equal(device.email, ACCOUNT.email, 'email should be account email')
-
-            // Fetch the session token with its verification state and device info
-            return db.sessionWithDevice(sessionTokenId)
-              .then(
-                function (s) {
-                  assert.deepEqual(s.deviceId, device.id, 'id')
-                  assert.deepEqual(s.uid, device.uid, 'uid')
-                  assert.equal(s.deviceName, device.name, 'name')
-                  assert.equal(s.deviceType, device.type, 'type')
-                  assert.equal(s.deviceCreatedAt, device.createdAt, 'createdAt')
-                  assert.equal(s.deviceCallbackURL, device.callbackURL, 'callbackURL')
-                  assert.equal(s.deviceCallbackPublicKey, device.callbackPublicKey, 'callbackPublicKey')
-                  assert.equal(s.deviceCallbackAuthKey, device.callbackAuthKey, 'callbackAuthKey')
-                  assert.equal(s.deviceCallbackIsExpired, device.callbackIsExpired, 'callbackIsExpired')
-                  assert.equal(!! s.mustVerify, !! SESSION_TOKEN.mustVerify, 'mustVerify is correct')
-                  assert.deepEqual(s.tokenVerificationId, SESSION_TOKEN.tokenVerificationId, 'tokenVerificationId is correct')
-                },
-                function (e) {
-                  assert(false, 'getting the sessionWithDevice should not have failed')
-                }
-              )
-          })
-          .then(function () {
-            // Verify the session token
-            return db.verifyTokens(SESSION_TOKEN.tokenVerificationId, { uid: SESSION_TOKEN.uid })
-          })
-          .then(function () {
-            // Fetch the session token with its verification state and device info
-            return db.sessionWithDevice(sessionTokenId)
-          })
-          .then(function (s) {
-            assert.equal(s.mustVerify, null, 'mustVerify is null')
-            assert.equal(s.tokenVerificationId, null, 'tokenVerificationId is null')
-
-            // Update the device
-            return db.updateDevice(ACCOUNT.uid, deviceId, deviceInfo)
-          })
-          .then(function (result) {
-            assert.deepEqual(result, {}, 'returned empty object')
-
-            // Fetch all of the devices for the account
-            return db.accountDevices(ACCOUNT.uid)
-          })
-          .then(function (devices) {
-            assert.equal(devices.length, 1, 'devices length still 1')
-            return devices[0]
-          })
-          .then(function (device) {
-            assert.deepEqual(device.sessionTokenId, sessionTokenId, 'sessionTokenId')
+            const device = devices[0]
+            assert.deepEqual(device.sessionTokenId, sessionTokenData.tokenId, 'sessionTokenId')
             assert.equal(device.name, deviceInfo.name, 'name')
-            assert.deepEqual(device.id, deviceId, 'id')
-            assert.equal(device.createdAt, createdAt, 'createdAt')
+            assert.deepEqual(device.id, deviceInfo.deviceId, 'id')
+            assert.equal(device.createdAt, deviceInfo.createdAt, 'createdAt')
             assert.equal(device.type, deviceInfo.type, 'type')
             assert.equal(device.callbackURL, deviceInfo.callbackURL, 'callbackURL')
             assert.equal(device.callbackPublicKey, deviceInfo.callbackPublicKey, 'callbackPublicKey')
             assert.equal(device.callbackAuthKey, deviceInfo.callbackAuthKey, 'callbackAuthKey')
             assert.equal(device.callbackIsExpired, deviceInfo.callbackIsExpired, 'callbackIsExpired')
             assert(device.lastAccessTime > 0, 'has a lastAccessTime')
-            assert.equal(device.email, ACCOUNT.email, 'email should be account email')
+            assert.equal(device.email, accountData.email, 'email should be account email')
+          })
+      })
 
-            // Create a second session token
-            return db.createSessionToken(newSessionTokenId, SESSION_TOKEN)
-          })
-          .then(function () {
-            // Update the device name and session token
-            return db.updateDevice(ACCOUNT.uid, deviceId, {
-              sessionTokenId: newSessionTokenId,
-              name: 'updated name',
-              type: null
-            })
-          })
-          .then(function () {
-            // Fetch all of the devices for the account
-            return db.accountDevices(ACCOUNT.uid)
-          })
-          .then(function (devices) {
-            assert.equal(devices.length, 1, 'devices length still 1')
-            return devices[0]
-          })
-          .then(function (device) {
-            assert.deepEqual(device.sessionTokenId, newSessionTokenId, 'sessionTokenId updated')
-            assert.equal(device.name, 'updated name', 'name updated')
-            assert.equal(device.type, deviceInfo.type, 'type unchanged')
-            assert.equal(device.callbackURL, deviceInfo.callbackURL, 'callbackURL unchanged')
-            assert.equal(device.callbackPublicKey, deviceInfo.callbackPublicKey, 'callbackPublicKey unchanged')
-            assert.equal(device.callbackAuthKey, deviceInfo.callbackAuthKey, 'callbackAuthKey unchanged')
-            assert.equal(device.callbackIsExpired, deviceInfo.callbackIsExpired, 'callbackIsExpired unchanged')
+      it('should update device', () => {
+        deviceInfo.name = 'New New Device'
+        deviceInfo.type = 'desktop'
+        deviceInfo.callbackURL = ''
+        deviceInfo.callbackPublicKey = ''
+        deviceInfo.callbackAuthKey = ''
+        deviceInfo.callbackIsExpired = true
 
-            // Update the device type and callback params
-            return db.updateDevice(ACCOUNT.uid, deviceId, {
-              type: 'desktop',
-              callbackURL: '',
-              callbackPublicKey: '',
-              callbackAuthKey: '',
-              callbackIsExpired: true
-            })
-          })
-          .then(function (result) {
-            // Fetch all of the devices for the account
-            return db.accountDevices(ACCOUNT.uid)
-          })
-          .then(function (devices) {
-            assert.equal(devices.length, 1, 'devices length still 1')
-            return devices[0]
-          })
-          .then(function (device) {
-            assert.deepEqual(device.sessionTokenId, newSessionTokenId, 'sessionTokenId updated')
-            assert.equal(device.name, 'updated name', 'name unchanged')
-            assert.equal(device.type, 'desktop', 'type updated')
-            assert.equal(device.callbackURL, '', 'callbackURL updated')
-            assert.equal(device.callbackPublicKey, '', 'callbackPublicKey updated')
-            assert.equal(device.callbackAuthKey, '', 'callbackAuthKey updated')
-            assert.equal(device.callbackIsExpired, true, 'callbackIsExpired updated')
+        const newSessionTokenData = makeMockSessionToken(accountData.uid)
+        deviceInfo.sessionTokenId = newSessionTokenData.tokenId
 
-            // Make the device a zombie, by giving it a non-existent session token
-            return db.updateDevice(ACCOUNT.uid, deviceId, {
-              sessionTokenId: zombieSessionTokenId
-            })
+        return db.createSessionToken(newSessionTokenData.tokenId, newSessionTokenData)
+          .then(() => {
+            return db.updateDevice(accountData.uid, deviceInfo.deviceId, deviceInfo)
           })
-          .then(function () {
-            // Fetch all of the devices for the account
-            return db.accountDevices(ACCOUNT.uid)
-          })
-          .then(function (devices) {
-            assert.equal(devices.length, 0, 'devices is empty')
-
-            // Reinstate the previous session token for the device
-            return db.updateDevice(ACCOUNT.uid, deviceId, {
-              sessionTokenId: newSessionTokenId
-            })
-          })
-          .then(function () {
-            // Fetch all of the devices for the account
-            return db.accountDevices(ACCOUNT.uid)
-          })
-          .then(function (devices) {
-            assert.equal(devices.length, 1, 'devices contains one item again')
-
-            // Attempt to create a second device with the same session token
-            return db.createDevice(ACCOUNT.uid, newUuid(), {
-              sessionTokenId: newSessionTokenId,
-              name: 'second device',
-              createdAt: Date.now(),
-              type: 'desktop',
-              callbackURL: 'https://foo/bar',
-              callbackPublicKey: base64_65(),
-              callbackAuthKey: base64_16(),
-              callbackIsExpired: false
-            })
-            .then(function () {
-              assert(false, 'adding a second device should have failed when the session token is already registered')
-            }, function (err) {
-              assert.equal(err.code, 409, 'err.code')
-              assert.equal(err.errno, 101, 'err.errno')
-            })
-          })
-          .then(function () {
-            // Fetch all of the devices for the account
-            return db.accountDevices(ACCOUNT.uid)
-          })
-          .then(function (devices) {
-            assert.equal(devices.length, 1, 'devices length still 1')
-
-            // Create a second device
-            return db.createDevice(ACCOUNT.uid, newDeviceId, {
-              sessionTokenId: sessionTokenId,
-              name: 'second device',
-              createdAt: Date.now(),
-              type: 'desktop',
-              callbackURL: 'https://foo/bar',
-              callbackPublicKey: base64_65(),
-              callbackAuthKey: base64_16(),
-              callbackIsExpired: false
-            })
-            .then(function () {
-            }, function (err) {
-              assert(false, 'adding a second device should not have failed when the session token is not registered')
-            })
-          })
-          .then(function () {
-            // Fetch all of the devices for the account
-            return db.accountDevices(ACCOUNT.uid)
-          })
-          .then(function (devices) {
-            assert.equal(devices.length, 2, 'devices length 2')
-
-            // Delete the first device
-            return db.deleteDevice(ACCOUNT.uid, deviceId)
-          })
-          .then(function (result) {
+          .then((result) => {
             assert.deepEqual(result, {}, 'returned empty object')
-
-            // Fetch all of the devices for the account
-            return db.accountDevices(ACCOUNT.uid)
+            return db.accountDevices(accountData.uid)
           })
-          .then(function (devices) {
+          .then((devices) => {
             assert.equal(devices.length, 1, 'devices length 1')
+            const device = devices[0]
+            assert.deepEqual(device.sessionTokenId, newSessionTokenData.tokenId, 'sessionTokenId updated')
+            assert.equal(device.name, 'New New Device', 'name updated')
+            assert.equal(device.type, 'desktop', 'type unchanged')
+            assert.equal(device.callbackURL, '', 'callbackURL unchanged')
+            assert.equal(device.callbackPublicKey, '', 'callbackPublicKey unchanged')
+            assert.equal(device.callbackAuthKey, '', 'callbackAuthKey unchanged')
+            assert.equal(device.callbackIsExpired, true, 'callbackIsExpired unchanged')
+          })
+      })
 
-            // Attempt to delete the first device again
-            return db.deleteDevice(ACCOUNT.uid, deviceId)
-              .then(function () {
-                assert(false, 'deleting a non-existent device should have failed')
-              }, function (err) {
-                assert.equal(err.code, 404, 'err.code')
-                assert.equal(err.errno, 116, 'err.errno')
-              })
+      it('should fail to return zombie session', () => {
+        // zombie devices don't have an associated session
+        deviceInfo.sessionTokenId = hex16()
+        return db.updateDevice(accountData.uid, deviceInfo.deviceId, deviceInfo)
+          .then((result) => {
+            assert.deepEqual(result, {}, 'returned empty object')
+            return db.accountDevices(accountData.uid)
           })
-          .then(function () {
-            // Fetch all of the devices for the account
-            return db.accountDevices(ACCOUNT.uid)
-          })
-          .then(function (devices) {
-            assert.equal(devices.length, 1, 'devices length 1')
-
-            // Attempt to fetch the session token that was associated with the deleted device
-            return db.sessionWithDevice(newSessionTokenId)
-          })
-          .then(function () {
-            assert(false, 'deleting the device should have deleted the session token')
-          }, function (err) {
-            assert.equal(err.code, 404, 'err.code')
-            assert.equal(err.errno, 116, 'err.errno')
-          })
-          .then(function () {
-            // Attempt to verify the session token that was associated with the deleted device
-            return db.verifyTokens(newTokenVerificationId, { uid: ACCOUNT.uid })
-          })
-          .then(function () {
-            assert(false, 'deleting the device should have deleted the unverified token')
-          }, function (err) {
-            assert.equal(err.code, 404, 'err.code')
-            assert.equal(err.errno, 116, 'err.errno')
-          })
-          .then(function () {
-            // Delete the second device
-            return db.deleteDevice(ACCOUNT.uid, newDeviceId)
-          })
-          .then(function () {
-            // Fetch all of the devices for the account
-            return db.accountDevices(ACCOUNT.uid)
-          })
-          .then(function (devices) {
+          .then((devices) => {
             assert.equal(devices.length, 0, 'devices length 0')
           })
-      }
-    )
+      })
 
-    it(
-      'db.resetAccount',
-      () => {
-        var account = createAccount()
-        var uid = account.uid
-        var createdAt = Date.now()
-        var THROWAWAY_PASSWORD_FORGOT_TOKEN_ID = hex32()
-        var THROWAWAY_PASSWORD_FORGOT_TOKEN = {
-          data : hex32(),
-          uid : uid,
-          passCode : hex16(),
-          tries : 1,
-          createdAt: now
-        }
-        var THROWAWAY_ACCOUNT_RESET_TOKEN_ID = hex32()
-        var THROWAWAY_ACCOUNT_RESET_TOKEN = {
-          tokenId : THROWAWAY_ACCOUNT_RESET_TOKEN_ID,
-          data : hex32(),
-          uid : uid,
-          createdAt: now + 4
-        }
-        var sessionToken = {
-          data : hex32(),
-          uid : account.uid,
-          createdAt : now + 1,
-          uaBrowser : 'mock browser',
-          uaBrowserVersion : 'mock browser version',
-          uaOS : 'mock OS',
-          uaOSVersion : 'mock OS version',
-          uaDeviceType : 'mock device type',
-          mustVerify: true,
-          tokenVerificationId : hex16()
-        }
+      it('should fail add multiple device to session', () => {
+        const anotherDevice = makeMockDevice(sessionTokenData.tokenId)
+        return db.createDevice(accountData.uid, anotherDevice.deviceId, anotherDevice)
+          .then(assert.fail, (err) => {
+            assert.equal(err.code, 409, 'err.code')
+            assert.equal(err.errno, 101, 'err.errno')
+          })
+      })
 
-        return db.createAccount(account.uid, account)
-          .then(function () {
-            return db.createSessionToken(SESSION_TOKEN_ID, sessionToken)
+      it('should fail to update non-existent device', () => {
+        return db.updateDevice(accountData.uid, hex16(), deviceInfo)
+          .then(assert.fail, (err) => {
+            assert.equal(err.code, 404, 'err.code')
+            assert.equal(err.errno, 116, 'err.errno')
           })
-          .then(function() {
-            return db.createDevice(account.uid, newUuid(), {
-              sessionTokenId: SESSION_TOKEN_ID,
-              createdAt: createdAt
-            })
+      })
+
+      it('should fail to delete non-existent device', () => {
+        return db.deleteDevice(accountData.uid, hex16())
+          .then(assert.fail, (err) => {
+            assert.equal(err.code, 404, 'err.code')
+            assert.equal(err.errno, 116, 'err.errno')
           })
-          .then(function() {
-            return db.createPasswordForgotToken(THROWAWAY_PASSWORD_FORGOT_TOKEN_ID, THROWAWAY_PASSWORD_FORGOT_TOKEN)
+      })
+
+      it('should delete session when device is deleted', () => {
+        return db.deleteDevice(accountData.uid, deviceInfo.deviceId)
+          .then((result) => {
+            assert.deepEqual(result, {}, 'returned empty object')
+            return db.sessionWithDevice(sessionTokenData.tokenId)
           })
-          .then(function(passwordForgotToken) {
-            return P.all([db.account(uid), db.accountEmails(uid)])
+          .then(assert.fail, (err) => {
+            assert.equal(err.code, 404, 'err.code')
+            assert.equal(err.errno, 116, 'err.errno')
+            return db.accountDevices(accountData.uid)
           })
-          .spread(function(accountResult, emails) {
+          .then((devices) => assert.equal(devices.length, 0, 'devices length 0'))
+      })
+    })
+
+    describe('db.resetAccount', () => {
+      let passwordForgotTokenData, sessionTokenData, deviceInfo
+      beforeEach(() => {
+        accountData = createAccount()
+        sessionTokenData = makeMockSessionToken(accountData.uid, true)
+        passwordForgotTokenData = makeMockForgotPasswordToken(accountData.uid)
+        deviceInfo = makeMockDevice(sessionTokenData.tokenId)
+
+        return db.createAccount(accountData.uid, accountData)
+          .then(() => db.createSessionToken(sessionTokenData.tokenId, sessionTokenData))
+          .then(() => db.createDevice(accountData.uid, deviceInfo.deviceId, deviceInfo))
+          .then(() => db.createPasswordForgotToken(passwordForgotTokenData.tokenId, passwordForgotTokenData))
+      })
+
+      it('should verify account upon forgot token creation', () => {
+        return db.accountEmails(accountData.uid)
+          .then((emails) => {
             // Account should be unverified
-            assert.equal(!! accountResult.emailVerified, false, 'email is not verified')
+            assert.equal(emails.length, 1, 'correct number of emails')
             assert.equal(!! emails[0].isVerified, false, 'email is not verified')
             assert.equal(!! emails[0].isPrimary, true, 'email is primary')
-            assert.equal(accountResult.email, emails[0].email, 'emails should match')
 
-            return db.forgotPasswordVerified(THROWAWAY_PASSWORD_FORGOT_TOKEN_ID, THROWAWAY_ACCOUNT_RESET_TOKEN)
+            return db.forgotPasswordVerified(passwordForgotTokenData.tokenId, passwordForgotTokenData)
           })
-          .then(function() {
-            return P.all([db.account(uid), db.accountEmails(uid)])
-          })
-          .spread(function(accountResult, emails) {
+          .then(() => db.accountEmails(accountData.uid))
+          .then((emails) => {
             // Account should be verified
-            assert.equal(!! accountResult.emailVerified, true, 'email is verified')
+            assert.equal(emails.length, 1, 'correct number of emails')
             assert.equal(!! emails[0].isVerified, true, 'email is verified')
             assert.equal(!! emails[0].isPrimary, true, 'email is primary')
-            assert.equal(accountResult.email, emails[0].email, 'emails should match')
           })
-          .then(function() {
-            return db.resetAccount(uid, ACCOUNT)
+      })
+
+      it('should remove devices after account reset', () => {
+        return db.accountDevices(accountData.uid)
+          .then((devices) => {
+            assert.equal(devices.length, 1, 'The devices length should be one')
+            return db.resetAccount(accountData.uid, accountData)
           })
-          .then(function() {
-            return db.accountDevices(uid)
-          })
-          .then(function(devices) {
+          .then(() => db.accountDevices(accountData.uid))
+          .then((devices) => {
             assert.equal(devices.length, 0, 'The devices length should be zero')
-
-            // Attempt to verify the session token
-            return db.verifyTokens(sessionToken.tokenVerificationId, { uid: uid })
           })
-          .then(function () {
-            assert(false, 'Verifying deleted token should have failed')
-          }, function (err) {
-            assert.equal(err.errno, 116, 'err.errno is correct')
-            assert.equal(err.code, 404, 'err.code is correct')
+      })
+
+      it('should remove session after account reset', () => {
+        return db.resetAccount(accountData.uid, accountData)
+          .then(() => db.sessionToken(sessionTokenData.tokenId))
+          .then(assert.fail, (err) => {
+            assert.equal(err.code, 404, 'err.code')
+            assert.equal(err.errno, 116, 'err.errno')
           })
-          .then(function() {
-            // Attempt to fetch the session token
-            return db.sessionToken(SESSION_TOKEN_ID)
+      })
+
+      it('should still retrieve account after account reset', () => {
+        return db.account(accountData.uid)
+          .then((account) => {
+            assert.ok(account, 'account exists')
+            return db.resetAccount(accountData.uid, accountData)
           })
-          .then(function () {
-            assert(false, 'Fetching deleted token should have failed')
-          }, function (err) {
-            assert.equal(err.errno, 116, 'err.errno is correct')
-            assert.equal(err.code, 404, 'err.code is correct')
-          })
-          .then(function() {
-            // account should STILL exist for this email address
-            var emailBuffer = Buffer(account.email)
-            return db.accountExists(emailBuffer)
-          })
-          .then(function(exists) {
-            assert(exists, 'account still exists ok')
-          }, function(err) {
-            assert(false, 'the account for this email address should still exist')
-          })
-      }
-    )
+          .then(() => db.account(accountData.uid))
+          .then((account) => assert.ok(account, 'account exists'))
+      })
 
-    it(
-      'securityEvents',
-      () => {
+    })
 
-        function securityEvents(suite) {
-          return suite.setUp().then(function () {
-            delete suite.setUp
+    describe('db.securityEvents', () => {
+      let session1, session2, session3, uid1, uid2
+      const evA = 'account.login', evB = 'account.create', evC = 'account.reset'
+      const addr1 = '127.0.0.1', addr2 = '::127.0.0.2'
 
-            var names = Object.keys(suite)
-
-            function run () {
-              var unit = names.shift()
-
-              if (unit) {
-                return suite[unit]().then(run)
-              }
-            }
-
-            return run()
-          })
-        }
-
-        function createSession (id, session) {
-          return db.createSessionToken(id, session)
-        }
-
-        function verifySession (id, uid) {
-          return db.verifyTokens(id, { uid: uid })
-        }
-
-        function deleteSession (id) {
-          return db.deleteSessionToken(id)
-        }
-
-        function insert (uid, addr, name, session) {
-          return db.createSecurityEvent({
-            uid: uid,
-            ipAddr: addr,
-            name: name,
-            tokenId: session
-          })
-        }
-
-        function query (uid, addr, cb) {
-          return function () {
-            return db.securityEvents({
-              id: uid,
-              ipAddr: addr
-            })
-            .then(cb)
-          }
-        }
-
-        var uid1 = ACCOUNT.uid
-        var uid2 = newUuid()
-        var addr1 = '127.0.0.1'
-        var addr2 = '::127.0.0.2'
-
-        var evA = 'account.login'
-        var evB = 'account.create'
-        var evC = 'account.reset'
-
-        var sessionId1 = hex32()
-        var sessionId2 = hex32()
-        var sessionId3 = hex32()
-
-        var session1 = {
-          data: hex32(),
-          uid: uid1,
-          createdAt: Date.now(),
-          uaBrowser: 'foo',
-          uaBrowserVersion: 'bar',
-          uaOS: 'baz',
-          uaOSVersion: 'qux',
-          uaDeviceType: 'wibble',
-          mustVerify: false,
-          tokenVerificationId: hex16()
-        }
-
-        var session2 = {
-          data: hex32(),
-          uid: uid1,
-          createdAt: Date.now(),
-          uaBrowser: 'foo',
-          uaBrowserVersion: 'bar',
-          uaOS: 'baz',
-          uaOSVersion: 'qux',
-          uaDeviceType: 'wibble'
-          // no tokenVerificationId means verified
-        }
-
-        var session3 = {
-          data: hex32(),
-          uid: uid1,
-          createdAt: Date.now(),
-          uaBrowser: 'foo',
-          uaBrowserVersion: 'bar',
-          uaOS: 'baz',
-          uaOSVersion: 'qux',
-          uaDeviceType: 'wibble',
-          mustVerify: false,
-          tokenVerificationId: hex16()
-        }
-
-        return securityEvents({
-          setUp: function () {
-            return P.all([
-              createSession(sessionId1, session1),
-              createSession(sessionId2, session2),
-              createSession(sessionId3, session3)
-            ])
-            // Don't paralleize these, the order of them matters
-            // because they record timestamps in the db.
-            .then(function () {
-              return insert(uid1, addr1, evA, sessionId2).delay(10)
-            })
-            .then(function () {
-              return insert(uid1, addr1, evB, sessionId1).delay(10)
-            })
-            .then(function () {
-              return insert(uid1, addr1, evC).delay(10)
-            })
-            .then(function () {
-              return insert(uid1, addr2, evA, sessionId3).delay(10)
-            })
-            .then(function () {
-              return insert(uid2, addr1, evA, hex32())
-            })
-          },
-
-          testGetEvent: query(
-            uid1, addr1,
-            function (results) {
-              assert.equal(results.length, 3, 'three events for uid and addr')
-              // The most recent event is returned first.
-              assert.equal(results[0].name, evC, 'correct event name')
-              assert.equal(!! results[0].verified, true, 'event without a session is already verified')
-              assert(results[0].createdAt < Date.now(), 'createdAt is set')
-              assert.equal(results[1].name, evB, 'correct event name')
-              assert.equal(!! results[1].verified, false, 'second session is not verified yet')
-              assert(results[1].createdAt < results[0].createdAt, 'createdAt is lower than previous event')
-              assert.equal(results[2].name, evA, 'correct event name')
-              assert.equal(!! results[2].verified, true, 'first session is already verified')
-              assert(results[2].createdAt < results[1].createdAt, 'createdAt is lower than previous event')
-            }
-          ),
-
-          testGetEventAfterSessionVerified: function () {
-            return verifySession(session1.tokenVerificationId, uid1)
-              .then(query(uid1, addr1, function (results) {
-                assert.equal(results.length, 3, 'three events for uid and addr')
-                assert.equal(!! results[0].verified, true, 'first session verified')
-                assert.equal(!! results[1].verified, true, 'second session verified')
-                assert.equal(!! results[2].verified, true, 'third session verified')
-              }))
-          },
-
-          testGetSecondAddr: query(
-            uid1, addr2,
-            function (results) {
-              assert.equal(results.length, 1, 'one event for addr2')
-              assert.equal(results[0].name, evA)
-              assert.equal(!! results[0].verified, false, 'session3 not verified yet')
-            }
-          ),
-
-          testGetSecondAddrAfterDeletingUnverifiedSession: function () {
-            return deleteSession(sessionId3)
-              .then(query(uid1, addr2, function (results) {
-                assert.equal(results.length, 1, 'one event for addr2')
-                assert.equal(results[0].name, evA)
-                assert.equal(!! results[0].verified, false, 'session3 not verified yet')
-              }))
-          },
-
-          testGetWithIPv6: query(
-            uid1, '::' + addr1,
-            function (results) {
-              assert.equal(results.length, 3, 'three events for ipv6 addr')
-            }
-          ),
-
-          testUnknownUid: query(
-            newUuid(), addr1,
-            function (results) {
-              assert.equal(results.length, 0, 'no events for unknown uid')
-            }
-          )
+      function insert (uid, addr, name, session) {
+        return db.createSecurityEvent({
+          uid: uid,
+          ipAddr: addr,
+          name: name,
+          tokenId: session
         })
       }
-    )
 
-    it(
-      'account deletion',
-      () => {
-        var uid = ACCOUNT.uid
-        return db.deleteAccount(uid)
-          .then(function() {
-            // account should no longer exist for this email address
-            var emailBuffer = Buffer(ACCOUNT.email)
-            return db.accountExists(emailBuffer)
-          })
-          .then(function(exists) {
-            assert(false, 'account should no longer exist for this email address')
-          }, function(err) {
-            // Fetch the session token with its verification state
-            return db.sessionTokenWithVerificationStatus(SESSION_TOKEN_ID)
-          })
-          .then(function () {
-            // Attempt to verify session token
-            return db.verifyTokens(SESSION_TOKEN.tokenVerificationId, { uid: uid })
-          })
-          .then(function () {
-            assert(false, 'Verifying deleted token should have failed')
-          }, function (err) {
-            assert.equal(err.errno, 116, 'err.errno is correct')
-            assert.equal(err.code, 404, 'err.code is correct')
-          })
-          .then(function() {
-            // Attempt to fetch session token
-            return db.sessionToken(SESSION_TOKEN_ID)
-          })
-          .then(function () {
-            assert(false, 'Fetching deleted token should have failed')
-          }, function (err) {
-            assert.equal(err.errno, 116, 'err.errno is correct')
-            assert.equal(err.code, 404, 'err.code is correct')
-          })
-      }
-    )
+      beforeEach(() => {
+        accountData = createAccount()
+        session1 = makeMockSessionToken(accountData.uid)
+        session2 = makeMockSessionToken(accountData.uid)
+        // Make session verified
+        delete session2.tokenVerificationId
 
-    it(
-      'reminders - create and delete',
-      () => {
-        var fetchQuery = {
+        session3 = makeMockSessionToken(accountData.uid)
+
+        uid1 = accountData.uid
+        uid2 = newUuid()
+
+        return db.createAccount(accountData.uid, accountData)
+          .then(() => P.all([
+            db.createSessionToken(session1.tokenId, session1),
+            db.createSessionToken(session2.tokenId, session2),
+            db.createSessionToken(session3.tokenId, session3)
+          ]))
+        // Don't paralleize these, the order of them matters
+        // because they record timestamps in the db.
+          .then(() => insert(uid1, addr1, evA, session2.tokenId).delay(10))
+          .then(() => insert(uid1, addr1, evB, session1.tokenId).delay(10))
+          .then(() => insert(uid1, addr1, evC).delay(10))
+          .then(() => insert(uid1, addr2, evA, session3.tokenId).delay(10))
+          .then(() => insert(uid2, addr1, evA, hex32()))
+      })
+
+      it('should get security event', () => {
+        return db.securityEvents({id: uid1, ipAddr: addr1})
+          .then((results) => {
+            assert.equal(results.length, 3, 'three events for uid and addr')
+            // The most recent event is returned first.
+            assert.equal(results[0].name, evC, 'correct event name')
+            assert.equal(!! results[0].verified, true, 'event without a session is already verified')
+            assert(results[0].createdAt < Date.now(), 'createdAt is set')
+            assert.equal(results[1].name, evB, 'correct event name')
+            assert.equal(!! results[1].verified, false, 'second session is not verified yet')
+            assert(results[1].createdAt < results[0].createdAt, 'createdAt is lower than previous event')
+            assert.equal(results[2].name, evA, 'correct event name')
+            assert.equal(!! results[2].verified, true, 'first session is already verified')
+            assert(results[2].createdAt < results[1].createdAt, 'createdAt is lower than previous event')
+          })
+      })
+
+      it('should get event after session verified', () => {
+        return db.verifyTokens(session1.tokenVerificationId, {uid: uid1})
+          .then(() => db.securityEvents({id: uid1, ipAddr: addr1}))
+          .then((results) => {
+            assert.equal(results.length, 3, 'three events for uid and addr')
+            assert.equal(!! results[0].verified, true, 'first session verified')
+            assert.equal(!! results[1].verified, true, 'second session verified')
+            assert.equal(!! results[2].verified, true, 'third session verified')
+          })
+      })
+
+      it('should get second address', () => {
+        return db.securityEvents({id: uid1, ipAddr: addr2})
+          .then((results) => {
+            assert.equal(results.length, 1, 'one event for addr2')
+            assert.equal(results[0].name, evA)
+            assert.equal(!! results[0].verified, false, 'session3 not verified yet')
+          })
+      })
+
+      it('should get second addr after deleting unverified session', () => {
+        return db.deleteSessionToken(session3.tokenId)
+          .then(() => db.securityEvents({id: uid1, ipAddr: addr2}))
+          .then((results) => {
+            assert.equal(results.length, 1, 'one event for addr2')
+            assert.equal(results[0].name, evA)
+            assert.equal(!! results[0].verified, false, 'session3 not verified yet')
+          })
+      })
+
+      it('should get with IPv6', () => {
+        return db.securityEvents({id: uid1, ipAddr: '::' + addr1})
+          .then((results) => assert.equal(results.length, 3, 'three events for ipv6 addr'))
+      })
+
+      it('should fail with unknown uid', () => {
+        return db.securityEvents({id: newUuid(), ipAddr: addr1})
+          .then((results) => assert.equal(results.length, 0, 'no events for unknown uid'))
+      })
+    })
+
+    describe('db.deleteAccount', () => {
+      let sessionTokenData
+      beforeEach(() => {
+        accountData = createAccount()
+        sessionTokenData = makeMockSessionToken(accountData.uid)
+
+        return db.createAccount(accountData.uid, accountData)
+          .then(() => db.createSessionToken(sessionTokenData.tokenId, sessionTokenData))
+          .then(() => db.accountExists(accountData.emailBuffer))
+          .then((exists) => {
+            assert.ok(exists, 'account exists')
+            return db.deleteAccount(accountData.uid)
+          })
+      })
+
+      it('should have delete account', () => {
+        return db.accountExists(accountData.emailBuffer)
+          .then(assert.fail, (err) => {
+            assert.equal(err.code, 404, 'err.code')
+            assert.equal(err.errno, 116, 'err.errno')
+          })
+      })
+
+      it('should fail to verify session', () => {
+        return db.verifyTokens(sessionTokenData.tokenVerificationId, accountData)
+          .then(assert.fail, (err) => {
+            assert.equal(err.code, 404, 'err.code')
+            assert.equal(err.errno, 116, 'err.errno')
+          })
+      })
+
+      it('should fail to fetch session', () => {
+        return db.sessionToken(sessionTokenData.tokenId)
+          .then(assert.fail, (err) => {
+            assert.equal(err.code, 404, 'err.code')
+            assert.equal(err.errno, 116, 'err.errno')
+          })
+      })
+    })
+
+    describe('reminders', () => {
+      let accountData2, fetchQuery
+      beforeEach(() => {
+        accountData = createAccount()
+        accountData2 = createAccount()
+        return P.all([
+          db.createAccount(accountData.uid, accountData),
+          db.createAccount(accountData2.uid, accountData2)
+        ])
+      })
+
+      it('create and delete', () => {
+        fetchQuery = {
           type: 'second',
           reminderTime: 1,
           reminderTimeOutdated: 100,
           limit: 20
         }
-        var account = createAccount()
-        return db.createAccount(account.uid, account)
-          .then(
-            function () {
-              return db.createVerificationReminder({
-                uid: account.uid,
-                type: 'second'
-              })
-            }
-          )
-          .then(
-            function () {
-              return P.delay(20).then(function () {
-                return db.fetchReminders({}, fetchQuery)
-              })
-            }
-          )
-          .then(
-            function (result) {
-              assert.equal(result[0].type, 'second', 'correct type')
-              assert.equal(result[0].uid.toString('hex'), account.uid.toString('hex'), 'correct uid')
-            }
-          )
-          .then(
-            function () {
-              return db.fetchReminders({}, fetchQuery)
-            }
-          )
-          .then(
-            function (result) {
-              assert.equal(result.length, 0, 'no more reminders')
-            }
-          )
-      }
-    )
 
-    it(
-      'reminders - multiple accounts',
-      () => {
-        var fetchQuery = {
+        return db.createVerificationReminder({uid: accountData.uid, type: 'second'})
+          .then(() => P.delay(20))
+          .then(() => db.fetchReminders({}, fetchQuery))
+          .then((result) => {
+            assert.equal(result[0].type, 'second', 'correct type')
+            assert.equal(result[0].uid.toString('hex'), accountData.uid.toString('hex'), 'correct uid')
+            return db.fetchReminders({}, fetchQuery)
+          })
+          .then((result) => assert.equal(result.length, 0, 'no more reminders'))
+      })
+
+      it('multiple accounts', () => {
+        fetchQuery = {
           type: 'first',
           reminderTime: 1,
           reminderTimeOutdated: 3000,
           limit: 20
         }
-        var account = createAccount()
-        var account2 = createAccount()
-        return db.createAccount(account.uid, account)
-          .then(
-            function () {
-              return db.createAccount(account2.uid, account2)
-            }
-          )
-          .then(
-            function () {
-              // create 'first' reminder for account one.
-              return db.createVerificationReminder({
-                uid: account.uid,
-                type: 'first'
-              })
-            }
-          )
-          .then(
-            function () {
-              // create 'first' reminder for account two.
-              return db.createVerificationReminder({
-                uid: account2.uid,
-                type: 'first'
-              })
-            }
-          )
-          .then(
-            function () {
-              return P.delay(20).then(function () {
-                return db.fetchReminders({}, fetchQuery)
-              })
-            }
-          )
-          .then(
-            function (result) {
-              assert.equal(result.length, 2, 'correct size of result')
-              assert.equal(result[0].type, 'first', 'correct type')
-              assert.equal(result[1].type, 'first', 'correct type')
-            }
-          )
-          .then(
-            function () {
-              return db.fetchReminders({}, fetchQuery)
-            }
-          )
-          .then(
-            function (result) {
-              assert.equal(result.length, 0, 'no more first reminders')
-            }
-          )
-      }
-    )
 
-    it(
-      'reminders - multi fetch',
-      () => {
-        var fetchQuery = {
+        // create 'first' reminder for account one.
+        return db.createVerificationReminder({uid: accountData.uid, type: 'first'})
+        // create 'first' reminder for account two.
+          .then(() => db.createVerificationReminder({uid: accountData2.uid, type: 'first'}))
+          .then(() => P.delay(20))
+          .then(() => db.fetchReminders({}, fetchQuery))
+          .then((result) => {
+            assert.equal(result.length, 2, 'correct size of result')
+            assert.equal(result[0].type, 'first', 'correct type')
+            assert.equal(result[1].type, 'first', 'correct type')
+            return db.fetchReminders({}, fetchQuery)
+          })
+          .then((result) => assert.equal(result.length, 0, 'no more first reminders'))
+      })
+
+      it('multi fetch', () => {
+        fetchQuery = {
           type: 'first',
           reminderTime: 1,
           reminderTimeOutdated: 100,
           limit: 20
         }
-        var account = createAccount()
-        var account2 = createAccount()
-        return db.createAccount(account.uid, account)
-          .then(
-            function () {
-              return db.createAccount(account2.uid, account2)
-            }
-          )
-          .then(
-            function () {
-              // create 'first' reminder for account one.
-              return db.createVerificationReminder({
-                uid: account.uid,
-                type: 'first'
-              })
-            }
-          )
-          .then(
-            function () {
-              // create 'first' reminder for account two.
-              return db.createVerificationReminder({
-                uid: account2.uid,
-                type: 'first'
-              })
-            }
-          )
-          .then(
-            function () {
-              return P.delay(20).then(function () {
-                return P.all([
-                  // only one query should give results
-                  db.fetchReminders({}, fetchQuery),
-                  db.fetchReminders({}, fetchQuery),
-                  db.fetchReminders({}, fetchQuery),
-                  db.fetchReminders({}, fetchQuery),
-                  db.fetchReminders({}, fetchQuery),
-                  db.fetchReminders({}, fetchQuery),
-                  db.fetchReminders({}, fetchQuery),
-                  db.fetchReminders({}, fetchQuery),
-                  db.fetchReminders({}, fetchQuery),
-                  db.fetchReminders({}, fetchQuery)
-                ])
-              })
-            }
-          )
-          .then(
-            function (results) {
-              var found = 0
-              results.forEach((result) => {
-                if (result.length === 2) {
-                  found++
-                }
-              })
 
-              assert.equal(found, 1, 'only one query has the result')
-            }
-          )
-      }
-    )
+        // create 'first' reminder for account one.
+        return db.createVerificationReminder({uid: accountData.uid, type: 'first'})
+        // create 'first' reminder for account two.
+          .then(() => db.createVerificationReminder({uid: accountData2.uid, type: 'first'}))
+          .then(() => P.delay(20))
+          .then(() => P.all([
+            // only one query should give results
+            db.fetchReminders({}, fetchQuery),
+            db.fetchReminders({}, fetchQuery),
+            db.fetchReminders({}, fetchQuery),
+            db.fetchReminders({}, fetchQuery),
+            db.fetchReminders({}, fetchQuery),
+            db.fetchReminders({}, fetchQuery),
+            db.fetchReminders({}, fetchQuery),
+            db.fetchReminders({}, fetchQuery),
+            db.fetchReminders({}, fetchQuery),
+            db.fetchReminders({}, fetchQuery)
+          ]))
+          .then((results) => {
+            let found = 0
+            results.forEach((result) => {
+              if (result.length === 2) {
+                found++
+              }
+            })
 
-    it(
-      'unblockCodes',
-      () => {
-        var uid1 = newUuid()
-        var code1 = unblockCode()
+            assert.equal(found, 1, 'only one query has the result')
+          })
+      })
+    })
 
+    describe('unblockCodes', () => {
+      let uid1, code1
+      beforeEach(() => {
+        uid1 = newUuid()
+        code1 = unblockCode()
+
+        return db.createUnblockCode(uid1, code1)
+      })
+
+      it('should fail to consume unknown code', () => {
+        return db.consumeUnblockCode(newUuid(), code1)
+          .then(assert.fail, (err) => {
+            assert.equal(err.code, 404, 'err.code')
+            assert.equal(err.errno, 116, 'err.errno')
+          })
+      })
+
+      it('should consume unblock code', () => {
         return db.consumeUnblockCode(uid1, code1)
-          .then(
-            function () {
-              assert(false, 'consuming unknown code should error')
-            },
-            function (err) {
-              return db.createUnblockCode(uid1, code1)
-            }
-          )
-          .then(
-            function () {
-              return db.consumeUnblockCode(uid1, code1)
-            }
-          )
-          .then(
-            function (code) {
-              assert(code.createdAt <= Date.now(), 'returns unblock code timestamp')
-              return db.consumeUnblockCode(uid1, code1)
-            }
-          )
-          .then(
-            function () {
-              assert(false, 'consumed unblock code should not be able to consume again')
-            },
-            function (err) {
-              // consume a consumed code errors
-            }
-          )
-      }
-    )
+          .then((code) => {
+            assert(code.createdAt <= Date.now(), 'returns unblock code timestamp')
+          })
+      })
+
+      it('should fail to consume code twice', () => {
+        return db.consumeUnblockCode(uid1, code1)
+          .then((code) => {
+            assert(code.createdAt <= Date.now(), 'returns unblock code timestamp')
+            return db.consumeUnblockCode(uid1, code1)
+              .then(assert.fail, (err) => {
+                assert.equal(err.code, 404, 'err.code')
+                assert.equal(err.errno, 116, 'err.errno')
+              })
+          })
+      })
+    })
 
     it(
       'emailBounces',
@@ -2008,506 +1385,328 @@ module.exports = function(config, DB) {
       }
     )
 
-    it(
-      'emails',
-      () => {
-        const account = createAccount()
-        account.emailVerified = true
-
-        var secondEmail = createEmail({
-          uid: account.uid
+    describe('emails', () => {
+      let secondEmail
+      beforeEach(() => {
+        accountData = createAccount()
+        accountData.emailVerified = true
+        secondEmail = createEmail({
+          uid: accountData.uid
         })
 
-        /**
-         * This sequence of tests, test the happy path of adding an
-         * additional email.
-         *
-         * 1) Create an account
-         * 2) Get `accountEmails` only returns email on account table
-         * 3) Add an additional email
-         * 4) Get `accountEmails` returns both emails
-         * 5) Get `getSecondaryEmail` returns specified email on emails table
-         * 5) Verify secondary email
-         * 6) Get `accountEmails` returns both emails, shows verified
-         * 7) Delete secondary email
-         * 8) Get `accountEmails` only return email on account table
-         * 9) Can create account from deleted account's secondary email
-         * 10) Can reuse secondary email from deleted account
-         *
-         */
-        // Lets begin our journey by creating a new account.
-        return db.createAccount(account.uid, account)
-          .then(function (result) {
+        return db.createAccount(accountData.uid, accountData)
+          .then((result) => {
             assert.deepEqual(result, {}, 'Returned an empty object on account creation')
 
-            // Attempt to add a new email address to this user's account.
-            // At this point we should only have one email address returned, which
-            // should be the email on the accounts table.
-            return db.accountEmails(account.uid)
+            return db.createEmail(accountData.uid, secondEmail)
           })
-          .then(
-            function(result) {
-              assert.equal(result.length, 1, 'one email returned')
+          .then((result) => assert.deepEqual(result, {}, 'Returned an empty object on email creation'))
+      })
 
-              // Check first email is email from accounts table
-              assert.equal(result[0].email, account.email, 'matches account email')
-              assert.equal(!! result[0].isPrimary, true, 'isPrimary is true on account email')
-              assert.equal(!! result[0].isVerified, account.emailVerified, 'matches account emailVerified')
+      it('should return only account email if no secondary email', () => {
+        const anotherAccountData = createAccount()
+        return db.createAccount(anotherAccountData.uid, anotherAccountData)
+          .then(() => db.accountEmails(anotherAccountData.uid))
+          .then((result) => {
+            assert.equal(result.length, 1, 'one email returned')
 
-              // Attempt to create an additional email for this user account.
-              return db.createEmail(account.uid, secondEmail)
-            }
-          )
-          .then(function (result) {
-            assert.deepEqual(result, {}, 'Returned an empty object on email creation')
-
-            // Check that second email was added to account.
-            return db.accountEmails(account.uid)
+            // Check first email is email from accounts table
+            assert.equal(result[0].email, anotherAccountData.email, 'matches account email')
+            assert.equal(!! result[0].isPrimary, true, 'isPrimary is true on account email')
+            assert.equal(!! result[0].isVerified, anotherAccountData.emailVerified, 'matches account emailVerified')
           })
-          .then(
-            function(result) {
-              assert.equal(result.length, 2, 'two emails returned')
+      })
 
-              // Check first email is email from accounts table
-              assert.equal(result[0].email, account.email, 'matches account email')
-              assert.equal(!! result[0].isPrimary, true, 'isPrimary is true on account email')
-              assert.equal(!! result[0].isVerified, account.emailVerified, 'matches account emailVerified')
+      it('should return secondary emails', () => {
+        return db.accountEmails(accountData.uid)
+          .then((result) => {
+            assert.equal(result.length, 2, 'two emails returned')
 
-              // Check second email is from emails table
-              assert.equal(result[1].email, secondEmail.email, 'matches secondEmail email')
-              assert.equal(!! result[1].isPrimary, false, 'isPrimary is false on secondEmail email')
-              assert.equal(!! result[1].isVerified, secondEmail.isVerified, 'matches secondEmail isVerified')
+            // Check first email is email from accounts table
+            assert.equal(result[0].email, accountData.email, 'matches account email')
+            assert.equal(!! result[0].isPrimary, true, 'isPrimary is true on account email')
+            assert.equal(!! result[0].isVerified, accountData.emailVerified, 'matches account emailVerified')
 
-              // Get a specific email
-              return db.getSecondaryEmail(secondEmail.email)
-            }
-          )
-          .then(
-            function(result) {
-              assert.equal(result.email, secondEmail.email, 'matches secondEmail email')
-              assert.equal(!! result.isPrimary, false, 'isPrimary is false on secondEmail email')
-              assert.equal(!! result.isVerified, secondEmail.isVerified, 'matches secondEmail isVerified')
+            // Check second email is from emails table
+            assert.equal(result[1].email, secondEmail.email, 'matches secondEmail email')
+            assert.equal(!! result[1].isPrimary, false, 'isPrimary is false on secondEmail email')
+            assert.equal(!! result[1].isVerified, secondEmail.isVerified, 'matches secondEmail isVerified')
+          })
+      })
 
-              // Verify second email
-              return db.verifyEmail(secondEmail.uid, secondEmail.emailCode)
-            }
-          )
-          .then(
-            function(result) {
-              assert.deepEqual(result, {}, 'Returned an empty object on email verification')
+      it('should get secondary email', () => {
+        return db.getSecondaryEmail(secondEmail.email)
+          .then((result) => {
+            assert.equal(result.email, secondEmail.email, 'matches secondEmail email')
+            assert.equal(!! result.isPrimary, false, 'isPrimary is false on secondEmail email')
+            assert.equal(!! result.isVerified, secondEmail.isVerified, 'matches secondEmail isVerified')
+          })
+      })
 
-              // Get all emails and check to see if second email has been marked verified
-              return db.accountEmails(account.uid)
-            }
-          )
-          .then(
-            function(result) {
-              assert.equal(result.length, 2, 'two email returned')
+      it('should verify secondary email', () => {
+        return db.verifyEmail(secondEmail.uid, secondEmail.emailCode)
+          .then((result) => {
+            assert.deepEqual(result, {}, 'Returned an empty object on email verification')
+            return db.accountEmails(accountData.uid)
+          })
+          .then((result) => {
+            assert.equal(result.length, 2, 'two email returned')
 
-              // Check second email is from emails table and verified
-              assert.equal(result[1].email, secondEmail.email, 'matches secondEmail email')
-              assert.equal(!! result[1].isPrimary, false, 'isPrimary is false on secondEmail email')
-              assert.equal(!! result[1].isVerified, true, 'secondEmail isVerified is true')
+            // Check second email is from emails table and verified
+            assert.equal(result[1].email, secondEmail.email, 'matches secondEmail email')
+            assert.equal(!! result[1].isPrimary, false, 'isPrimary is false on secondEmail email')
+            assert.equal(!! result[1].isVerified, true, 'secondEmail isVerified is true')
+          })
+      })
 
-              // Remove additional email from account
-              return db.deleteEmail(secondEmail.uid, secondEmail.email)
-            }
-          )
-          .then(
-            function(result) {
-              assert.deepEqual(result, {}, 'Returned an empty object on email deletion')
+      it('should delete email', () => {
+        return db.deleteEmail(secondEmail.uid, secondEmail.email)
+          .then((result) => {
+            assert.deepEqual(result, {}, 'Returned an empty object on email deletion')
 
-              // Get all emails and check to see if it has been removed
-              return db.accountEmails(account.uid)
-            }
-          )
-          .then(
-            function(result) {
-              // Verify that the email has been removed
-              assert.equal(result.length, 1, 'one email returned')
+            // Get all emails and check to see if it has been removed
+            return db.accountEmails(accountData.uid)
+          })
+          .then((result) => {
+            // Verify that the email has been removed
+            assert.equal(result.length, 1, 'one email returned')
 
-              // Only email returned should be from users account
-              assert.equal(result[0].email, account.email, 'matches account email')
-              assert.equal(!! result[0].isPrimary, true, 'isPrimary is true on account email')
-              assert.equal(!! result[0].isVerified, account.emailVerified, 'matches account emailVerified')
+            // Only email returned should be from users account
+            assert.equal(result[0].email, accountData.email, 'matches account email')
+            assert.equal(!! result[0].isPrimary, true, 'isPrimary is true on account email')
+            assert.equal(!! result[0].isVerified, accountData.emailVerified, 'matches account emailVerified')
 
-              return P.resolve()
-            }
-          )
-          .then(
-            function() {
-              // Can create an account from a deleted account's secondary email
-              const testAccount = createAccount()
-              testAccount.emailVerified = true
+          })
+      })
 
-              const testSecondaryEmail = createEmail({
-                uid: testAccount.uid,
-                isVerified: true
-              })
-
-              return db.createAccount(testAccount.uid, testAccount)
-                .then(function () {
-                  return db.createEmail(testAccount.uid, testSecondaryEmail)
-                })
-                .then(function () {
-                  return db.deleteAccount(testAccount.uid)
-                })
-                .then(function () {
-                  testAccount.email = testSecondaryEmail.email
-                  testAccount.normalizedEmail = testSecondaryEmail.normalizedEmail
-
-                  // Create new account with secondary email that was deleted
-                  return db.createAccount(testAccount.uid, testAccount)
-                })
-                .then(function (res) {
-                  assert.deepEqual(res, {}, 'successfully created an account')
-
-                  // Attempt to create secondary email address
-                  return db.createEmail(testAccount.uid, testSecondaryEmail)
-                    .then(
-                      () => {
-                        assert(false, 'Should not have created secondary email')
-                      },
-                      (err) => {
-                        assert.equal(err.errno, 101, 'Correct errno')
-                      }
-                    )
-                })
-            }
-          )
-          .then(
-            function() {
-              // Ensure that secondary emails get removed from an account
-              // when account is deleted and that it can be reused
-              // in another account
-              const testAccount = createAccount()
-              testAccount.emailVerified = true
-
-              const testAccount2 = createAccount()
-              testAccount2.emailVerified = true
-
-              const testSecondaryEmail = createEmail({
-                uid: testAccount.uid,
-                isVerified: true
-              })
-
-              return db.createAccount(testAccount.uid, testAccount)
-                .then(function () {
-                  return db.createEmail(testAccount.uid, testSecondaryEmail)
-                })
-                .then(function () {
-                  return db.deleteAccount(testAccount.uid)
-                })
-                .then(function () {
-                  // Create new account and attempt to add secondary email
-                  // that was deleted
-                  return db.createAccount(testAccount2.uid, testAccount2)
-                })
-                .then(function (res) {
-                  assert.deepEqual(res, {}, 'successfully created an account')
-                  testSecondaryEmail.uid = testAccount2.uid
-                  return db.createEmail(testAccount2.uid, testSecondaryEmail)
-                })
-                .then((res) => {
-                  assert.deepEqual(res, {}, 'successfully created an secondary email on new account')
-                })
-            }
-          )
+      it('should free secondary email on account deletion', () => {
+        let anotherAccountData
+        return db.verifyEmail(secondEmail.uid, secondEmail.emailCode)
+          .then(() => db.deleteAccount(accountData.uid))
           .then(() => {
-            /**
-             * This sequence of code tests the failure paths
-             *
-             * 1) Can not add an an email that exits in emails table or accounts table
-             * 2) Can not delete primary email
-             * 3) Can not create an new account that has an email in the emails table
-             * 4) Can not get non-existent secondary email
-             */
+            anotherAccountData = createAccount()
+            anotherAccountData.email = secondEmail.email
+            anotherAccountData.normalizedEmail = secondEmail.normalizedEmail
 
-            // Attempt to add the account email to the emails table.
-            const anotherEmail = createEmail({email: account.email})
-            return db.createEmail(account.uid, anotherEmail)
-              .then(
-                () => {
-                  assert(false, 'Failed to throw error for creating an already existing email.')
-                },
-                err => {
-                  assert.equal(err.errno, 101, 'should return duplicate entry errno')
-                  assert.equal(err.code, 409, 'should return duplicate entry code')
-                }
-              )
-              .then(() => {
-                // Attempt to add duplicate email to emails table
-                const anotherEmail = createEmail({email: secondEmail.email})
-                return db.createEmail(account.uid, anotherEmail)
-                  .then(function (result) {
-                    assert.deepEqual(result, {}, 'Returned an empty object on email creation')
-                    return db.createEmail(account.uid, anotherEmail)
-                      .then(
-                        () => {
-                          assert(false, 'Failed to throw error for creating an already existing email.')
-                        },
-                        err => {
-                          assert.equal(err.errno, 101, 'should return duplicate entry errno')
-                          assert.equal(err.code, 409, 'should return duplicate entry code')
-                        }
-                      )
-                  })
-              })
-              .then(() => {
-                // Attempt to delete a primary email
-                return db.deleteEmail(account.uid, account.normalizedEmail)
-                  .then(
-                    () => {
-                      assert(false, 'Failed to not delete a primary email')
-                    },
-                    err => {
-                      assert.equal(err.errno, 136, 'should return email delete errno')
-                      assert.equal(err.code, 400, 'should return email delete code')
-                    }
-                  )
-              })
-              .then(() => {
-                // Attempt to create a new account with an existing email in the emails table
-                const anotherAccount = createAccount()
-                anotherAccount.email = secondEmail.email
-                anotherAccount.normalizedEmail = secondEmail.normalizedEmail
-                anotherAccount.emailVerified = true
-
-                return db.createAccount(anotherAccount.uid, anotherAccount)
-                  .then(
-                    () => {
-                      assert(false, 'Failed to not created account with duplicate email')
-                    },
-                    err => {
-                      assert.equal(err.errno, 101, 'should return duplicate entry errno')
-                      assert.equal(err.code, 409, 'should return duplicate entry code')
-                    }
-                  )
-              })
-              .then(() => {
-                // Attempt to get a non-existent email
-                return db.getSecondaryEmail('non-existent@email.com')
-                  .then(
-                    () => {
-                      assert(false, 'Failed to not get a non-existent email')
-                    },
-                    (err) => {
-                      assert.equal(err.errno, 116, 'should return not found errno')
-                      assert.equal(err.code, 404, 'should return not found code')
-                    }
-                  )
-              })
+            return db.createAccount(anotherAccountData.uid, anotherAccountData)
           })
-      }
-    )
+          .then((result) => {
+            assert.deepEqual(result, {}, 'successfully created an account')
 
-    it('sign-in codes', () => {
-      const SIGNIN_CODES = [ hex6(), hex6(), hex6() ]
-      const NOW = Date.now()
-      const TIMESTAMPS = [ NOW - 1, NOW - 2, NOW - config.signinCodesMaxAge - 1 ]
-      const FLOW_IDS = [ hex32(), hex32(), hex32() ]
+            // Attempt to create secondary email address
+            return db.createEmail(accountData.uid, secondEmail)
+              .then(assert.fail, (err) => assert.equal(err.errno, 101, 'Correct errno'))
+          })
+      })
 
-      // Create an account
-      return db.createAccount(ACCOUNT.uid, ACCOUNT)
-        // Create 3 sign-in codes, two fresh and the other expired
-        .then(() => P.all([
-          db.createSigninCode(SIGNIN_CODES[0], ACCOUNT.uid, TIMESTAMPS[0], FLOW_IDS[0]),
-          db.createSigninCode(SIGNIN_CODES[1], ACCOUNT.uid, TIMESTAMPS[1], FLOW_IDS[1]),
-          db.createSigninCode(SIGNIN_CODES[2], ACCOUNT.uid, TIMESTAMPS[2], FLOW_IDS[2])
-        ]))
-        .then(results => {
-          results.forEach(r => assert.deepEqual(r, {}, 'createSigninCode should return an empty object'))
+      it('should fail to add secondary email that exists on account table', () => {
+        const anotherEmail = createEmail({email: accountData.email})
+        return db.createEmail(accountData.uid, anotherEmail)
+          .then(assert.fail, (err) => {
+            assert.equal(err.errno, 101, 'should return duplicate entry errno')
+            assert.equal(err.code, 409, 'should return duplicate entry code')
+          })
+      })
 
-          // Attempt to create a duplicate code
-          return db.createSigninCode(SIGNIN_CODES[0], ACCOUNT.uid, TIMESTAMPS[0])
-            .then(
-              () => assert(false, 'db.createSigninCode should fail for duplicate codes'),
-              err => {
-                assert(err, 'db.createSigninCode should reject with an error')
-                assert.equal(err.code, 409, 'db.createSigninCode should reject with code 404')
-                assert.equal(err.errno, 101, 'db.createSigninCode should reject with errno 116')
-              }
-            )
-        })
-        .then(() => {
-          // Consume a fresh code
-          return db.consumeSigninCode(SIGNIN_CODES[0])
-        })
-        .then(result => {
-          assert.deepEqual(result, {
-            email: ACCOUNT.email,
-            flowId: FLOW_IDS[0]
-          }, 'db.consumeSigninCode should return an email address and flowId for non-expired codes')
+      it('should fail to add duplicate secondary email', () => {
+        const anotherEmail = createEmail({email: secondEmail.email})
+        return db.createEmail(accountData.uid, anotherEmail)
+          .then(assert.fail, (err) => {
+            assert.equal(err.errno, 101, 'should return duplicate entry errno')
+            assert.equal(err.code, 409, 'should return duplicate entry code')
+          })
+      })
 
-          // Attempt to re-consume the consumed code
-          return db.consumeSigninCode(SIGNIN_CODES[0])
-            .then(
-              () => assert(false, 'db.consumeSigninCode should fail for consumed codes'),
-              err => {
-                assert(err, 'db.consumeSigninCode should reject with an error')
-                assert.equal(err.code, 404, 'db.consumeSigninCode should reject with code 404')
-                assert.equal(err.errno, 116, 'db.consumeSigninCode should reject with errno 116')
-              }
-            )
-        })
-        .then(() => {
-          // Attempt to consume the expired code
-          return db.consumeSigninCode(SIGNIN_CODES[2])
-            .then(
-              () => assert(false, 'db.consumeSigninCode should fail for expired codes'),
-              err => {
-                assert(err, 'db.consumeSigninCode should reject with an error')
-                assert.equal(err.code, 404, 'db.consumeSigninCode should reject with code 404')
-                assert.equal(err.errno, 116, 'db.consumeSigninCode should reject with errno 116')
-              }
-            )
-        })
-        // Clean up the account
-        .then(() => db.deleteAccount(ACCOUNT.uid))
-        .then(() => {
-          // Attempt to use an unused fresh code associated with a deleted account
-          return db.consumeSigninCode(SIGNIN_CODES[1])
-            .then(
-              () => assert(false, 'db.consumeSigninCode should fail for deleted accounts'),
-              err => {
-                assert(err, 'db.consumeSigninCode should reject with an error')
-                assert.equal(err.code, 404, 'db.consumeSigninCode should reject with code 404')
-                assert.equal(err.errno, 116, 'db.consumeSigninCode should reject with errno 116')
-              }
-            )
-        })
+      it('should fail to delete primary email', () => {
+        return db.deleteEmail(accountData.uid, accountData.normalizedEmail)
+          .then(assert.fail, (err) => {
+            assert.equal(err.errno, 136, 'should return email delete errno')
+            assert.equal(err.code, 400, 'should return email delete code')
+          })
+      })
+
+      it('should fail to create account that used a secondary email as primary', () => {
+        const anotherAccount = createAccount()
+        anotherAccount.email = secondEmail.email
+        anotherAccount.normalizedEmail = secondEmail.normalizedEmail
+        return db.createAccount(anotherAccount.uid, anotherAccount)
+          .then(assert.fail, (err) => {
+            assert.equal(err.errno, 101, 'should return duplicate entry errno')
+            assert.equal(err.code, 409, 'should return duplicate entry code')
+          })
+      })
+
+      it('should fail to get non-existent secondary email', () => {
+        return db.getSecondaryEmail('non-existent@email.com')
+          .then(assert.fail, (err) => {
+            assert.equal(err.errno, 116, 'should return not found errno')
+            assert.equal(err.code, 404, 'should return not found code')
+          })
+      })
     })
 
-    it('email on account/email table in sync', () => {
-      const account = createAccount()
+    describe('sign-in codes', () => {
+      let SIGNIN_CODES, NOW, TIMESTAMPS, FLOW_IDS
 
-      return db.createAccount(account.uid, account)
-        .then(function (result) {
-          assert.deepEqual(result, {}, 'returned empty response on account creation')
-          return P.all([db.accountEmails(account.uid), db.account(account.uid)])
-        })
-        .spread(function (emails, account) {
-          assert.equal(emails[0].email, account.email, 'correct email returned')
-          assert.equal(!! emails[0].isVerified, !! account.emailVerified, 'correct email verification')
-          assert.equal(!! emails[0].isPrimary, true, 'correct email primary')
 
-          // Verify account email
-          return db.verifyEmail(account.uid, account.emailCode)
-        })
-        .then(function (result) {
-          assert.deepEqual(result, {}, 'returned empty response on verify email')
-          return P.all([db.accountEmails(account.uid), db.account(account.uid)])
-        })
-        .spread(function (emails, account) {
-          assert.equal(emails[0].email, account.email, 'correct email returned')
-          assert.equal(!! emails[0].isVerified, !! account.emailVerified, 'correct email verification')
-          assert.equal(!! emails[0].isPrimary, true, 'correct email primary')
-        })
+      beforeEach(() => {
+        accountData = createAccount()
+        SIGNIN_CODES = [ hex6(), hex6(), hex6() ]
+        NOW = Date.now()
+        TIMESTAMPS = [ NOW - 1, NOW - 2, NOW - config.signinCodesMaxAge - 1 ]
+        FLOW_IDS = [ hex32(), hex32(), hex32() ]
+
+        return db.createAccount(accountData.uid, accountData)
+          .then(() => P.all([
+            db.createSigninCode(SIGNIN_CODES[0], accountData.uid, TIMESTAMPS[0], FLOW_IDS[0]),
+            db.createSigninCode(SIGNIN_CODES[1], accountData.uid, TIMESTAMPS[1], FLOW_IDS[1]),
+            db.createSigninCode(SIGNIN_CODES[2], accountData.uid, TIMESTAMPS[2], FLOW_IDS[2])
+          ]))
+          .then((results) => {
+            results.forEach(r => assert.deepEqual(r, {}, 'createSigninCode should return an empty object'))
+          })
+      })
+
+      it('should fail to create duplicate sign-in code', () => {
+        return db.createSigninCode(SIGNIN_CODES[0], accountData.uid, TIMESTAMPS[0])
+          .then(assert.fail, (err) => {
+            assert(err, 'db.createSigninCode should reject with an error')
+            assert.equal(err.code, 409, 'db.createSigninCode should reject with code 404')
+            assert.equal(err.errno, 101, 'db.createSigninCode should reject with errno 116')
+          })
+      })
+
+      it('should consume sign-in code', () => {
+        return db.consumeSigninCode(SIGNIN_CODES[0])
+          .then((result) => {
+            assert.deepEqual(result, {
+              email: accountData.email,
+              flowId: FLOW_IDS[0]
+            }, 'db.consumeSigninCode should return an email address and flowId for non-expired codes')
+          })
+      })
+
+      it('should fail consume sign-in code twice', () => {
+        return db.consumeSigninCode(SIGNIN_CODES[0])
+          .then(() => db.consumeSigninCode(SIGNIN_CODES[0]))
+          .then(assert.fail, (err) => {
+            assert(err, 'db.consumeSigninCode should reject with an error')
+            assert.equal(err.code, 404, 'db.consumeSigninCode should reject with code 404')
+            assert.equal(err.errno, 116, 'db.consumeSigninCode should reject with errno 116')
+          })
+      })
+
+      it('should fail consume expired sign-in code', () => {
+        return db.consumeSigninCode(SIGNIN_CODES[2])
+          .then(assert.fail, (err) => {
+            assert(err, 'db.consumeSigninCode should reject with an error')
+            assert.equal(err.code, 404, 'db.consumeSigninCode should reject with code 404')
+            assert.equal(err.errno, 116, 'db.consumeSigninCode should reject with errno 116')
+          })
+      })
+
+      it('should fail to use sign-in code from deleted account', () => {
+        return db.deleteAccount(accountData.uid)
+          .then(() => {
+            return db.consumeSigninCode(SIGNIN_CODES[1])
+              .then(assert.fail, (err) => {
+                assert(err, 'db.consumeSigninCode should reject with an error')
+                assert.equal(err.code, 404, 'db.consumeSigninCode should reject with code 404')
+                assert.equal(err.errno, 116, 'db.consumeSigninCode should reject with errno 116')
+              })
+          })
+      })
+    })
+
+    describe('account email and emails table syncing', () => {
+      beforeEach(() => {
+        accountData = createAccount()
+        return db.createAccount(accountData.uid, accountData)
+      })
+
+      it('should keep emails in sync', () => {
+        return P.all([db.accountEmails(accountData.uid), db.account(accountData.uid)])
+          .spread(function (emails, account) {
+            assert.equal(emails[0].email, account.email, 'correct email returned')
+            assert.equal(!! emails[0].isVerified, !! account.emailVerified, 'correct email verification')
+            assert.equal(!! emails[0].isPrimary, true, 'correct email primary')
+
+            // Verify account email
+            return db.verifyEmail(account.uid, account.emailCode)
+          })
+          .then(function (result) {
+            assert.deepEqual(result, {}, 'returned empty response on verify email')
+            return P.all([db.accountEmails(accountData.uid), db.account(accountData.uid)])
+          })
+          .spread(function (emails, account) {
+            assert.equal(emails[0].email, account.email, 'correct email returned')
+            assert.equal(!! emails[0].isVerified, !! account.emailVerified, 'correct email verification')
+            assert.equal(!! emails[0].isPrimary, true, 'correct email primary')
+          })
+      })
     })
 
     describe('db.resetAccountTokens', () => {
-      let account, passwordChangeToken, passwordChangeTokenId, passwordForgotToken, passwordForgotTokenId,
-        accountResetToken
+      let passwordChangeToken, passwordForgotToken, accountResetToken
 
       before(() => {
-        account = createAccount()
-        account.emailVerified = true
-        passwordChangeToken = {
-          data: hex32(),
-          uid: account.uid,
-          createdAt: now + 4
-        }
-        passwordChangeTokenId = hex32()
-        passwordForgotToken = {
-          data: hex32(),
-          uid: account.uid,
-          passCode: hex16(),
-          tries: 1,
-          createdAt: Date.now()
-        }
-        passwordForgotTokenId = hex32()
-        accountResetToken = {
-          tokenId: passwordForgotTokenId,
-          data: hex32(),
-          uid: account.uid,
-          createdAt: now + 5
-        }
+        accountData = createAccount()
+        accountData.emailVerified = true
+        passwordChangeToken = makeMockChangePasswordToken(accountData.uid)
+        passwordForgotToken = makeMockForgotPasswordToken(accountData.uid)
+        accountResetToken = makeMockAccountResetToken(accountData.uid, passwordForgotToken.tokenId)
 
-        return db.createAccount(account.uid, account)
+        return db.createAccount(accountData.uid, accountData)
       })
 
       it('should remove account reset tokens', () => {
-        return db.createPasswordForgotToken(passwordForgotTokenId, passwordForgotToken)
+        return db.createPasswordForgotToken(passwordForgotToken.tokenId, passwordForgotToken)
           .then(() => {
             // db.forgotPasswordVerified requires a passwordForgotToken to have been made
-            return db.forgotPasswordVerified(passwordForgotTokenId, accountResetToken)
+            return db.forgotPasswordVerified(passwordForgotToken.tokenId, accountResetToken)
               .then(() => {
-                return db.accountResetToken(passwordForgotTokenId)
-                  .then((res) => {
-                    assert.deepEqual(res.uid, account.uid, 'token belongs to account')
-                  })
+                return db.accountResetToken(passwordForgotToken.tokenId)
+                  .then((res) => assert.deepEqual(res.uid, accountData.uid, 'token belongs to account'))
               })
           })
+          .then(() => db.resetAccountTokens(accountData.uid))
           .then(() => {
-            return db.resetAccountTokens(account.uid)
-          })
-          .then(() => {
-            return db.accountResetToken(passwordForgotTokenId)
-              .then(() => {
-                assert.equal(false, 'should not have return account reset token token')
-              })
-              .catch((err) => {
-                assert.equal(err.errno, 116, 'did not find password change token')
-              })
+            return db.accountResetToken(passwordForgotToken.tokenId)
+              .then(() => assert.equal(false, 'should not have return account reset token token'))
+              .catch((err) => assert.equal(err.errno, 116, 'did not find password change token'))
           })
       })
 
       it('should remove password change tokens', () => {
-        return db.createPasswordChangeToken(passwordChangeTokenId, passwordChangeToken)
+        return db.createPasswordChangeToken(passwordChangeToken.tokenId, passwordChangeToken)
           .then(() => {
-            return db.passwordChangeToken(passwordChangeTokenId)
-              .then((res) => {
-                assert.deepEqual(res.uid, account.uid, 'token belongs to account')
-              })
+            return db.passwordChangeToken(passwordChangeToken.tokenId)
+              .then((res) => assert.deepEqual(res.uid, accountData.uid, 'token belongs to account'))
           })
+          .then(() => db.resetAccountTokens(accountData.uid))
           .then(() => {
-            return db.resetAccountTokens(account.uid)
-          })
-          .then(() => {
-            return db.passwordChangeToken(passwordChangeTokenId)
-              .then(() => {
-                assert.equal(false, 'should not have return password change token')
-              })
-              .catch((err) => {
-                assert.equal(err.errno, 116, 'did not find password change token')
-              })
+            return db.passwordChangeToken(passwordChangeToken.tokenId)
+              .then(() => assert.equal(false, 'should not have return password change token'))
+              .catch((err) => assert.equal(err.errno, 116, 'did not find password change token'))
           })
       })
 
       it('should remove password forgot tokens', () => {
-        return db.createPasswordForgotToken(passwordForgotTokenId, passwordForgotToken)
+        return db.createPasswordForgotToken(passwordForgotToken.tokenId, passwordForgotToken)
           .then(() => {
-            return db.passwordForgotToken(passwordForgotTokenId)
-              .then((res) => {
-                assert.deepEqual(res.uid, account.uid, 'token belongs to account')
-              })
+            return db.passwordForgotToken(passwordForgotToken.tokenId)
+              .then((res) => assert.deepEqual(res.uid, accountData.uid, 'token belongs to account'))
           })
+          .then(() => db.resetAccountTokens(accountData.uid))
           .then(() => {
-            return db.resetAccountTokens(account.uid)
-          })
-          .then(() => {
-            return db.passwordForgotToken(passwordForgotTokenId)
-              .then(() => {
-                assert.equal(false, 'should not have return password forgot token')
-              })
-              .catch((err) => {
-                assert.equal(err.errno, 116, 'did not find password forgot token')
-              })
+            return db.passwordForgotToken(passwordForgotToken.tokenId)
+              .then(() => assert.equal(false, 'should not have return password forgot token'))
+              .catch((err) => assert.equal(err.errno, 116, 'did not find password forgot token'))
           })
       })
     })
 
-    describe('change email', () => {
+    describe('db.setPrimaryEmail', () => {
       let account, secondEmail
 
       before(() => {
@@ -2540,6 +1739,7 @@ module.exports = function(config, DB) {
       })
 
       it('should change a user\'s email', () => {
+        let sessionTokenData
         return db.setPrimaryEmail(account.uid, secondEmail.email)
           .then(function (res) {
             assert.deepEqual(res, {}, 'Returned an empty object on email change')
@@ -2559,10 +1759,10 @@ module.exports = function(config, DB) {
             assert.equal(!! res[1].isPrimary, false, 'isPrimary is false')
 
             // Verify correct email set in session
-            const sessionToken = makeMockSessionToken(account.uid)
-            return db.createSessionToken(SESSION_TOKEN_ID, sessionToken)
+            sessionTokenData = makeMockSessionToken(account.uid)
+            return db.createSessionToken(sessionTokenData.tokenId, sessionTokenData)
               .then(() => {
-                return P.all([db.sessionToken(SESSION_TOKEN_ID), db.sessionTokenWithVerificationStatus(SESSION_TOKEN_ID)])
+                return P.all([db.sessionToken(sessionTokenData.tokenId), db.sessionTokenWithVerificationStatus(sessionTokenData.tokenId)])
               })
           })
           .then((res) => {
@@ -2592,7 +1792,7 @@ module.exports = function(config, DB) {
 
       it('should verify tokenVerificationCode', () => {
         tokenId = hex32()
-        sessionToken = makeMockSessionToken(account.uid)
+        sessionToken = makeMockSessionToken(account.uid, false)
         tokenVerificationCode = sessionToken.tokenVerificationCode
         return db.createSessionToken(tokenId, sessionToken)
           .then(() => {

--- a/db-server/test/backend/db_tests.js
+++ b/db-server/test/backend/db_tests.js
@@ -693,7 +693,6 @@ module.exports = function (config, DB) {
               assert.deepEqual(token.uid, accountData.uid, 'token belongs to this account')
               assert.equal(token.createdAt, changePasswordTokenData.createdAt, 'createdAt is correct')
               assert.equal(token.verifierSetAt, accountData.verifierSetAt, 'verifierSetAt is set correctly')
-              assert.equal(token.email, accountData.email, 'email is set correctly')
             })
         })
 
@@ -716,7 +715,6 @@ module.exports = function (config, DB) {
               assert.deepEqual(token.uid, accountData.uid, 'token belongs to this account')
               assert.equal(token.createdAt, anotherChangePasswordTokenData.createdAt, 'createdAt is correct')
               assert.equal(token.verifierSetAt, accountData.verifierSetAt, 'verifierSetAt is set correctly')
-              assert.equal(token.email, accountData.email, 'email is set correctly')
             })
         })
       })
@@ -876,7 +874,7 @@ module.exports = function (config, DB) {
       })
 
       it('should fail for session with no device', () => {
-        return db.deviceFromTokenVerificationId(accountData.uid, sessionTokenData.tokenId)
+        return db.deviceFromTokenVerificationId(accountData.uid, sessionTokenData.tokenVerificationId)
           .then(assert.fail, (err) => {
             assert.equal(err.code, 404, 'err.code')
             assert.equal(err.errno, 116, 'err.errno')

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -791,7 +791,6 @@ module.exports = function (log, error) {
 
     var accountId = token.uid.toString('hex')
     var account = accounts[accountId]
-    item.email = account.email
     item.verifierSetAt = account.verifierSetAt
 
     return P.resolve(item)

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -602,6 +602,10 @@ module.exports = function (log, error) {
       .then(function (account) {
         return filterAccount(account)
       })
+      .then((account) => {
+        delete account.locale
+        return account
+      })
   }
 
   Memory.prototype.sessions = function (uid) {


### PR DESCRIPTION
This PR updates the db tests to use more features of mocha. This is cleanup work that will make working with this repo more manageable.

- Tests can run independently of each other
- Testing blocks are much smaller with same coverage
- Expanded some tests and removed duplicate tests
- Removed checking email on change password token https://github.com/mozilla/fxa-auth-db-mysql/pull/293/commits/9cc30b1ca88547a933d255b7b44dbc658489ffda. Turns out that mysql was not returning this but the mem db was. Looking at the auth-server the email was not being used so I think it is fair to remove from mem.

The easiest way I think this could be reviewed is doing a side by side comparison of original db tests. Sorry in advance for including some styling changes :(

Fixes #246 