### PR TITLE
fix(unblock): delete unblock codes only when successfully consumed code

### DIFF
--- a/db-server/test/backend/db_tests.js
+++ b/db-server/test/backend/db_tests.js
@@ -1384,6 +1384,23 @@ module.exports = function (config, DB) {
               })
           })
       })
+
+      it('should delete all code when successfully consumed code', () => {
+        return db.consumeUnblockCode(uid1, 'NOTREAL')
+          .then(assert.fail, (err) => {
+            assert.equal(err.code, 404, 'err.code')
+            assert.equal(err.errno, 116, 'err.errno')
+            return db.consumeUnblockCode(uid1, code1)
+          })
+          .then((code) => {
+            assert(code.createdAt <= Date.now(), 'returns unblock code timestamp')
+            return db.consumeUnblockCode(uid1, code2)
+          }, assert.fail)
+          .then(assert.fail, (err) => {
+            assert.equal(err.code, 404, 'err.code')
+            assert.equal(err.errno, 116, 'err.errno')
+          })
+      })
     })
 
     it(

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -848,7 +848,7 @@ module.exports = function (log, error) {
     )
   }
 
-  var CONSUME_UNBLOCK_CODE = 'CALL consumeUnblockCode_2(?, ?)'
+  var CONSUME_UNBLOCK_CODE = 'CALL consumeUnblockCode_3(?, ?)'
 
   MySql.prototype.consumeUnblockCode = function (uid, code) {
     // hash the code since it's like a password

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 77
+module.exports.level = 78

--- a/lib/db/schema/patch-077-078.sql
+++ b/lib/db/schema/patch-077-078.sql
@@ -1,0 +1,28 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CREATE PROCEDURE `consumeUnblockCode_3` (
+    inUid BINARY(16),
+    inCodeHash BINARY(32)
+)
+BEGIN
+    DECLARE timestamp BIGINT;
+
+    SET @timestamp = (
+        SELECT createdAt FROM unblockCodes
+        WHERE
+            uid = inUid
+        AND
+            unblockCodeHash = inCodeHash
+    );
+
+    IF @timestamp > 0 THEN
+        DELETE FROM unblockCodes
+        WHERE
+            uid = inUid;
+    END IF;
+
+    SELECT @timestamp AS createdAt;
+END;
+
+UPDATE dbMetadata SET value = '78' WHERE name = 'schema-patch-level';
+

--- a/lib/db/schema/patch-078-077.sql
+++ b/lib/db/schema/patch-078-077.sql
@@ -1,0 +1,6 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DROP PROCEDURE `consumeUnblockCode_3`;
+
+-- UPDATE dbMetadata SET value = '77' WHERE name = 'schema-patch-level';
+


### PR DESCRIPTION
This was previously deleting all unblock codes whenever it called the `consumeUnblockCode` procedure, regardless if it consumed the code or not.

@vladikoff r?