### PR TITLE
feat(totp): Add initial totp session verification logic

### DIFF
--- a/db-server/index.js
+++ b/db-server/index.js
@@ -97,6 +97,7 @@ function createServer(db) {
       return db.deleteEmail(req.params.id, req.params.email)
     })
   )
+
   api.get('/email/:email',
     op(function (req) {
       return db.getSecondaryEmail(Buffer(req.params.email, 'hex'))
@@ -125,6 +126,7 @@ function createServer(db) {
 
   api.get('/keyFetchToken/:id/verified', withIdAndBody(db.keyFetchTokenWithVerificationStatus))
   api.post('/tokens/:id/verify', withIdAndBody(db.verifyTokens))
+  api.post('/tokens/:id/verifyWith', withIdAndBody(db.verifyTokensWithMethod))
   api.post('/tokens/:code/verifyCode', withParamsAndBody(db.verifyTokenCode))
 
   api.get('/accountResetToken/:id', withIdAndBody(db.accountResetToken))
@@ -156,6 +158,7 @@ function createServer(db) {
   api.get('/totp/:id', withIdAndBody(db.totpToken))
   api.del('/totp/:id', withIdAndBody(db.deleteTotpToken))
   api.put('/totp/:id', withIdAndBody(db.createTotpToken))
+  api.post('/totp/:id/update', withIdAndBody(db.updateTotpToken))
 
   api.get('/__heartbeat__', withIdAndBody(db.ping))
 

--- a/db-server/lib/error.js
+++ b/db-server/lib/error.js
@@ -72,6 +72,17 @@ AppError.expiredTokenVerificationCode = function () {
   )
 }
 
+AppError.invalidVerificationMethod = function () {
+  return new AppError(
+    {
+      code: 400,
+      error: 'Bad request',
+      errno: 138,
+      message: 'Invalid verification method'
+    }
+  )
+}
+
 AppError.wrap = function (err) {
   return new AppError(
     {

--- a/db-server/test/fake.js
+++ b/db-server/test/fake.js
@@ -128,7 +128,9 @@ module.exports.newUserDataHex = function() {
 
   data.totp = {
     sharedSecret: hex(10),
-    epoch: 0
+    epoch: 0,
+    verified: false,
+    enabled: true
   }
 
   return data

--- a/docs/API.md
+++ b/docs/API.md
@@ -91,13 +91,15 @@ The following datatypes are used throughout this document:
     * forgotPasswordVerified    : `POST /passwordForgotToken/:id/verified`
 * Unverified tokens:
     * verifyTokens              : `POST /tokens/:tokenVerificationId/verify`
+    * verifyTokensWithMethod    : `POST /tokens/:tokenId/verifyWith`
 * Sign-in codes
     * createSigninCode          : `PUT /signinCodes/:code`
     * consumeSigninCode         : `POST /signinCodes/:code/consume`
-* TOTP resetTokens
+* TOTP tokens:
     * createTotpToken           : `PUT /totp/:id`
     * totpToken                 : `GET /totp/:id`
     * deleteTotpToken           : `DEL /totp/:id`
+    * updateTotpToken           : `POST /totp/:id/update`
 
 ## Ping : `GET /`
 
@@ -1743,6 +1745,53 @@ Content-Length: 2
     * Body : {"code":"InternalError","message":"...<message related to the error>..."}
 ```
 
+## verifyTokens : `POST /tokens/<tokenId>/verifyWith`
+
+This method verifies sessionTokens, keyFetchTokens and sets
+the the verification method used on the sessions table.
+
+### Example
+
+```
+curl \
+    -v \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d '{"verificatioMethod":"totp-2fa"}' \
+    http://localhost:8000/tokens/8e8c27b704dbf6a5dc556453c92e7506/verifyWith
+```
+
+### Request
+
+* Method : POST
+* Path : `/tokens/<tokenId>/verifyWith`
+    * tokenVerificationId : hex128
+* Params:
+    * uid : hex128
+
+### Response
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 2
+
+{}
+```
+
+* Status Code : 200 OK
+    * Content-Type : 'application/json'
+    * Body : {}
+* Status Code : 404 Not Found
+    * Conditions: if no unverified tokens exist for tokenId
+    * Content-Type : 'application/json'
+    * Body : `{"message":"Not Found"}`
+* Status Code : 500 Internal Server Error
+    * Conditions: if something goes wrong on the server
+    * Content-Type : 'application/json'
+    * Body : {"code":"InternalError","message":"...<message related to the error>..."}
+```
+
 ## createSigninCode : `PUT /signinCodes/:code`
 
 Create a user-specific, time-limited, single-use code
@@ -1895,7 +1944,7 @@ curl \
 ### Request
 
 * Method : `GET`
-* Path : `/totp/<uid>
+* Path : `/totp/<uid>`
     * `uid` : hex   
 
 ### Response
@@ -1907,7 +1956,9 @@ Content-Length: 2
 
 {
   "sharedSecret": "LEVXGTLWMFITC6BSIF2DOQKTIU2WUOKJ",
-  "epoch": 0
+  "epoch": 0,
+  "verified": true,
+  "enable": true
 }
 ```
 
@@ -1939,7 +1990,49 @@ curl \
 ### Request
 
 * Method : `DEL`
-* Path : `/totp/<uid>
+* Path : `/totp/<uid>`
+    * `uid` : hex   
+
+### Response
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 2
+
+{}
+```
+
+* Status Code : `200 OK`
+    * Content-Type : `application/json`
+    * Body : `{}`  
+* Status Code : `500 Internal Server Error`
+    * Conditions: if something goes wrong on the server
+    * Content-Type : `application/json`
+    * Body : `{"code":"InternalError","message":"..."}`
+
+## updateTotpToken : `POST /totp/:uid/update`
+
+Updates the user's TOTP token.
+
+### Example
+
+```
+curl \
+    -v \
+    -X DEL \
+    -H "Content-Type: application/json" \
+    -d '{
+        "verified" : true,
+        "enable": true
+    }' \    
+    http://localhost:8000/totp/1234567890ab/update   
+```
+
+### Request
+
+* Method : `POST`
+* Path : `/totp/<uid>/update`
     * `uid` : hex   
 
 ### Response

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 72
+module.exports.level = 73

--- a/lib/db/schema/patch-072-073.sql
+++ b/lib/db/schema/patch-072-073.sql
@@ -1,0 +1,239 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- Add columns `verified` and `enabled` to help manage TOTP token state
+ALTER TABLE `totp`
+ADD COLUMN `verified` BOOLEAN DEFAULT FALSE,
+ADD COLUMN `enabled` BOOLEAN DEFAULT TRUE,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+-- Add verification details to session token table
+ALTER TABLE `sessionTokens`
+ADD COLUMN `verificationMethod` INT DEFAULT NULL,
+ADD COLUMN `verifiedAt` BIGINT DEFAULT NULL,
+ADD COLUMN `mustVerify` BOOLEAN DEFAULT TRUE,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+CREATE PROCEDURE `totpToken_2` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+
+  SELECT sharedSecret, epoch, verified, enabled FROM `totp` WHERE uid = uidArg;
+
+END;
+
+CREATE PROCEDURE `updateTotpToken_1` (
+  IN `uidArg` BINARY(16),
+  IN `verifiedArg` BOOLEAN,
+  IN `enabledArg` BOOLEAN
+)
+BEGIN
+
+  UPDATE `totp` SET verified = verifiedArg, enabled = enabledArg WHERE uid = uidArg;
+
+END;
+
+CREATE PROCEDURE `verifyTokensWithMethod_1` (
+  IN `tokenIdArg` BINARY(32),
+  IN `verificationMethodArg` INT,
+  IN `verifiedAtArg` BIGINT(1)
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+    -- Update session verification methods
+    UPDATE `sessionTokens` SET verificationMethod = verificationMethodArg, verifiedAt = verifiedAtArg
+    WHERE tokenId = tokenIdArg;
+
+    -- Get the tokenVerificationId and uid for session
+    SET @tokenVerificationId = NULL;
+    SET @uid = NULL;
+    SELECT tokenVerificationId, uid INTO @tokenVerificationId, @uid FROM `unverifiedTokens`
+    WHERE tokenId = tokenIdArg;
+
+    -- Verify tokens with tokenVerificationId
+    CALL verifyToken_3(@tokenVerificationId, @uid);
+
+    SET @updateCount = (SELECT ROW_COUNT());
+  COMMIT;
+
+  SELECT @updateCount;
+END;
+
+CREATE PROCEDURE `sessionWithDevice_12` (
+  IN `tokenIdArg` BINARY(32)
+)
+BEGIN
+  SELECT
+    t.tokenData,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.uaFormFactor,
+    t.lastAccessTime,
+    t.verificationMethod,
+    t.verifiedAt,
+    COALESCE(t.authAt, t.createdAt) AS authAt,
+    e.isVerified AS emailVerified,
+    e.email,
+    e.emailCode,
+    a.verifierSetAt,
+    a.locale,
+    a.createdAt AS accountCreatedAt,
+    d.id AS deviceId,
+    d.nameUtf8 AS deviceName,
+    d.type AS deviceType,
+    d.createdAt AS deviceCreatedAt,
+    d.callbackURL AS deviceCallbackURL,
+    d.callbackPublicKey AS deviceCallbackPublicKey,
+    d.callbackAuthKey AS deviceCallbackAuthKey,
+    d.callbackIsExpired AS deviceCallbackIsExpired,
+    ut.tokenVerificationId,
+    COALESCE(t.mustVerify, ut.mustVerify) AS mustVerify
+  FROM sessionTokens AS t
+  LEFT JOIN accounts AS a
+    ON t.uid = a.uid
+  LEFT JOIN emails AS e
+    ON t.uid = e.uid
+    AND e.isPrimary = true
+  LEFT JOIN devices AS d
+    ON (t.tokenId = d.sessionTokenId AND t.uid = d.uid)
+  LEFT JOIN unverifiedTokens AS ut
+    ON t.tokenId = ut.tokenId
+  WHERE t.tokenId = tokenIdArg;
+END;
+
+CREATE PROCEDURE `createSessionToken_9` (
+  IN `tokenId` BINARY(32),
+  IN `tokenData` BINARY(32),
+  IN `uid` BINARY(16),
+  IN `createdAt` BIGINT UNSIGNED,
+  IN `uaBrowser` VARCHAR(255),
+  IN `uaBrowserVersion` VARCHAR(255),
+  IN `uaOS` VARCHAR(255),
+  IN `uaOSVersion` VARCHAR(255),
+  IN `uaDeviceType` VARCHAR(255),
+  IN `uaFormFactor` VARCHAR(255),
+  IN `tokenVerificationId` BINARY(16),
+  IN `mustVerify` BOOLEAN,
+  IN `tokenVerificationCodeHash` BINARY(32),
+  IN `tokenVerificationCodeExpiresAt` BIGINT UNSIGNED
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  INSERT INTO sessionTokens(
+    tokenId,
+    tokenData,
+    uid,
+    createdAt,
+    uaBrowser,
+    uaBrowserVersion,
+    uaOS,
+    uaOSVersion,
+    uaDeviceType,
+    uaFormFactor,
+    lastAccessTime,
+    mustVerify
+  )
+  VALUES(
+    tokenId,
+    tokenData,
+    uid,
+    createdAt,
+    uaBrowser,
+    uaBrowserVersion,
+    uaOS,
+    uaOSVersion,
+    uaDeviceType,
+    uaFormFactor,
+    createdAt,
+    mustVerify
+  );
+
+  IF tokenVerificationId IS NOT NULL THEN
+    INSERT INTO unverifiedTokens(
+      tokenId,
+      tokenVerificationId,
+      uid,
+      mustVerify,
+      tokenVerificationCodeHash,
+      tokenVerificationCodeExpiresAt
+    )
+    VALUES(
+      tokenId,
+      tokenVerificationId,
+      uid,
+      mustVerify,
+      tokenVerificationCodeHash,
+      tokenVerificationCodeExpiresAt
+    );
+  END IF;
+
+  COMMIT;
+END;
+
+CREATE PROCEDURE `updateSessionToken_3` (
+    IN tokenIdArg BINARY(32),
+    IN uaBrowserArg VARCHAR(255),
+    IN uaBrowserVersionArg VARCHAR(255),
+    IN uaOSArg VARCHAR(255),
+    IN uaOSVersionArg VARCHAR(255),
+    IN uaDeviceTypeArg VARCHAR(255),
+    IN uaFormFactorArg VARCHAR(255),
+    IN lastAccessTimeArg BIGINT UNSIGNED,
+    IN authAtArg BIGINT UNSIGNED,
+    IN mustVerifyArg BOOLEAN
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  UPDATE sessionTokens
+    SET uaBrowser = COALESCE(uaBrowserArg, uaBrowser),
+      uaBrowserVersion = COALESCE(uaBrowserVersionArg, uaBrowserVersion),
+      uaOS = COALESCE(uaOSArg, uaOS),
+      uaOSVersion = COALESCE(uaOSVersionArg, uaOSVersion),
+      uaDeviceType = COALESCE(uaDeviceTypeArg, uaDeviceType),
+      uaFormFactor = COALESCE(uaFormFactorArg, uaFormFactor),
+      lastAccessTime = COALESCE(lastAccessTimeArg, lastAccessTime),
+      authAt = COALESCE(authAtArg, authAt, createdAt)
+    WHERE tokenId = tokenIdArg;
+
+  -- Allow updating mustVerify from FALSE to TRUE,
+  -- but not the other way around.
+  IF mustVerifyArg THEN
+    UPDATE unverifiedTokens
+      SET mustVerify = TRUE
+      WHERE tokenId = tokenIdArg;
+
+    UPDATE sessionTokens
+      SET mustVerify = TRUE
+      WHERE tokenId = tokenIdArg;
+  END IF;
+
+  COMMIT;
+END;
+
+UPDATE dbMetadata SET value = '73' WHERE name = 'schema-patch-level';
+

--- a/lib/db/schema/patch-073-072.sql
+++ b/lib/db/schema/patch-073-072.sql
@@ -1,0 +1,22 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- ALTER TABLE `totp`
+-- DROP COLUMN `verified`,
+-- DROP COLUMN `enabled`
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- ALTER TABLE `sessionTokens`
+-- DROP COLUMN `verificationMethod`,
+-- DROP COLUMN `verifiedAt`,
+-- DROP COLUMN `mustVerify`
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- DROP PROCEDURE `totpToken_2`;
+-- DROP PROCEDURE `updateTotpToken_1`;
+-- DROP PROCEDURE `verifyTokensWithMethod_1`;
+-- DROP PROCEDURE `sessionWithDevice_12`;
+-- DROP PROCEDURE `createSessionToken_9`;
+-- DROP PROCEDURE `updateSessionToken_3`;
+
+-- UPDATE dbMetadata SET value = '72' WHERE name = 'schema-patch-level';
+

--- a/lib/db/util.js
+++ b/lib/db/util.js
@@ -31,6 +31,12 @@ const BOUNCE_SUB_TYPES = new Map([
   ['virus', 14]
 ])
 
+const VERIFICATION_METHODS = new Map([
+  ['email', 0],     // sign-in confirmation email link
+  ['email-2fa', 1], // sign-in confirmation email code (token code)
+  ['totp-2fa', 2]   // TOTP code
+])
+
 module.exports = {
 
   mapEmailBounceType(val) {
@@ -46,6 +52,14 @@ module.exports = {
       return val
     } else {
       return BOUNCE_SUB_TYPES.get(val) || 0
+    }
+  },
+
+  mapVerificationMethodType(val) {
+    if (typeof val === 'number') {
+      return val
+    } else {
+      return VERIFICATION_METHODS.get(val) || undefined
     }
   },
 


### PR DESCRIPTION
This PR is the next stage for TOTP tokens. It adds the ability to verify TOTP tokens and sessions.

* Adds the `verified, enabled` property to TOTP tokens.
* Adds the `verificationMethod, verifiedAt` property to session tokens.
* Adds the `mustVerify` property to the session table. This property is in sync with the property on the unverified tokens table, ref: https://github.com/mozilla/fxa-auth-db-mysql/issues/301#issuecomment-366051763.
* Can be tested against https://github.com/mozilla/fxa-auth-server/pull/2321

Fixes #301 