### PR TITLE
fix(verify): `verifyTokenWithMethod` should update already verified session status

### DIFF
--- a/db-server/test/backend/db_tests.js
+++ b/db-server/test/backend/db_tests.js
@@ -1956,6 +1956,30 @@ module.exports = function (config, DB) {
           })
       })
 
+      it('should update session verificationMethod', () => {
+        const verifyOptions = {
+          verificationMethod: 'totp-2fa'
+        }
+        return db.verifyTokens(sessionToken.tokenVerificationId, account)
+          .then(() => {
+            return db.sessionToken(tokenId)
+          }, assert.fail)
+          .then((token) => {
+            assert.equal(token.mustVerify, false, 'mustVerify is false')
+            assert.equal(token.tokenVerificationId, null, 'tokenVerificationId is null')
+            assert.equal(token.verificationMethod, null, 'verificationMethod is null')
+            return db.verifyTokensWithMethod(tokenId, verifyOptions)
+          })
+          .then(() => {
+            return db.sessionToken(tokenId)
+          }, assert.fail)
+          .then((token) => {
+            assert.equal(token.mustVerify, false, 'mustVerify is false')
+            assert.equal(token.tokenVerificationId, null, 'tokenVerificationId is null')
+            assert.equal(token.verificationMethod, 2, 'verificationMethod is set')
+          })
+      })
+
       it('should fail to verify unknown verification method', () => {
         const verifyOptions = {
           verificationMethod: 'super-invalid-method'

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -558,7 +558,7 @@ module.exports = function (log, error) {
     item.authAt = sessionTokens[id].authAt || sessionTokens[id].createdAt
     item.verificationMethod = sessionTokens[id].verificationMethod || null
     item.verifiedAt = sessionTokens[id].verifiedAt || null
-    item.mustVerify = sessionTokens[id].mustVerify || null
+    item.mustVerify = !! sessionTokens[id].mustVerify
 
     var accountId = sessionTokens[id].uid.toString('hex')
     var account = accounts[accountId]

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -1388,7 +1388,7 @@ module.exports = function (log, error) {
     })
   }
 
-  const VERIFY_SESSION_WITH_METHOD = 'CALL verifyTokensWithMethod_1(?, ?, ?)'
+  const VERIFY_SESSION_WITH_METHOD = 'CALL verifyTokensWithMethod_2(?, ?, ?)'
   MySql.prototype.verifyTokensWithMethod = function (tokenId, data) {
     return P.resolve()
       .then(() => {

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 75
+module.exports.level = 76

--- a/lib/db/schema/patch-075-076.sql
+++ b/lib/db/schema/patch-075-076.sql
@@ -1,0 +1,36 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CREATE PROCEDURE `verifyTokensWithMethod_2` (
+  IN `tokenIdArg` BINARY(32),
+  IN `verificationMethodArg` INT,
+  IN `verifiedAtArg` BIGINT(1)
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+    -- Update session verification methods
+    UPDATE `sessionTokens` SET verificationMethod = verificationMethodArg, verifiedAt = verifiedAtArg
+    WHERE tokenId = tokenIdArg;
+
+    SET @updateCount = (SELECT ROW_COUNT());
+
+    -- Get the tokenVerificationId and uid for session
+    SET @tokenVerificationId = NULL;
+    SET @uid = NULL;
+    SELECT tokenVerificationId, uid INTO @tokenVerificationId, @uid FROM `unverifiedTokens`
+    WHERE tokenId = tokenIdArg;
+
+    -- Verify tokens with tokenVerificationId
+    CALL verifyToken_3(@tokenVerificationId, @uid);
+  COMMIT;
+
+  SELECT @updateCount;
+END;
+
+UPDATE dbMetadata SET value = '76' WHERE name = 'schema-patch-level';
+

--- a/lib/db/schema/patch-076-075.sql
+++ b/lib/db/schema/patch-076-075.sql
@@ -1,0 +1,6 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DROP PROCEDURE verifyTokensWithMethod_2;
+
+-- UPDATE dbMetadata SET value = '75' WHERE name = 'schema-patch-level';
+


### PR DESCRIPTION
From debugging https://github.com/mozilla/fxa-auth-server/issues/2351, I found that the `verifyTokenWithMethod` stored procedure was not correctly updating an already verified session's verificationMethod. This could help explain why https://github.com/mozilla/fxa-auth-server/pull/2346#discussion_r175366433 happened.

Either way, this PR fixes the issue and matches how the mem db's method works.

