### PR TITLE
feat(devices): Devices capabilities

### DIFF
--- a/db-server/lib/error.js
+++ b/db-server/lib/error.js
@@ -83,7 +83,22 @@ AppError.invalidVerificationMethod = function () {
   )
 }
 
+AppError.unknownDeviceCapability = function () {
+  return new AppError(
+    {
+      code: 400,
+      error: 'Bad request',
+      errno: 139,
+      message: 'Unknown device capability'
+    }
+  )
+}
+
 AppError.wrap = function (err) {
+  // Don't re-wrap!
+  if (err instanceof AppError) {
+    return err
+  }
   return new AppError(
     {
       code: 500,

--- a/db-server/test/fake.js
+++ b/db-server/test/fake.js
@@ -75,7 +75,8 @@ module.exports.newUserDataHex = function() {
     callbackURL: 'fake callback URL',
     callbackPublicKey: base64_65(),
     callbackAuthKey: base64_16(),
-    callbackIsExpired: false
+    callbackIsExpired: false,
+    capabilities: ['pushbox']
   }
 
   // keyFetchToken

--- a/docs/API.md
+++ b/docs/API.md
@@ -663,6 +663,7 @@ Content-Type: application/json
         "callbackPublicKey": "BCp93zru09_hab2Bg37LpTNG__Pw6eMPEP2hrQpwuytoj3h4chXpGc-3qqdKyqjuvAiEupsnOd_RLyc7erJHWgA",
         "callbackAuthKey": "w3b14Zjc-Afj2SDOLOyong",
         "callbackIsExpired": false,
+        "capabilities": ["pushbox"],
         "uaBrowser": "Firefox",
         "uaBrowserVersion": "42",
         "uaOS": "Android",
@@ -720,7 +721,8 @@ Content-Type: application/json
     "callbackURL": "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef",
     "callbackPublicKey": "BCp93zru09_hab2Bg37LpTNG__Pw6eMPEP2hrQpwuytoj3h4chXpGc-3qqdKyqjuvAiEupsnOd_RLyc7erJHWgA",
     "callbackAuthKey": "w3b14Zjc-Afj2SDOLOyong",
-    "callbackIsExpired": false
+    "callbackIsExpired": false,
+    "capabilities": ["pushbox"]
 }
 ```
 
@@ -755,7 +757,8 @@ curl \
       "callbackURL": "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef",
       "callbackPublicKey": "BCp93zru09_hab2Bg37LpTNG__Pw6eMPEP2hrQpwuytoj3h4chXpGc-3qqdKyqjuvAiEupsnOd_RLyc7erJHWgA",
       "callbackAuthKey": "w3b14Zjc-Afj2SDOLOyong",
-      "callbackIsExpired": false
+      "callbackIsExpired": false,
+      "capabilities": ["pushbox"]
     }'
 ```
 
@@ -775,6 +778,10 @@ Content-Type: application/json
     * Conditions: if id already exists or sessionTokenId is already used by a different device
     * Content-Type : 'application/json'
     * Body : `{"errno":101",message":"Record already exists"}`
+* Status Code : 400 Bad Request
+    * Conditions: if the device in the request body contained an unknown capability name
+    * Content-Type : 'application/json'
+    * Body : `{"errno":139",message":"Unknown device capability"}`
 * Status Code : 500 Internal Server Error
     * Conditions: if something goes wrong on the server
     * Content-Type : 'application/json'
@@ -799,7 +806,8 @@ curl \
       "callbackURL": "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef",
       "callbackPublicKey": "BCp93zru09_hab2Bg37LpTNG__Pw6eMPEP2hrQpwuytoj3h4chXpGc-3qqdKyqjuvAiEupsnOd_RLyc7erJHWgA",
       "callbackAuthKey": "w3b14Zjc-Afj2SDOLOyong",
-      "callbackIsExpired": false
+      "callbackIsExpired": false,
+      "capabilities": ["pushbox"]
     }'
 ```
 
@@ -819,6 +827,10 @@ Content-Type: application/json
     * Conditions: if sessionTokenId is already used by a different device
     * Content-Type : 'application/json'
     * Body : `{"errno":101",message":"Record already exists"}`
+* Status Code : 400 Bad Request
+    * Conditions: if the device in the request body contained an unknown capability name
+    * Content-Type : 'application/json'
+    * Body : `{"errno":139",message":"Unknown device capability"}`
 * Status Code : 404 Not Found
     * Conditions: if device(uid,id) is not found in the database
     * Content-Type : 'application/json'
@@ -909,6 +921,7 @@ Content-Length: 285
     "deviceCallbackURL":null,
     "deviceCallbackPublicKey":null,
     "deviceCallbackIsExpired":false,
+    "deviceCapabilities":["pushbox"],
     "mustVerify":true,
     "tokenVerificationId":"12c41fac80fd6149f3f695e188b5f846"
 }
@@ -975,6 +988,7 @@ Content-Length: 285
     "deviceCallbackURL":null,
     "deviceCallbackPublicKey":null,
     "deviceCallbackIsExpired":false,
+    "deviceCapabilities":["pushbox"],
     "mustVerify":true,
     "tokenVerificationId":"12c41fac80fd6149f3f695e188b5f846"
 }

--- a/docs/DB_API.md
+++ b/docs/DB_API.md
@@ -510,6 +510,7 @@ The deviceCallbackPublicKey and deviceCallbackAuthKey fields are urlsafe-base64 
                  d.callbackPublicKey AS deviceCallbackPublicKey,
                  d.callbackAuthKey AS deviceCallbackAuthKey,
                  d.callbackIsExpired AS deviceCallbackIsExpired,
+                 d.capabilities AS deviceCapabilities,
                  ut.mustVerify, ut.tokenVerificationId
 * keyFetchToken : t.authKey, t.uid, t.keyBundle, t.createdAt, a.emailVerified, a.verifierSetAt
 * keyFetchTokenWithVerificationStatus : t.authKey, t.uid, t.keyBundle, t.createdAt, a.emailVerified,
@@ -743,6 +744,8 @@ Parameters:
     Public key for push service
   * `callbackAuthKey` (string):
     Auth key for push service
+  * `capabilities` (array):
+    Array of strings describing the current device capabilities
 
 Returns:
 
@@ -750,6 +753,7 @@ Returns:
   * An empty object `{}`
 * Rejects with:
   * `error.duplicate()` if a device already exists with the same `uid` and `deviceId`
+  * `error.unknownDeviceCapability()` if the input device contained an unknown capability name
   * Any error from the underlying storage system (wrapped in `error.wrap()`)
 
 ## updateDevice(uid, deviceId, device)
@@ -777,12 +781,15 @@ Parameters:
     Public key for push service
   * `callbackAuthKey` (string):
     Auth key for push service
+  * `capabilities` (array):
+    Array of strings describing the current device capabilities
 
 Returns:
 
 * Resolves with:
   * An empty object `{}`
 * Rejects with:
+  * `error.unknownDeviceCapability()` if the input device contained an unknown capability name
   * Any error from the underlying storage system (wrapped in `error.wrap()`)
 
 ## deleteDevice(uid, deviceId)

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 73
+module.exports.level = 74

--- a/lib/db/schema/patch-073-074.sql
+++ b/lib/db/schema/patch-073-074.sql
@@ -1,0 +1,179 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CREATE TABLE IF NOT EXISTS deviceCapabilities (
+  uid BINARY(16) NOT NULL,
+  deviceId BINARY(16) NOT NULL,
+  capability TINYINT UNSIGNED NOT NULL,
+  PRIMARY KEY (uid, deviceId, capability),
+  FOREIGN KEY (uid, deviceId) REFERENCES devices(uid, id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE PROCEDURE `addCapability_1` (
+  IN `inUid` BINARY(16),
+  IN `inDeviceId` BINARY(16),
+  IN `inCapability` TINYINT UNSIGNED
+)
+BEGIN
+  INSERT INTO deviceCapabilities(
+    uid,
+    deviceId,
+    capability
+  )
+  VALUES (
+    inUid,
+    inDeviceId,
+    inCapability
+  );
+END;
+
+CREATE PROCEDURE `purgeCapabilities_1` (
+  IN `inUid` BINARY(16),
+  IN `inDeviceId` BINARY(16)
+)
+BEGIN
+  DELETE FROM deviceCapabilities WHERE uid = inUid AND deviceId = inDeviceId;
+END;
+
+CREATE PROCEDURE `accountDevices_13` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  SELECT
+    d.uid,
+    d.id,
+    d.sessionTokenId,
+    d.nameUtf8 AS name,
+    d.type,
+    d.createdAt,
+    d.callbackURL,
+    d.callbackPublicKey,
+    d.callbackAuthKey,
+    d.callbackIsExpired,
+    (SELECT GROUP_CONCAT(dc.capability)
+     FROM deviceCapabilities dc
+     WHERE dc.uid = d.uid AND dc.deviceId = d.id) AS capabilities,
+    s.uaBrowser,
+    s.uaBrowserVersion,
+    s.uaOS,
+    s.uaOSVersion,
+    s.uaDeviceType,
+    s.uaFormFactor,
+    s.lastAccessTime,
+    e.email
+  FROM devices AS d
+  INNER JOIN sessionTokens AS s
+    ON d.sessionTokenId = s.tokenId
+  INNER JOIN emails AS e
+    ON d.uid = e.uid
+    AND e.isPrimary = true
+  WHERE d.uid = uidArg;
+END;
+
+CREATE PROCEDURE `deviceFromTokenVerificationId_4` (
+    IN inUid BINARY(16),
+    IN inTokenVerificationId BINARY(16)
+)
+BEGIN
+    SELECT
+        d.id,
+        d.nameUtf8 AS name,
+        d.type,
+        d.createdAt,
+        d.callbackURL,
+        d.callbackPublicKey,
+        d.callbackAuthKey,
+        d.callbackIsExpired,
+        (SELECT GROUP_CONCAT(dc.capability)
+         FROM deviceCapabilities dc
+         WHERE dc.uid = d.uid AND dc.deviceId = d.id) AS capabilities
+    FROM unverifiedTokens AS u
+    INNER JOIN devices AS d
+        ON (u.tokenId = d.sessionTokenId AND u.uid = d.uid)
+    WHERE u.uid = inUid AND u.tokenVerificationId = inTokenVerificationId;
+END;
+
+
+CREATE PROCEDURE `sessionWithDevice_13` (
+  IN `tokenIdArg` BINARY(32)
+)
+BEGIN
+  SELECT
+    t.tokenData,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.uaFormFactor,
+    t.lastAccessTime,
+    t.verificationMethod,
+    t.verifiedAt,
+    COALESCE(t.authAt, t.createdAt) AS authAt,
+    e.isVerified AS emailVerified,
+    e.email,
+    e.emailCode,
+    a.verifierSetAt,
+    a.locale,
+    a.createdAt AS accountCreatedAt,
+    d.id AS deviceId,
+    d.nameUtf8 AS deviceName,
+    d.type AS deviceType,
+    d.createdAt AS deviceCreatedAt,
+    d.callbackURL AS deviceCallbackURL,
+    d.callbackPublicKey AS deviceCallbackPublicKey,
+    d.callbackAuthKey AS deviceCallbackAuthKey,
+    d.callbackIsExpired AS deviceCallbackIsExpired,
+    (SELECT GROUP_CONCAT(dc.capability)
+     FROM deviceCapabilities dc
+     WHERE dc.uid = d.uid AND dc.deviceId = d.id) AS deviceCapabilities,
+    ut.tokenVerificationId,
+    COALESCE(t.mustVerify, ut.mustVerify) AS mustVerify
+  FROM sessionTokens AS t
+  LEFT JOIN accounts AS a
+    ON t.uid = a.uid
+  LEFT JOIN emails AS e
+    ON t.uid = e.uid
+    AND e.isPrimary = true
+  LEFT JOIN devices AS d
+    ON (t.tokenId = d.sessionTokenId AND t.uid = d.uid)
+  LEFT JOIN unverifiedTokens AS ut
+    ON t.tokenId = ut.tokenId
+  WHERE t.tokenId = tokenIdArg;
+END;
+
+CREATE PROCEDURE `sessions_9` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  SELECT
+    t.tokenId,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.uaFormFactor,
+    t.lastAccessTime,
+    COALESCE(t.authAt, t.createdAt) AS authAt,
+    d.id AS deviceId,
+    d.nameUtf8 AS deviceName,
+    d.type AS deviceType,
+    d.createdAt AS deviceCreatedAt,
+    d.callbackURL AS deviceCallbackURL,
+    d.callbackPublicKey AS deviceCallbackPublicKey,
+    d.callbackAuthKey AS deviceCallbackAuthKey,
+    d.callbackIsExpired AS deviceCallbackIsExpired,
+    (SELECT GROUP_CONCAT(dc.capability)
+     FROM deviceCapabilities dc
+     WHERE dc.uid = d.uid AND dc.deviceId = d.id) AS deviceCapabilities
+  FROM sessionTokens AS t
+  LEFT JOIN devices AS d
+    ON (t.tokenId = d.sessionTokenId AND t.uid = d.uid)
+  WHERE t.uid = uidArg;
+END;
+
+UPDATE dbMetadata SET value = '74' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-074-073.sql
+++ b/lib/db/schema/patch-074-073.sql
@@ -1,0 +1,13 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DROP TABLE `deviceCapabilities`;
+
+-- DROP PROCEDURE `addCapability_1`;
+-- DROP PROCEDURE `purgeCapabilities_1`;
+-- DROP PROCEDURE `accountDevices_13`;
+-- DROP PROCEDURE `deviceFromTokenVerificationId_4`;
+-- DROP PROCEDURE `sessionWithDevice_13`;
+-- DROP PROCEDURE `sessions_9`;
+
+-- UPDATE dbMetadata SET value = '73' WHERE name = 'schema-patch-level';
+

--- a/lib/db/util.js
+++ b/lib/db/util.js
@@ -37,7 +37,23 @@ const VERIFICATION_METHODS = new Map([
   ['totp-2fa', 2]   // TOTP code
 ])
 
+// If you modify one of these maps, modify the other.
+const DEVICE_CAPABILITIES = new Map([
+  ['pushbox', 1]
+])
+const DEVICE_CAPABILITIES_IDS = new Map([
+  [1, 'pushbox']
+])
+
 module.exports = {
+
+  mapDeviceCapability(val) {
+    if (typeof val === 'number') {
+      return DEVICE_CAPABILITIES_IDS.get(val) || null
+    } else {
+      return DEVICE_CAPABILITIES.get(val) || null
+    }
+  },
 
   mapEmailBounceType(val) {
     if (typeof val === 'number') {


### PR DESCRIPTION
Connects to mozilla/fxa-auth-server#2320 (please read for context).

- When fetching a device infos, we want to query `devices` and `devicesCapabilities` at the same time.
Since MySQL doesn't have an Array type, we pull the device capabilities using a `GROUP_CONCAT` and convert them to an array in JS.
- For creating or updating a device, we have no choice but to make multiple queries in the same transaction (see the new `writeMultiple` method).
- We maintain a "capability name" <> "capability id" mapping. In practice this is the `CAPABILITIES` array in `mysql.js`.
- If `device.capabilities` is supplied in `updateDevice`, it is implied that we are replacing the current device capabilities.