### PR TITLE
feat(devices): return session token id from deleteDevice

### DIFF
--- a/db-server/test/backend/db_tests.js
+++ b/db-server/test/backend/db_tests.js
@@ -1376,7 +1376,7 @@ module.exports = function(config, DB) {
             return db.deleteDevice(ACCOUNT.uid, deviceId)
           })
           .then(function (result) {
-            assert.deepEqual(result, {}, 'returned empty object')
+            assert.deepEqual(result, { tokenId: newSessionTokenId })
 
             // Fetch all of the devices for the account
             return db.accountDevices(ACCOUNT.uid)
@@ -1423,7 +1423,9 @@ module.exports = function(config, DB) {
             // Delete the second device
             return db.deleteDevice(ACCOUNT.uid, newDeviceId)
           })
-          .then(function () {
+          .then(result => {
+            assert.deepEqual(result, { tokenId: sessionTokenId })
+
             // Fetch all of the devices for the account
             return db.accountDevices(ACCOUNT.uid)
           })

--- a/db-server/test/backend/db_tests.js
+++ b/db-server/test/backend/db_tests.js
@@ -1376,7 +1376,7 @@ module.exports = function(config, DB) {
             return db.deleteDevice(ACCOUNT.uid, deviceId)
           })
           .then(function (result) {
-            assert.deepEqual(result, { tokenId: newSessionTokenId })
+            assert.deepEqual(result, { sessionTokenId: newSessionTokenId })
 
             // Fetch all of the devices for the account
             return db.accountDevices(ACCOUNT.uid)
@@ -1424,7 +1424,7 @@ module.exports = function(config, DB) {
             return db.deleteDevice(ACCOUNT.uid, newDeviceId)
           })
           .then(result => {
-            assert.deepEqual(result, { tokenId: sessionTokenId })
+            assert.deepEqual(result, { sessionTokenId })
 
             // Fetch all of the devices for the account
             return db.accountDevices(ACCOUNT.uid)

--- a/db-server/test/backend/remote.js
+++ b/db-server/test/backend/remote.js
@@ -776,7 +776,7 @@ module.exports = function(cfg, makeServer) {
           })
           .then(function(r) {
             respOk(r)
-            assert.deepEqual(r.obj, { tokenId: user.sessionTokenId })
+            assert.deepEqual(r.obj, { sessionTokenId: user.sessionTokenId })
             return client.getThen('/account/' + user.accountId + '/devices')
           })
           .then(function(r) {

--- a/db-server/test/backend/remote.js
+++ b/db-server/test/backend/remote.js
@@ -776,6 +776,7 @@ module.exports = function(cfg, makeServer) {
           })
           .then(function(r) {
             respOk(r)
+            assert.deepEqual(r.obj, { tokenId: user.sessionTokenId })
             return client.getThen('/account/' + user.accountId + '/devices')
           })
           .then(function(r) {

--- a/docs/API.md
+++ b/docs/API.md
@@ -840,7 +840,7 @@ curl \
 HTTP/1.1 200 OK
 Content-Type: application/json
 
-{"tokenId":"522c251a1623e1f1db1f4fe68b9594d26772d6e77e04cb68e110c58600f97a77"}
+{"sessionTokenId":"522c251a1623e1f1db1f4fe68b9594d26772d6e77e04cb68e110c58600f97a77"}
 ```
 
 * Status Code : 200 OK

--- a/docs/API.md
+++ b/docs/API.md
@@ -840,7 +840,7 @@ curl \
 HTTP/1.1 200 OK
 Content-Type: application/json
 
-{}
+{"tokenId":"522c251a1623e1f1db1f4fe68b9594d26772d6e77e04cb68e110c58600f97a77"}
 ```
 
 * Status Code : 200 OK

--- a/docs/DB_API.md
+++ b/docs/DB_API.md
@@ -809,7 +809,8 @@ Parameters:
 Returns:
 
 * Resolves with:
-  * An object containing a `tokenId` property identifying the associated session token,
+  * An object containing a `sessionTokenId` property
+    identifying the associated session token,
     which was also deleted
 * Rejects with:
   * Any error from the underlying storage system (wrapped in `error.wrap()`)

--- a/docs/DB_API.md
+++ b/docs/DB_API.md
@@ -11,6 +11,7 @@ There are a number of methods that a DB storage backend should implement:
     * .resetAccount(uid, data)
     * .deleteAccount(uid)
     * .sessions(uid)
+    * .devices(uid)
     * .accountEmails(uid)
     * .createEmail(uid, data)
     * .deleteEmail(uid, email)
@@ -28,6 +29,10 @@ There are a number of methods that a DB storage backend should implement:
     * .sessionTokenWithVerificationStatus(tokenId)
     * .sessionWithDevice(tokenId)
     * .deleteSessionToken(tokenId)
+* Devices
+    * .createDevice(uid, deviceId, device)
+    * .updateDevice(uid, deviceId, device)
+    * .deleteDevice(uid, deviceId)
 * Key Fetch Tokens
     * .createKeyFetchToken(tokenId, keyFetchToken)
     * .keyFetchToken(id)
@@ -228,6 +233,22 @@ Returns:
     * an array of incompletely-populated session tokens
 * rejects with:
     * any errors from the underlying storage engine
+
+## .devices(uid) ##
+
+Fetch all devices for a user.
+
+Parameters:
+
+* `uid` (Buffer16):
+  The uid of the account to get devices for
+
+Returns:
+
+* Resolves with:
+  * An array of device records
+* Rejects with:
+  * Any errors from the underlying storage engine
 
 ## .accountEmails(uid) ##
 
@@ -706,3 +727,90 @@ Parameters:
 
 * `code` (Buffer):
   The value of the code
+
+## createDevice(uid, deviceId, device)
+
+Create a device record.
+
+Parameters:
+
+* `uid` (Buffer16):
+  The uid of the owning account
+* `deviceId` (Buffer16):
+  The id of the device record
+* `device` (object):
+  * `sessionTokenId` (Buffer32):
+    The id of the associated session token
+  * `name` (string):
+    The name of the device
+  * `type` (string):
+    The device type, e.g. 'mobile', 'tablet'
+  * `createdAt` (number):
+    Creation timestamp for the device, milliseconds since the epoch
+  * `callbackURL` (string):
+    URL for push service
+  * `callbackPublicKey` (string):
+    Public key for push service
+  * `callbackAuthKey` (string):
+    Auth key for push service
+
+Returns:
+
+* Resolves with:
+  * An empty object `{}`
+* Rejects with:
+  * `error.duplicate()` if a device already exists with the same `uid` and `deviceId`
+  * Any error from the underlying storage system (wrapped in `error.wrap()`)
+
+## updateDevice(uid, deviceId, device)
+
+Updates a device record.
+
+Parameters:
+
+* `uid` (Buffer16):
+  The uid of the owning account
+* `deviceId` (Buffer16):
+  The id of the device record
+* `device` (object):
+  * `sessionTokenId` (Buffer32):
+    The id of the associated session token
+  * `name` (string):
+    The name of the device
+  * `type` (string):
+    The device type, e.g. 'mobile', 'tablet'
+  * `createdAt` (number):
+    Creation timestamp for the device, milliseconds since the epoch
+  * `callbackURL` (string):
+    URL for push service
+  * `callbackPublicKey` (string):
+    Public key for push service
+  * `callbackAuthKey` (string):
+    Auth key for push service
+
+Returns:
+
+* Resolves with:
+  * An empty object `{}`
+* Rejects with:
+  * Any error from the underlying storage system (wrapped in `error.wrap()`)
+
+## deleteDevice(uid, deviceId)
+
+Delete a device record.
+
+Parameters:
+
+* `uid` (Buffer16):
+  The uid of the owning account
+* `deviceId` (Buffer16):
+  The id of the device record
+
+Returns:
+
+* Resolves with:
+  * An object containing a `tokenId` property identifying the associated session token,
+    which was also deleted
+* Rejects with:
+  * Any error from the underlying storage system (wrapped in `error.wrap()`)
+

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -431,7 +431,7 @@ module.exports = function (log, error) {
 
   Memory.prototype.deleteDevice = function (uid, deviceId) {
     const deviceKey = deviceId.toString('hex')
-    let tokenId
+    let sessionTokenId
 
     return getAccountByUid(uid)
       .then(account => {
@@ -440,13 +440,13 @@ module.exports = function (log, error) {
         }
 
         const device = account.devices[deviceKey]
-        tokenId = device.sessionTokenId
+        sessionTokenId = device.sessionTokenId
 
         delete account.devices[deviceKey]
 
-        return Memory.prototype.deleteSessionToken(tokenId)
+        return Memory.prototype.deleteSessionToken(sessionTokenId)
       })
-      .then(() => ({ tokenId }))
+      .then(() => ({ sessionTokenId }))
   }
 
   // READ

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -430,20 +430,23 @@ module.exports = function (log, error) {
   }
 
   Memory.prototype.deleteDevice = function (uid, deviceId) {
-    var deviceKey = deviceId.toString('hex')
+    const deviceKey = deviceId.toString('hex')
+    let tokenId
+
     return getAccountByUid(uid)
-      .then(
-        function (account) {
-          if (! account.devices[deviceKey]) {
-            throw error.notFound()
-          }
-
-          var device = account.devices[deviceKey]
-          delete account.devices[deviceKey]
-
-          return Memory.prototype.deleteSessionToken(device.sessionTokenId)
+      .then(account => {
+        if (! account.devices[deviceKey]) {
+          throw error.notFound()
         }
-      )
+
+        const device = account.devices[deviceKey]
+        tokenId = device.sessionTokenId
+
+        delete account.devices[deviceKey]
+
+        return Memory.prototype.deleteSessionToken(tokenId)
+      })
+      .then(() => ({ tokenId }))
   }
 
   // READ

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -618,10 +618,10 @@ module.exports = function (log, error) {
     return this.write(DELETE_PASSWORD_CHANGE_TOKEN, [tokenId])
   }
 
+  // Select : devices
+  // Fields : sessionTokenId
   // Delete : devices, sessionTokens, unverifiedTokens
   // Where  : uid = $1, deviceId = $2
-  // Select : sessionTokens
-  // Fields : tokenId
   var DELETE_DEVICE = 'CALL deleteDevice_3(?, ?)'
 
   MySql.prototype.deleteDevice = function (uid, deviceId) {

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -620,20 +620,19 @@ module.exports = function (log, error) {
 
   // Delete : devices, sessionTokens, unverifiedTokens
   // Where  : uid = $1, deviceId = $2
-  var DELETE_DEVICE = 'CALL deleteDevice_2(?, ?)'
+  // Select : sessionTokens
+  // Fields : tokenId
+  var DELETE_DEVICE = 'CALL deleteDevice_3(?, ?)'
 
   MySql.prototype.deleteDevice = function (uid, deviceId) {
-    return this.write(
-      DELETE_DEVICE,
-      [ uid, deviceId ],
-      function (result) {
-        if (result.affectedRows === 0) {
-          log.error('MySql.deleteDevice', { err: result })
-          throw error.notFound()
-        }
-        return {}
+    return this.write(DELETE_DEVICE, [ uid, deviceId ], results => {
+      const result = results[1]
+      if (result.affectedRows === 0) {
+        log.error('MySql.deleteDevice', { err: result })
+        throw error.notFound()
       }
-    )
+      return results[0][0]
+    })
   }
 
   // VERIFICATION REMINDERS

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 69
+module.exports.level = 70

--- a/lib/db/schema/patch-069-070.sql
+++ b/lib/db/schema/patch-069-070.sql
@@ -7,11 +7,8 @@ CREATE PROCEDURE `deleteDevice_3` (
   IN `idArg` BINARY(16)
 )
 BEGIN
-  SELECT sessionTokens.tokenId
-  FROM devices INNER JOIN sessionTokens
-    ON devices.sessionTokenId = sessionTokens.tokenId
-  WHERE devices.uid = uidArg
-    AND devices.id = idArg;
+  SELECT devices.sessionTokenId FROM devices
+  WHERE devices.uid = uidArg AND devices.id = idArg;
 
   DELETE devices, sessionTokens, unverifiedTokens
   FROM devices

--- a/lib/db/schema/patch-069-070.sql
+++ b/lib/db/schema/patch-069-070.sql
@@ -1,0 +1,27 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- Return the sessionToken id from deleteDevice
+-- so the auth server can remove it from Redis
+CREATE PROCEDURE `deleteDevice_3` (
+  IN `uidArg` BINARY(16),
+  IN `idArg` BINARY(16)
+)
+BEGIN
+  SELECT sessionTokens.tokenId
+  FROM devices INNER JOIN sessionTokens
+    ON devices.sessionTokenId = sessionTokens.tokenId
+  WHERE devices.uid = uidArg
+    AND devices.id = idArg;
+
+  DELETE devices, sessionTokens, unverifiedTokens
+  FROM devices
+  LEFT JOIN sessionTokens
+    ON devices.sessionTokenId = sessionTokens.tokenId
+  LEFT JOIN unverifiedTokens
+    ON sessionTokens.tokenId = unverifiedTokens.tokenId
+  WHERE devices.uid = uidArg
+    AND devices.id = idArg;
+END;
+
+UPDATE dbMetadata SET value = '70' WHERE name = 'schema-patch-level';
+

--- a/lib/db/schema/patch-070-069.sql
+++ b/lib/db/schema/patch-070-069.sql
@@ -1,0 +1,6 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DROP PROCEDURE `deleteDevice_3`;
+
+-- UPDATE dbMetadata SET value = '69' WHERE name = 'schema-patch-level';
+


### PR DESCRIPTION
Related to mozilla/fxa-auth-server#2260.

Currently, the auth server doesn't delete session tokens from Redis in its `db.deleteDevice` method. In order to fix that, the auth server needs to know the session token id for the deleted device. I figured the easiest way to do that would be just to return it from this repo's `deleteDevice` method. Although perhaps it isn't the "correct" way in API terms, I don't know.

Anyway, here it is. If this approach does seem okay, it would be great if we could include this in train 104, so that train 105 can contain the equivalent auth server changes. No dramas if it doesn't make it though.

@mozilla/fxa-devs r?