### PR TITLE
feat(sessions): Add support for reauth on an existing session.

### DIFF
--- a/db-server/test/backend/remote.js
+++ b/db-server/test/backend/remote.js
@@ -345,7 +345,7 @@ module.exports = function(cfg, makeServer) {
             respOk(r)
             var sessions = r.obj
             assert.equal(sessions.length, 1, 'sessions contains one item')
-            assert.equal(Object.keys(sessions[0]).length, 18, 'session has correct properties')
+            assert.equal(Object.keys(sessions[0]).length, 19, 'session has correct properties')
             assert.equal(sessions[0].tokenId, user.sessionTokenId, 'tokenId is correct')
             assert.equal(sessions[0].uid, user.accountId, 'uid is correct')
             assert.equal(sessions[0].createdAt, user.sessionToken.createdAt, 'createdAt is correct')
@@ -356,6 +356,7 @@ module.exports = function(cfg, makeServer) {
             assert.equal(sessions[0].uaDeviceType, user.sessionToken.uaDeviceType, 'uaDeviceType is correct')
             assert.equal(sessions[0].uaFormFactor, user.sessionToken.uaFormFactor, 'uaFormFactor is correct')
             assert.equal(sessions[0].lastAccessTime, user.sessionToken.createdAt, 'lastAccessTime is correct')
+            assert.equal(sessions[0].authAt, user.sessionToken.createdAt, 'authAt is correct')
 
             // Fetch the session token
             return client.getThen('/sessionToken/' + user.sessionTokenId)
@@ -373,6 +374,7 @@ module.exports = function(cfg, makeServer) {
             assert.equal(token.uaDeviceType, user.sessionToken.uaDeviceType, 'uaDeviceType matches')
             assert.equal(token.uaFormFactor, user.sessionToken.uaFormFactor, 'uaFormFactor matches')
             assert.equal(token.lastAccessTime, token.createdAt, 'lastAccessTime was set')
+            assert.equal(token.authAt, token.createdAt, 'authAt was set to default')
             assert.equal(!! token.emailVerified, user.account.emailVerified, 'emailVerified same as account emailVerified')
             assert.equal(token.email, user.account.email, 'token.email same as account email')
             assert.deepEqual(token.emailCode, user.account.emailCode, 'token emailCode same as account emailCode')
@@ -397,6 +399,7 @@ module.exports = function(cfg, makeServer) {
             assert.equal(token.uaDeviceType, user.sessionToken.uaDeviceType, 'uaDeviceType matches')
             assert.equal(token.uaFormFactor, user.sessionToken.uaFormFactor, 'uaFormFactor matches')
             assert.equal(token.lastAccessTime, token.createdAt, 'lastAccessTime was set')
+            assert.equal(token.authAt, token.createdAt, 'authAt was set to default')
             assert.equal(!! token.emailVerified, user.account.emailVerified, 'emailVerified same as account emailVerified')
             assert.equal(token.email, user.account.email, 'token.email same as account email')
             assert.deepEqual(token.emailCode, user.account.emailCode, 'token emailCode same as account emailCode')
@@ -427,6 +430,7 @@ module.exports = function(cfg, makeServer) {
             assert.equal(token.uaDeviceType, verifiedUser.sessionToken.uaDeviceType, 'uaDeviceType matches')
             assert.equal(token.uaFormFactor, verifiedUser.sessionToken.uaFormFactor, 'uaFormFactor matches')
             assert.equal(token.lastAccessTime, token.createdAt, 'lastAccessTime was set')
+            assert.equal(token.authAt, token.createdAt, 'authAt was set to default')
             assert.equal(!! token.emailVerified, verifiedUser.account.emailVerified, 'emailVerified same as account emailVerified')
             assert.equal(token.email, verifiedUser.account.email, 'token.email same as account email')
             assert.deepEqual(token.emailCode, verifiedUser.account.emailCode, 'token emailCode same as account emailCode')
@@ -451,6 +455,7 @@ module.exports = function(cfg, makeServer) {
             assert.equal(token.uaDeviceType, verifiedUser.sessionToken.uaDeviceType, 'uaDeviceType matches')
             assert.equal(token.uaFormFactor, verifiedUser.sessionToken.uaFormFactor, 'uaFormFactor matches')
             assert.equal(token.lastAccessTime, token.createdAt, 'lastAccessTime was set')
+            assert.equal(token.authAt, token.createdAt, 'authAt was set to default')
             assert.equal(!! token.emailVerified, verifiedUser.account.emailVerified, 'emailVerified same as account emailVerified')
             assert.equal(token.email, verifiedUser.account.email, 'token.email same as account email')
             assert.deepEqual(token.emailCode, verifiedUser.account.emailCode, 'token emailCode same as account emailCode')
@@ -517,7 +522,8 @@ module.exports = function(cfg, makeServer) {
               uaOS: 'different OS',
               uaOSVersion: 'different OS version',
               uaDeviceType: 'different device type',
-              lastAccessTime: 42
+              lastAccessTime: 42,
+              authAt: 1234567
             })
           })
           .then(function(r) {
@@ -539,6 +545,7 @@ module.exports = function(cfg, makeServer) {
             assert.equal(sessions[0].uaOSVersion, 'different OS version', 'uaOSVersion is correct')
             assert.equal(sessions[0].uaDeviceType, 'different device type', 'uaDeviceType is correct')
             assert.equal(sessions[0].lastAccessTime, 42, 'lastAccessTime is correct')
+            assert.equal(sessions[0].authAt, 1234567, 'authAt is correct')
 
             // Fetch the newly verified session token
             return client.getThen('/sessionToken/' + user.sessionTokenId)
@@ -555,6 +562,7 @@ module.exports = function(cfg, makeServer) {
             assert.equal(token.uaOSVersion, 'different OS version', 'uaOSVersion was updated')
             assert.equal(token.uaDeviceType, 'different device type', 'uaDeviceType was updated')
             assert.equal(token.lastAccessTime, 42, 'lastAccessTime was updated')
+            assert.equal(token.authAt, 1234567, 'authAt was updated')
 
             // Create a device
             return client.putThen('/account/' + user.accountId + '/device/' + user.deviceId, user.device)

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -387,8 +387,9 @@ module.exports = function (log, error) {
 
   // Select : sessionTokens t, accounts a, devices d, unverifiedTokens ut
   // Fields : t.tokenData, t.uid, t.createdAt, t.uaBrowser, t.uaBrowserVersion, t.uaOS,
-  //          t.uaOSVersion, t.uaDeviceType, t.uaFormFactor, t.lastAccessTime, a.emailVerified,
-  //          a.email, a.emailCode, a.verifierSetAt, a.locale, a.createdAt AS accountCreatedAt,
+  //          t.uaOSVersion, t.uaDeviceType, t.uaFormFactor, t.lastAccessTime, t.authAt,
+  //          a.emailVerified, a.email, a.emailCode, a.verifierSetAt, a.locale,
+  //          a.createdAt AS accountCreatedAt,
   //          d.id AS deviceId, d.name AS deviceName, d.type AS deviceType, d.createdAt
   //          AS deviceCreatedAt, d.callbackURL AS deviceCallbackURL, d.callbackPublicKey
   //          AS deviceCallbackPublicKey, d.callbackAuthKey AS deviceCallbackAuthKey,
@@ -396,7 +397,7 @@ module.exports = function (log, error) {
   //          ut.tokenVerificationId, ut.mustVerify
   // Where  : t.tokenId = $1 AND t.uid = a.uid AND t.tokenId = d.sessionTokenId AND
   //          t.uid = d.uid AND t.tokenId = u.tokenId
-  var SESSION_DEVICE = 'CALL sessionWithDevice_10(?)'
+  var SESSION_DEVICE = 'CALL sessionWithDevice_11(?)'
 
   MySql.prototype.sessionWithDevice = function (id) {
     return this.readFirstResult(SESSION_DEVICE, [id])
@@ -404,12 +405,12 @@ module.exports = function (log, error) {
 
   // Select : sessionTokens
   // Fields : tokenId, uid, createdAt, uaBrowser, uaBrowserVersion,
-  //          uaOS, uaOSVersion, uaDeviceType, uaFormFactor, lastAccessTime,
+  //          uaOS, uaOSVersion, uaDeviceType, uaFormFactor, lastAccessTime, authAt,
   //          deviceId, deviceName, deviceType, deviceCreatedAt, deviceCallbackURL,
   //          deviceCallbackPublicKey, deviceCallbackAuthKey, deviceCallbackIsExpired
   // Where  : t.uid = $1 AND t.tokenId = d.sessionTokenId AND
   //          t.uid = d.uid AND t.tokenId = u.tokenId
-  var SESSIONS = 'CALL sessions_7(?)'
+  var SESSIONS = 'CALL sessions_8(?)'
 
   MySql.prototype.sessions = function (uid) {
     return this.readOneFromFirstResult(SESSIONS, [uid])
@@ -418,10 +419,11 @@ module.exports = function (log, error) {
   // Select : sessionTokens t, accounts a
   // Fields : t.tokenData, t.uid, t.createdAt, t.uaBrowser, t.uaBrowserVersion,
   //          t.uaOS, t.uaOSVersion, t.uaDeviceType, t.uaFormFactor, t.lastAccessTime,
+  //          t.authAt,
   //          a.emailVerified, a.email, a.emailCode, a.verifierSetAt, a.locale,
   //          a.createdAt AS accountCreatedAt
   // Where  : t.tokenId = $1 AND t.uid = a.uid
-  var SESSION_TOKEN = 'CALL sessionToken_7(?)'
+  var SESSION_TOKEN = 'CALL sessionToken_8(?)'
 
   MySql.prototype.sessionToken = function (id) {
     return this.readFirstResult(SESSION_TOKEN, [id])
@@ -430,10 +432,11 @@ module.exports = function (log, error) {
   // Select : sessionTokens t, accounts a, unverifiedTokens ut
   // Fields : t.tokenData, t.uid, t.createdAt, t.uaBrowser, t.uaBrowserVersion,
   //          t.uaOS, t.uaOSVersion, t.uaDeviceType, t.uaFormFactor, t.lastAccessTime,
+  //          t.authAt,
   //          a.emailVerified, a.email, a.emailCode, a.verifierSetAt, a.locale,
   //          a.createdAt AS accountCreatedAt, ut.tokenVerificationId, ut.mustVerify
   // Where  : t.tokenId = $1 AND t.uid = a.uid AND t.tokenId = ut.tokenId
-  var SESSION_TOKEN_VERIFIED = 'CALL sessionTokenWithVerificationStatus_7(?)'
+  var SESSION_TOKEN_VERIFIED = 'CALL sessionTokenWithVerificationStatus_8(?)'
 
   MySql.prototype.sessionTokenWithVerificationStatus = function (tokenId) {
     return this.readFirstResult(SESSION_TOKEN_VERIFIED, [tokenId])
@@ -514,22 +517,26 @@ module.exports = function (log, error) {
   }
 
   // Update : sessionTokens
-  // Set    : uaBrowser = $1, uaBrowserVersion = $2, uaOS = $3, uaOSVersion = $4,
-  //          uaDeviceType = $5, lastAccessTime = $6
-  // Where  : tokenId = $7
-  var UPDATE_SESSION_TOKEN = 'CALL updateSessionToken_1(?, ?, ?, ?, ?, ?, ?)'
+  // Set    : uaBrowser = $2, uaBrowserVersion = $3, uaOS = $4, uaOSVersion = $5,
+  //          uaDeviceType = $6, uaFormFactor = $7, lastAccessTime = $8,
+  //          authAt = $9, mustVerify = $10
+  // Where  : tokenId = $1
+  var UPDATE_SESSION_TOKEN = 'CALL updateSessionToken_2(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
 
   MySql.prototype.updateSessionToken = function (tokenId, token) {
     return this.write(
       UPDATE_SESSION_TOKEN,
       [
+        tokenId,
         token.uaBrowser,
         token.uaBrowserVersion,
         token.uaOS,
         token.uaOSVersion,
         token.uaDeviceType,
+        token.uaFormFactor,
         token.lastAccessTime,
-        tokenId
+        token.authAt,
+        token.mustVerify
       ]
     )
   }
@@ -802,7 +809,6 @@ module.exports = function (log, error) {
       }
     )
   }
-
 
   // USER EMAILS
   // Insert : emails

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 71
+module.exports.level = 72

--- a/lib/db/schema/patch-071-072.sql
+++ b/lib/db/schema/patch-071-072.sql
@@ -1,0 +1,208 @@
+--
+-- This migration adds an explicit `authAt` timestamp to the sessionTokens
+-- table, making it possible to re-authenticate within an existing session
+-- ratehr than generating a new one each time you need keys or a fresh auth
+-- tiemstamp.
+--
+
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+ALTER TABLE `sessionTokens`
+ADD COLUMN `authAt` BIGINT UNSIGNED DEFAULT NULL,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+-- The `authAt` column can be set by calling `updateSessionToken`.
+
+CREATE PROCEDURE `updateSessionToken_2` (
+    IN tokenIdArg BINARY(32),
+    IN uaBrowserArg VARCHAR(255),
+    IN uaBrowserVersionArg VARCHAR(255),
+    IN uaOSArg VARCHAR(255),
+    IN uaOSVersionArg VARCHAR(255),
+    IN uaDeviceTypeArg VARCHAR(255),
+    IN uaFormFactorArg VARCHAR(255),
+    IN lastAccessTimeArg BIGINT UNSIGNED,
+    IN authAtArg BIGINT UNSIGNED,
+    IN mustVerifyArg BOOLEAN
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  UPDATE sessionTokens
+    SET uaBrowser = COALESCE(uaBrowserArg, uaBrowser),
+      uaBrowserVersion = COALESCE(uaBrowserVersionArg, uaBrowserVersion),
+      uaOS = COALESCE(uaOSArg, uaOS),
+      uaOSVersion = COALESCE(uaOSVersionArg, uaOSVersion),
+      uaDeviceType = COALESCE(uaDeviceTypeArg, uaDeviceType),
+      uaFormFactor = COALESCE(uaFormFactorArg, uaFormFactor),
+      lastAccessTime = COALESCE(lastAccessTimeArg, lastAccessTime),
+      authAt = COALESCE(authAtArg, authAt, createdAt)
+    WHERE tokenId = tokenIdArg;
+
+  -- Allow updating mustVerify from FALSE to TRUE,
+  -- but not the other way around.
+  IF mustVerifyArg THEN
+    UPDATE unverifiedTokens
+      SET mustVerify = TRUE
+      WHERE tokenId = tokenIdArg;
+  END IF;
+
+  COMMIT;
+END;
+
+
+-- Various other session-token procedures need to read the new field.
+
+CREATE PROCEDURE `sessionToken_8` (
+  IN `tokenIdArg` BINARY(32)
+)
+BEGIN
+  SELECT
+    t.tokenData,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.uaFormFactor,
+    t.lastAccessTime,
+    COALESCE(t.authAt, t.createdAt) AS authAt,
+    e.isVerified AS emailVerified,
+    e.email,
+    e.emailCode,
+    a.verifierSetAt,
+    a.locale,
+    a.createdAt AS accountCreatedAt
+  FROM sessionTokens AS t
+  LEFT JOIN accounts AS a
+    ON t.uid = a.uid
+  LEFT JOIN emails AS e
+    ON t.uid = e.uid
+    AND e.isPrimary = true
+  WHERE t.tokenId = tokenIdArg;
+END;
+
+CREATE PROCEDURE `sessionTokenWithVerificationStatus_8` (
+  IN `tokenIdArg` BINARY(32)
+)
+BEGIN
+  SELECT
+    t.tokenData,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.uaFormFactor,
+    t.lastAccessTime,
+    COALESCE(t.authAt, t.createdAt) AS authAt,
+    e.isVerified AS emailVerified,
+    e.email,
+    e.emailCode,
+    a.verifierSetAt,
+    a.locale,
+    a.createdAt AS accountCreatedAt,
+    ut.tokenVerificationId,
+    ut.mustVerify,
+    ut.tokenVerificationCodeHash,
+    ut.tokenVerificationCodeExpiresAt
+  FROM sessionTokens AS t
+  LEFT JOIN accounts AS a
+    ON t.uid = a.uid
+  LEFT JOIN emails AS e
+    ON t.uid = e.uid
+    AND e.isPrimary = true
+  LEFT JOIN unverifiedTokens AS ut
+    ON t.tokenId = ut.tokenId
+  WHERE t.tokenId = tokenIdArg;
+END;
+
+CREATE PROCEDURE `sessionWithDevice_11` (
+  IN `tokenIdArg` BINARY(32)
+)
+BEGIN
+  SELECT
+    t.tokenData,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.uaFormFactor,
+    t.lastAccessTime,
+    COALESCE(t.authAt, t.createdAt) AS authAt,
+    e.isVerified AS emailVerified,
+    e.email,
+    e.emailCode,
+    a.verifierSetAt,
+    a.locale,
+    a.createdAt AS accountCreatedAt,
+    d.id AS deviceId,
+    d.nameUtf8 AS deviceName,
+    d.type AS deviceType,
+    d.createdAt AS deviceCreatedAt,
+    d.callbackURL AS deviceCallbackURL,
+    d.callbackPublicKey AS deviceCallbackPublicKey,
+    d.callbackAuthKey AS deviceCallbackAuthKey,
+    d.callbackIsExpired AS deviceCallbackIsExpired,
+    ut.tokenVerificationId,
+    ut.mustVerify
+  FROM sessionTokens AS t
+  LEFT JOIN accounts AS a
+    ON t.uid = a.uid
+  LEFT JOIN emails AS e
+    ON t.uid = e.uid
+    AND e.isPrimary = true
+  LEFT JOIN devices AS d
+    ON (t.tokenId = d.sessionTokenId AND t.uid = d.uid)
+  LEFT JOIN unverifiedTokens AS ut
+    ON t.tokenId = ut.tokenId
+  WHERE t.tokenId = tokenIdArg;
+END;
+
+
+CREATE PROCEDURE `sessions_8` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  SELECT
+    t.tokenId,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.uaFormFactor,
+    t.lastAccessTime,
+    COALESCE(t.authAt, t.createdAt) AS authAt,
+    d.id AS deviceId,
+    d.nameUtf8 AS deviceName,
+    d.type AS deviceType,
+    d.createdAt AS deviceCreatedAt,
+    d.callbackURL AS deviceCallbackURL,
+    d.callbackPublicKey AS deviceCallbackPublicKey,
+    d.callbackAuthKey AS deviceCallbackAuthKey,
+    d.callbackIsExpired AS deviceCallbackIsExpired
+  FROM sessionTokens AS t
+  LEFT JOIN devices AS d
+    ON (t.tokenId = d.sessionTokenId AND t.uid = d.uid)
+  WHERE t.uid = uidArg;
+END;
+
+
+UPDATE dbMetadata SET value = '72' WHERE name = 'schema-patch-level';
+

--- a/lib/db/schema/patch-072-071.sql
+++ b/lib/db/schema/patch-072-071.sql
@@ -1,0 +1,14 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+--
+-- ALTER TABLE `sessionTokens` DROP COLUMN `authAt`,
+-- ALGORITHM = INPLACE, LOCK = NONE;
+--
+-- DROP PROCEDURE `updateSessionToken_2`;
+-- DROP PROCEDURE `sessionToken_8`;
+-- DROP PROCEDURE `sessionTokenWithVerificationStatus_8`;
+-- DROP PROCEDURE `sessionWithDevice_8`;
+-- DROP PROCEDURE `sessions_8`;
+
+-- UPDATE dbMetadata SET value = '71' WHERE name = 'schema-patch-level';
+


### PR DESCRIPTION
Connects to https://github.com/mozilla/fxa-auth-server/issues/2212.

This adds supporting code for https://github.com/mozilla/fxa-auth-server/pull/2288, allowing us to re-authenticate against an existing sessionToken rather than creating a new one whenever we need the user to re-enter their password.

It's currently implemented on top of #299 to avoid migration conflicts; let's aim to get that merged first and then we can re-open this PR against master.  WIP for now.