### PR TITLE
fix(codes): update to latest recovery codes requirements

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -168,6 +168,20 @@ module.exports = function (fs, path, url, convict) {
       default: '',
       format: 'String',
       env: 'SENTRY_DSN'
+    },
+    recoveryCodes: {
+      keyspace: {
+        doc: 'Characters allowed in a recovery code',
+        default: 'abcdefghijklmnopqrstuvwxyz0123456789',
+        format: 'String',
+        env: 'RECOVERY_CODE_KEYSPACE'
+      },
+      length: {
+        doc: 'The length of a recovery code',
+        default: 10,
+        format: 'nat',
+        env: 'RECOVERY_CODE_LENGTH'
+      }
     }
   })
 

--- a/db-server/test/backend/db_tests.js
+++ b/db-server/test/backend/db_tests.js
@@ -2058,11 +2058,16 @@ module.exports = function (config, DB) {
       })
 
       const codeLengthTest = [0, 4, 8]
+      const codeTest = /^[a-zA-Z0-9]{0,20}$/
       codeLengthTest.forEach((num) => {
         it('should generate ' + num + ' recovery codes', () => {
           return db.replaceRecoveryCodes(account.uid, num)
             .then((codes) => {
               assert.equal(codes.length, num, 'correct number of codes')
+              codes.forEach((code) => {
+                assert.equal(codeTest.test(code), true, 'matches recovery code format')
+              })
+              assert.equal()
             }, (err) => {
               assert.equal(err.errno, 116, 'correct errno, not found')
             })

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 78
+module.exports.level = 79

--- a/lib/db/schema/patch-078-079.sql
+++ b/lib/db/schema/patch-078-079.sql
@@ -1,0 +1,55 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+ALTER TABLE recoveryCodes MODIFY COLUMN codeHash BINARY(32);
+
+ALTER TABLE recoveryCodes ADD COLUMN salt BINARY(32);
+
+CREATE PROCEDURE `recoveryCodes_1` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+
+  SELECT * FROM recoveryCodes WHERE uid = uidArg;
+
+END;
+
+CREATE PROCEDURE `consumeRecoveryCode_2` (
+  IN `uidArg` BINARY(16),
+  IN `codeHashArg` BINARY(32)
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  SET @deletedCount = 0;
+
+  DELETE FROM `recoveryCodes` WHERE `uid` = `uidArg` AND `codeHash` = `codeHashArg`;
+
+  SELECT ROW_COUNT() INTO @deletedCount;
+  IF @deletedCount = 0 THEN
+    SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 1643, MESSAGE_TEXT = 'Unknown recovery code.';
+  END IF;
+
+  SELECT COUNT(*) AS count FROM `recoveryCodes` WHERE `uid` = `uidArg`;
+
+  COMMIT;
+END;
+
+CREATE PROCEDURE `createRecoveryCode_2` (
+  IN `uidArg` BINARY(16),
+  IN `codeHashArg` BINARY(32),
+  IN `saltArg` BINARY(32)
+)
+BEGIN
+
+  INSERT INTO recoveryCodes (uid, codeHash, salt, createdAt) VALUES (uidArg, codeHashArg, saltArg, NOW());
+
+END;
+
+UPDATE dbMetadata SET value = '79' WHERE name = 'schema-patch-level';
+

--- a/lib/db/schema/patch-079-078.sql
+++ b/lib/db/schema/patch-079-078.sql
@@ -1,0 +1,12 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- ALTER TABLE recoveryCodes MODIFY COLUMN codeHash BINARY(64),
+-- ALGORITHM = COPY, LOCK = SHARED;
+-- ALTER TABLE recoveryCodes DROP COLUMN salt BINARY(32),
+-- ALGORITHM = COPY, LOCK = SHARED;
+-- DROP recoveryCodes_1;
+-- DROP consumeRecoveryCode_2;
+-- DROP createRecoveryCode_2;
+
+-- UPDATE dbMetadata SET value = '78' WHERE name = 'schema-patch-level';
+

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -83,7 +83,7 @@
     "eslint-plugin-fxa": {
       "version": "1.0.0",
       "from": "git+https://github.com/mozilla/eslint-plugin-fxa.git#master",
-      "resolved": "git+https://github.com/mozilla/eslint-plugin-fxa.git#41504c9dd30e8b52900c15b524946aa0428aef95"
+      "resolved": "git+https://github.com/mozilla/eslint-plugin-fxa.git#e082927b4c6dc17d21414e35f4c94312adbaba92"
     },
     "fxa-conventional-changelog": {
       "version": "1.1.0",
@@ -210,9 +210,16 @@
               "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
               "dependencies": {
                 "iconv-lite": {
-                  "version": "0.4.19",
+                  "version": "0.4.21",
                   "from": "iconv-lite@>=0.4.13 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+                  "dependencies": {
+                    "safer-buffer": {
+                      "version": "2.1.2",
+                      "from": "safer-buffer@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
+                    }
+                  }
                 }
               }
             }
@@ -331,9 +338,9 @@
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
                   "dependencies": {
                     "hosted-git-info": {
-                      "version": "2.5.0",
+                      "version": "2.6.0",
                       "from": "hosted-git-info@>=2.1.4 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz"
+                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz"
                     },
                     "is-builtin-module": {
                       "version": "1.0.0",
@@ -353,26 +360,38 @@
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
                     },
                     "validate-npm-package-license": {
-                      "version": "3.0.1",
+                      "version": "3.0.3",
                       "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
                       "dependencies": {
                         "spdx-correct": {
-                          "version": "1.0.2",
-                          "from": "spdx-correct@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                          "version": "3.0.0",
+                          "from": "spdx-correct@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
                           "dependencies": {
                             "spdx-license-ids": {
-                              "version": "1.2.2",
-                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+                              "version": "3.0.0",
+                              "from": "spdx-license-ids@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz"
                             }
                           }
                         },
                         "spdx-expression-parse": {
-                          "version": "1.0.4",
-                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+                          "version": "3.0.0",
+                          "from": "spdx-expression-parse@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+                          "dependencies": {
+                            "spdx-exceptions": {
+                              "version": "2.1.0",
+                              "from": "spdx-exceptions@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz"
+                            },
+                            "spdx-license-ids": {
+                              "version": "3.0.0",
+                              "from": "spdx-license-ids@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz"
+                            }
+                          }
                         }
                       }
                     }
@@ -669,9 +688,9 @@
           "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.0.tgz"
         },
         "grunt-legacy-log": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "from": "grunt-legacy-log@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.1.tgz",
           "dependencies": {
             "colors": {
               "version": "1.1.2",
@@ -742,14 +761,26 @@
               "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
             },
             "lodash": {
-              "version": "3.10.1",
-              "from": "lodash@>=3.10.1 <3.11.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+              "version": "4.17.5",
+              "from": "lodash@>=4.17.5 <4.18.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz"
             },
             "underscore.string": {
-              "version": "3.2.3",
-              "from": "underscore.string@>=3.2.3 <3.3.0",
-              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz"
+              "version": "3.3.4",
+              "from": "underscore.string@>=3.3.4 <3.4.0",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+              "dependencies": {
+                "sprintf-js": {
+                  "version": "1.1.1",
+                  "from": "sprintf-js@>=1.0.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                }
+              }
             }
           }
         },
@@ -798,9 +829,16 @@
           }
         },
         "iconv-lite": {
-          "version": "0.4.19",
+          "version": "0.4.21",
           "from": "iconv-lite@>=0.4.13 <0.5.0",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+          "dependencies": {
+            "safer-buffer": {
+              "version": "2.1.2",
+              "from": "safer-buffer@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
+            }
+          }
         },
         "js-yaml": {
           "version": "3.5.5",
@@ -938,24 +976,24 @@
           }
         },
         "concat-stream": {
-          "version": "1.6.0",
+          "version": "1.6.2",
           "from": "concat-stream@>=1.5.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "dependencies": {
+            "buffer-from": {
+              "version": "1.0.0",
+              "from": "buffer-from@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz"
+            },
             "inherits": {
               "version": "2.0.3",
               "from": "inherits@>=2.0.3 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
-            "typedarray": {
-              "version": "0.0.6",
-              "from": "typedarray@>=0.0.6 <0.0.7",
-              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-            },
             "readable-stream": {
-              "version": "2.3.4",
+              "version": "2.3.6",
               "from": "readable-stream@>=2.2.2 <3.0.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
@@ -978,9 +1016,9 @@
                   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
                 },
                 "string_decoder": {
-                  "version": "1.0.3",
-                  "from": "string_decoder@>=1.0.3 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                  "version": "1.1.1",
+                  "from": "string_decoder@>=1.1.1 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
@@ -988,6 +1026,11 @@
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "from": "typedarray@>=0.0.6 <0.0.7",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             }
           }
         },
@@ -1041,9 +1084,9 @@
                       "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz"
                     },
                     "modify-values": {
-                      "version": "1.0.0",
+                      "version": "1.0.1",
                       "from": "modify-values@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz"
                     }
                   }
                 },
@@ -1118,7 +1161,7 @@
                                   "dependencies": {
                                     "align-text": {
                                       "version": "0.1.4",
-                                      "from": "align-text@>=0.1.1 <0.2.0",
+                                      "from": "align-text@>=0.1.3 <0.2.0",
                                       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                       "dependencies": {
                                         "kind-of": {
@@ -1159,7 +1202,7 @@
                                   "dependencies": {
                                     "align-text": {
                                       "version": "0.1.4",
-                                      "from": "align-text@>=0.1.1 <0.2.0",
+                                      "from": "align-text@>=0.1.3 <0.2.0",
                                       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                       "dependencies": {
                                         "kind-of": {
@@ -1306,9 +1349,9 @@
               "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-0.1.0.tgz",
               "dependencies": {
                 "hosted-git-info": {
-                  "version": "2.5.0",
+                  "version": "2.6.0",
                   "from": "hosted-git-info@>=2.1.4 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz"
+                  "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz"
                 },
                 "normalize-package-data": {
                   "version": "2.4.0",
@@ -1328,26 +1371,38 @@
                       }
                     },
                     "validate-npm-package-license": {
-                      "version": "3.0.1",
+                      "version": "3.0.3",
                       "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
                       "dependencies": {
                         "spdx-correct": {
-                          "version": "1.0.2",
-                          "from": "spdx-correct@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                          "version": "3.0.0",
+                          "from": "spdx-correct@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
                           "dependencies": {
                             "spdx-license-ids": {
-                              "version": "1.2.2",
-                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+                              "version": "3.0.0",
+                              "from": "spdx-license-ids@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz"
                             }
                           }
                         },
                         "spdx-expression-parse": {
-                          "version": "1.0.4",
-                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+                          "version": "3.0.0",
+                          "from": "spdx-expression-parse@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+                          "dependencies": {
+                            "spdx-exceptions": {
+                              "version": "2.1.0",
+                              "from": "spdx-exceptions@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz"
+                            },
+                            "spdx-license-ids": {
+                              "version": "3.0.0",
+                              "from": "spdx-license-ids@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz"
+                            }
+                          }
                         }
                       }
                     }
@@ -1456,9 +1511,295 @@
               }
             },
             "git-semver-tags": {
-              "version": "1.3.2",
+              "version": "1.3.6",
               "from": "git-semver-tags@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.2.tgz"
+              "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.6.tgz",
+              "dependencies": {
+                "meow": {
+                  "version": "4.0.0",
+                  "from": "meow@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "4.2.0",
+                      "from": "camelcase-keys@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "4.1.0",
+                          "from": "camelcase@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
+                        },
+                        "map-obj": {
+                          "version": "2.0.0",
+                          "from": "map-obj@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz"
+                        },
+                        "quick-lru": {
+                          "version": "1.1.0",
+                          "from": "quick-lru@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz"
+                        }
+                      }
+                    },
+                    "decamelize-keys": {
+                      "version": "1.1.0",
+                      "from": "decamelize-keys@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+                      "dependencies": {
+                        "decamelize": {
+                          "version": "1.2.0",
+                          "from": "decamelize@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.1",
+                          "from": "map-obj@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "loud-rejection": {
+                      "version": "1.6.0",
+                      "from": "loud-rejection@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+                      "dependencies": {
+                        "currently-unhandled": {
+                          "version": "0.4.1",
+                          "from": "currently-unhandled@>=0.4.1 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+                          "dependencies": {
+                            "array-find-index": {
+                              "version": "1.0.2",
+                              "from": "array-find-index@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "signal-exit": {
+                          "version": "3.0.2",
+                          "from": "signal-exit@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+                        }
+                      }
+                    },
+                    "minimist": {
+                      "version": "1.2.0",
+                      "from": "minimist@>=1.1.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                    },
+                    "minimist-options": {
+                      "version": "3.0.2",
+                      "from": "minimist-options@>=3.0.1 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+                      "dependencies": {
+                        "arrify": {
+                          "version": "1.0.1",
+                          "from": "arrify@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                        },
+                        "is-plain-obj": {
+                          "version": "1.1.0",
+                          "from": "is-plain-obj@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
+                        }
+                      }
+                    },
+                    "normalize-package-data": {
+                      "version": "2.4.0",
+                      "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+                      "dependencies": {
+                        "hosted-git-info": {
+                          "version": "2.6.0",
+                          "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz"
+                        },
+                        "is-builtin-module": {
+                          "version": "1.0.0",
+                          "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                          "dependencies": {
+                            "builtin-modules": {
+                              "version": "1.1.1",
+                              "from": "builtin-modules@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+                            }
+                          }
+                        },
+                        "validate-npm-package-license": {
+                          "version": "3.0.3",
+                          "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+                          "dependencies": {
+                            "spdx-correct": {
+                              "version": "3.0.0",
+                              "from": "spdx-correct@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+                              "dependencies": {
+                                "spdx-license-ids": {
+                                  "version": "3.0.0",
+                                  "from": "spdx-license-ids@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz"
+                                }
+                              }
+                            },
+                            "spdx-expression-parse": {
+                              "version": "3.0.0",
+                              "from": "spdx-expression-parse@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+                              "dependencies": {
+                                "spdx-exceptions": {
+                                  "version": "2.1.0",
+                                  "from": "spdx-exceptions@>=2.1.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz"
+                                },
+                                "spdx-license-ids": {
+                                  "version": "3.0.0",
+                                  "from": "spdx-license-ids@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "read-pkg-up": {
+                      "version": "3.0.0",
+                      "from": "read-pkg-up@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+                      "dependencies": {
+                        "find-up": {
+                          "version": "2.1.0",
+                          "from": "find-up@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                          "dependencies": {
+                            "locate-path": {
+                              "version": "2.0.0",
+                              "from": "locate-path@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                              "dependencies": {
+                                "p-locate": {
+                                  "version": "2.0.0",
+                                  "from": "p-locate@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                                  "dependencies": {
+                                    "p-limit": {
+                                      "version": "1.2.0",
+                                      "from": "p-limit@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+                                      "dependencies": {
+                                        "p-try": {
+                                          "version": "1.0.0",
+                                          "from": "p-try@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "path-exists": {
+                                  "version": "3.0.0",
+                                  "from": "path-exists@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "read-pkg": {
+                          "version": "3.0.0",
+                          "from": "read-pkg@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+                          "dependencies": {
+                            "load-json-file": {
+                              "version": "4.0.0",
+                              "from": "load-json-file@>=4.0.0 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "4.1.11",
+                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                                },
+                                "parse-json": {
+                                  "version": "4.0.0",
+                                  "from": "parse-json@>=4.0.0 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                                  "dependencies": {
+                                    "error-ex": {
+                                      "version": "1.3.1",
+                                      "from": "error-ex@>=1.3.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+                                      "dependencies": {
+                                        "is-arrayish": {
+                                          "version": "0.2.1",
+                                          "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "json-parse-better-errors": {
+                                      "version": "1.0.2",
+                                      "from": "json-parse-better-errors@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "pify": {
+                                  "version": "3.0.0",
+                                  "from": "pify@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
+                                },
+                                "strip-bom": {
+                                  "version": "3.0.0",
+                                  "from": "strip-bom@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+                                }
+                              }
+                            },
+                            "path-type": {
+                              "version": "3.0.0",
+                              "from": "path-type@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                              "dependencies": {
+                                "pify": {
+                                  "version": "3.0.0",
+                                  "from": "pify@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "redent": {
+                      "version": "2.0.0",
+                      "from": "redent@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+                      "dependencies": {
+                        "indent-string": {
+                          "version": "3.2.0",
+                          "from": "indent-string@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz"
+                        },
+                        "strip-indent": {
+                          "version": "2.0.0",
+                          "from": "strip-indent@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "trim-newlines": {
+                      "version": "2.0.0",
+                      "from": "trim-newlines@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz"
+                    }
+                  }
+                }
+              }
             },
             "lodash": {
               "version": "3.10.1",
@@ -1527,9 +1868,9 @@
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
                   "dependencies": {
                     "hosted-git-info": {
-                      "version": "2.5.0",
+                      "version": "2.6.0",
                       "from": "hosted-git-info@>=2.1.4 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz"
+                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz"
                     },
                     "is-builtin-module": {
                       "version": "1.0.0",
@@ -1544,26 +1885,38 @@
                       }
                     },
                     "validate-npm-package-license": {
-                      "version": "3.0.1",
+                      "version": "3.0.3",
                       "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
                       "dependencies": {
                         "spdx-correct": {
-                          "version": "1.0.2",
-                          "from": "spdx-correct@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                          "version": "3.0.0",
+                          "from": "spdx-correct@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
                           "dependencies": {
                             "spdx-license-ids": {
-                              "version": "1.2.2",
-                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+                              "version": "3.0.0",
+                              "from": "spdx-license-ids@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz"
                             }
                           }
                         },
                         "spdx-expression-parse": {
-                          "version": "1.0.4",
-                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+                          "version": "3.0.0",
+                          "from": "spdx-expression-parse@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+                          "dependencies": {
+                            "spdx-exceptions": {
+                              "version": "2.1.0",
+                              "from": "spdx-exceptions@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz"
+                            },
+                            "spdx-license-ids": {
+                              "version": "3.0.0",
+                              "from": "spdx-license-ids@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz"
+                            }
+                          }
                         }
                       }
                     }
@@ -1697,9 +2050,9 @@
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
                   "dependencies": {
                     "hosted-git-info": {
-                      "version": "2.5.0",
+                      "version": "2.6.0",
                       "from": "hosted-git-info@>=2.1.4 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz"
+                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz"
                     },
                     "is-builtin-module": {
                       "version": "1.0.0",
@@ -1714,26 +2067,38 @@
                       }
                     },
                     "validate-npm-package-license": {
-                      "version": "3.0.1",
+                      "version": "3.0.3",
                       "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
                       "dependencies": {
                         "spdx-correct": {
-                          "version": "1.0.2",
-                          "from": "spdx-correct@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                          "version": "3.0.0",
+                          "from": "spdx-correct@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
                           "dependencies": {
                             "spdx-license-ids": {
-                              "version": "1.2.2",
-                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+                              "version": "3.0.0",
+                              "from": "spdx-license-ids@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz"
                             }
                           }
                         },
                         "spdx-expression-parse": {
-                          "version": "1.0.4",
-                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+                          "version": "3.0.0",
+                          "from": "spdx-expression-parse@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+                          "dependencies": {
+                            "spdx-exceptions": {
+                              "version": "2.1.0",
+                              "from": "spdx-exceptions@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz"
+                            },
+                            "spdx-license-ids": {
+                              "version": "3.0.0",
+                              "from": "spdx-license-ids@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz"
+                            }
+                          }
                         }
                       }
                     }
@@ -1829,9 +2194,9 @@
               "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
               "dependencies": {
                 "readable-stream": {
-                  "version": "2.3.4",
+                  "version": "2.3.6",
                   "from": "readable-stream@>=2.1.5 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -1859,9 +2224,9 @@
                       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
                     },
                     "string_decoder": {
-                      "version": "1.0.3",
-                      "from": "string_decoder@>=1.0.3 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                      "version": "1.1.1",
+                      "from": "string_decoder@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
@@ -1960,24 +2325,24 @@
           "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
           "dependencies": {
             "concat-stream": {
-              "version": "1.6.0",
+              "version": "1.6.2",
               "from": "concat-stream@>=1.4.6 <2.0.0",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
               "dependencies": {
+                "buffer-from": {
+                  "version": "1.0.0",
+                  "from": "buffer-from@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz"
+                },
                 "inherits": {
                   "version": "2.0.3",
                   "from": "inherits@>=2.0.3 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
-                "typedarray": {
-                  "version": "0.0.6",
-                  "from": "typedarray@>=0.0.6 <0.0.7",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-                },
                 "readable-stream": {
-                  "version": "2.3.4",
+                  "version": "2.3.6",
                   "from": "readable-stream@>=2.2.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -2000,9 +2365,9 @@
                       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
                     },
                     "string_decoder": {
-                      "version": "1.0.3",
-                      "from": "string_decoder@>=1.0.3 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                      "version": "1.1.1",
+                      "from": "string_decoder@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
@@ -2010,6 +2375,11 @@
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
+                },
+                "typedarray": {
+                  "version": "0.0.6",
+                  "from": "typedarray@>=0.0.6 <0.0.7",
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 }
               }
             },
@@ -2048,9 +2418,16 @@
                   "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz"
                 },
                 "es5-ext": {
-                  "version": "0.10.39",
+                  "version": "0.10.42",
                   "from": "es5-ext@>=0.10.14 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.39.tgz"
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
+                  "dependencies": {
+                    "next-tick": {
+                      "version": "1.0.0",
+                      "from": "next-tick@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz"
+                    }
+                  }
                 },
                 "es6-iterator": {
                   "version": "2.0.3",
@@ -2090,9 +2467,16 @@
                       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz"
                     },
                     "es5-ext": {
-                      "version": "0.10.39",
+                      "version": "0.10.42",
                       "from": "es5-ext@>=0.10.14 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.39.tgz"
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
+                      "dependencies": {
+                        "next-tick": {
+                          "version": "1.0.0",
+                          "from": "next-tick@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz"
+                        }
+                      }
                     },
                     "es6-iterator": {
                       "version": "2.0.3",
@@ -2107,28 +2491,21 @@
                   }
                 },
                 "esrecurse": {
-                  "version": "4.2.0",
+                  "version": "4.2.1",
                   "from": "esrecurse@>=4.1.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-                  "dependencies": {
-                    "object-assign": {
-                      "version": "4.1.1",
-                      "from": "object-assign@>=4.0.1 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-                    }
-                  }
+                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz"
                 }
               }
             },
             "espree": {
-              "version": "3.5.3",
+              "version": "3.5.4",
               "from": "espree@>=3.1.6 <4.0.0",
-              "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.3.tgz",
+              "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "5.4.1",
-                  "from": "acorn@>=5.4.0 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz"
+                  "version": "5.5.3",
+                  "from": "acorn@>=5.5.0 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz"
                 },
                 "acorn-jsx": {
                   "version": "3.0.1",
@@ -2204,9 +2581,9 @@
                           "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
                         },
                         "is-path-in-cwd": {
-                          "version": "1.0.0",
+                          "version": "1.0.1",
                           "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
                           "dependencies": {
                             "is-path-inside": {
                               "version": "1.0.1",
@@ -2533,9 +2910,9 @@
               "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz"
             },
             "js-yaml": {
-              "version": "3.10.0",
+              "version": "3.11.0",
               "from": "js-yaml@>=3.5.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "1.0.10",
@@ -2587,7 +2964,7 @@
             },
             "lodash": {
               "version": "4.17.5",
-              "from": "lodash@>=4.14.0 <5.0.0",
+              "from": "lodash@>=4.0.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz"
             },
             "mkdirp": {
@@ -2852,15 +3229,15 @@
               "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
             },
-            "debug": {
-              "version": "2.6.9",
-              "from": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
-            },
             "deep-extend": {
               "version": "0.4.2",
               "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
               "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz"
+            },
+            "debug": {
+              "version": "2.6.9",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.5",
@@ -3518,10 +3895,15 @@
           }
         },
         "concat-stream": {
-          "version": "1.6.0",
+          "version": "1.6.2",
           "from": "concat-stream@>=1.5.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "dependencies": {
+            "buffer-from": {
+              "version": "1.0.0",
+              "from": "buffer-from@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz"
+            },
             "inherits": {
               "version": "2.0.3",
               "from": "inherits@>=2.0.3 <3.0.0",
@@ -3569,9 +3951,9 @@
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "readable-stream": {
-          "version": "2.3.4",
+          "version": "2.3.6",
           "from": "readable-stream@>=2.1.4 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
@@ -3599,9 +3981,9 @@
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
             },
             "string_decoder": {
-              "version": "1.0.3",
-              "from": "string_decoder@>=1.0.3 <1.1.0",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+              "version": "1.1.1",
+              "from": "string_decoder@>=1.1.1 <1.2.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
             },
             "util-deprecate": {
               "version": "1.0.2",
@@ -3621,9 +4003,9 @@
           "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-2.2.0.tgz",
           "dependencies": {
             "nan": {
-              "version": "2.8.0",
+              "version": "2.10.0",
               "from": "nan@>=2.8.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz"
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz"
             }
           }
         }
@@ -3902,15 +4284,15 @@
           "from": "amdefine@>=0.0.4",
           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
         },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "from": "ansi-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-        },
         "ansi-styles": {
           "version": "2.2.1",
           "from": "ansi-styles@>=2.2.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "from": "ansi-regex@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
         },
         "append-transform": {
           "version": "0.4.0",
@@ -3947,25 +4329,25 @@
           "from": "babel-generator@>=6.18.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz"
         },
-        "babel-runtime": {
-          "version": "6.23.0",
-          "from": "babel-runtime@>=6.22.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-        },
         "babel-messages": {
           "version": "6.23.0",
           "from": "babel-messages@>=6.23.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
         },
-        "babel-traverse": {
-          "version": "6.24.1",
-          "from": "babel-traverse@>=6.18.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz"
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
         },
         "babel-template": {
           "version": "6.24.1",
           "from": "babel-template@>=6.16.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz"
+        },
+        "babel-traverse": {
+          "version": "6.24.1",
+          "from": "babel-traverse@>=6.18.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz"
         },
         "babel-types": {
           "version": "6.24.1",
@@ -3982,6 +4364,11 @@
           "from": "balanced-match@>=0.4.1 <0.5.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
         },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "from": "brace-expansion@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
+        },
         "braces": {
           "version": "1.8.5",
           "from": "braces@>=1.8.2 <2.0.0",
@@ -3992,25 +4379,20 @@
           "from": "builtin-modules@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
         },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "from": "brace-expansion@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
-        },
         "camelcase": {
           "version": "1.2.1",
           "from": "camelcase@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
         },
-        "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
-        },
         "center-align": {
           "version": "0.1.3",
           "from": "center-align@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "from": "chalk@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
         },
         "code-point-at": {
           "version": "1.1.0",
@@ -4057,15 +4439,15 @@
           "from": "error-ex@>=1.2.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
         },
-        "esutils": {
-          "version": "2.0.2",
-          "from": "esutils@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-        },
         "escape-string-regexp": {
           "version": "1.0.5",
           "from": "escape-string-regexp@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "from": "esutils@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
         },
         "expand-brackets": {
           "version": "0.1.5",
@@ -4277,11 +4659,6 @@
           "from": "lazy-cache@>=1.0.3 <2.0.0",
           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
         },
-        "lodash": {
-          "version": "4.17.4",
-          "from": "lodash@>=4.2.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-        },
         "lcid": {
           "version": "1.0.0",
           "from": "lcid@>=1.0.0 <2.0.0",
@@ -4291,6 +4668,11 @@
           "version": "1.1.0",
           "from": "load-json-file@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "from": "lodash@>=4.2.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
         },
         "longest": {
           "version": "1.0.1",
@@ -4322,15 +4704,15 @@
           "from": "minimist@0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         },
-        "normalize-package-data": {
-          "version": "2.3.8",
-          "from": "normalize-package-data@>=2.3.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz"
-        },
         "ms": {
           "version": "0.7.3",
           "from": "ms@0.7.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz"
+        },
+        "normalize-package-data": {
+          "version": "2.3.8",
+          "from": "normalize-package-data@>=2.3.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz"
         },
         "normalize-path": {
           "version": "2.1.1",
@@ -4427,6 +4809,11 @@
           "from": "preserve@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
         },
+        "pseudomap": {
+          "version": "1.0.2",
+          "from": "pseudomap@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+        },
         "randomatic": {
           "version": "1.1.6",
           "from": "randomatic@>=1.1.3 <2.0.0",
@@ -4436,11 +4823,6 @@
           "version": "1.1.0",
           "from": "read-pkg@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "from": "pseudomap@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
         },
         "read-pkg-up": {
           "version": "1.0.1",
@@ -4572,15 +4954,15 @@
           "from": "which@>=1.2.9 <2.0.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
         },
-        "window-size": {
-          "version": "0.1.0",
-          "from": "window-size@0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-        },
         "which-module": {
           "version": "1.0.0",
           "from": "which-module@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "from": "window-size@0.1.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
         },
         "wordwrap": {
           "version": "0.0.3",
@@ -4727,9 +5109,9 @@
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz"
         },
         "aws4": {
-          "version": "1.6.0",
+          "version": "1.7.0",
           "from": "aws4@>=1.6.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz"
         },
         "caseless": {
           "version": "0.12.0",
@@ -4786,9 +5168,9 @@
                   "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
                 },
                 "fast-deep-equal": {
-                  "version": "1.0.0",
+                  "version": "1.1.0",
                   "from": "fast-deep-equal@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz"
                 },
                 "fast-json-stable-stringify": {
                   "version": "2.0.0",
@@ -4883,9 +5265,9 @@
               }
             },
             "sshpk": {
-              "version": "1.13.1",
+              "version": "1.14.1",
               "from": "sshpk@>=1.7.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
               "dependencies": {
                 "asn1": {
                   "version": "0.2.3",
@@ -4979,9 +5361,9 @@
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
         },
         "tough-cookie": {
-          "version": "2.3.3",
+          "version": "2.3.4",
           "from": "tough-cookie@>=2.3.3 <2.4.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.4.1",
@@ -5035,9 +5417,9 @@
               "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.6.tgz",
               "dependencies": {
                 "nan": {
-                  "version": "2.8.0",
+                  "version": "2.10.0",
                   "from": "nan@>=2.3.3 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz"
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz"
                 }
               }
             },
@@ -5126,14 +5508,14 @@
               }
             },
             "safe-json-stringify": {
-              "version": "1.0.4",
+              "version": "1.1.0",
               "from": "safe-json-stringify@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.4.tgz"
+              "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.1.0.tgz"
             },
             "moment": {
-              "version": "2.20.1",
+              "version": "2.22.0",
               "from": "moment@>=2.10.6 <3.0.0",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz"
+              "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.0.tgz"
             }
           }
         },
@@ -5170,9 +5552,9 @@
           "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
         },
         "formidable": {
-          "version": "1.1.1",
+          "version": "1.2.1",
           "from": "formidable@>=1.0.14 <2.0.0",
-          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz"
         },
         "http-signature": {
           "version": "0.11.0",
@@ -5197,9 +5579,9 @@
           "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
         },
         "lru-cache": {
-          "version": "4.1.1",
+          "version": "4.1.2",
           "from": "lru-cache@>=4.0.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
           "dependencies": {
             "pseudomap": {
               "version": "1.0.2",
@@ -5288,9 +5670,9 @@
               "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz"
             },
             "spdy-transport": {
-              "version": "2.0.20",
+              "version": "2.1.0",
               "from": "spdy-transport@>=2.0.18 <3.0.0",
-              "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.20.tgz",
+              "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
               "dependencies": {
                 "detect-node": {
                   "version": "2.0.3",
@@ -5310,14 +5692,14 @@
                   }
                 },
                 "obuf": {
-                  "version": "1.1.1",
+                  "version": "1.1.2",
                   "from": "obuf@>=1.1.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz"
+                  "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz"
                 },
                 "readable-stream": {
-                  "version": "2.3.4",
+                  "version": "2.3.6",
                   "from": "readable-stream@>=2.2.9 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -5340,9 +5722,9 @@
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz"
                     },
                     "string_decoder": {
-                      "version": "1.0.3",
-                      "from": "string_decoder@>=1.0.3 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                      "version": "1.1.1",
+                      "from": "string_decoder@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
@@ -5352,9 +5734,9 @@
                   }
                 },
                 "wbuf": {
-                  "version": "1.7.2",
+                  "version": "1.7.3",
                   "from": "wbuf@>=1.7.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz",
+                  "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
                   "dependencies": {
                     "minimalistic-assert": {
                       "version": "1.0.0",
@@ -5419,9 +5801,9 @@
           "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz",
           "dependencies": {
             "nan": {
-              "version": "2.8.0",
+              "version": "2.10.0",
               "from": "nan@>=2.0.8 <3.0.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz"
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz"
             }
           }
         }
@@ -5431,6 +5813,23 @@
       "version": "0.2.0",
       "from": "restify-safe-json-formatter@0.2.0",
       "resolved": "https://registry.npmjs.org/restify-safe-json-formatter/-/restify-safe-json-formatter-0.2.0.tgz"
+    },
+    "scrypt-hash": {
+      "version": "1.1.14",
+      "from": "scrypt-hash@1.1.14",
+      "resolved": "https://registry.npmjs.org/scrypt-hash/-/scrypt-hash-1.1.14.tgz",
+      "dependencies": {
+        "bindings": {
+          "version": "1.2.1",
+          "from": "bindings@1.2.1",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
+        },
+        "nan": {
+          "version": "2.4.0",
+          "from": "nan@2.4.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
+        }
+      }
     },
     "sinon": {
       "version": "1.17.5",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "raven": "2.3.0",
     "request": "2.83.0",
     "restify": "4.3.0",
-    "restify-safe-json-formatter": "0.2.0"
+    "restify-safe-json-formatter": "0.2.0",
+    "scrypt-hash": "1.1.14"
   },
   "devDependencies": {
     "eslint-plugin-fxa": "git+https://github.com/mozilla/eslint-plugin-fxa#master",

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -1,0 +1,83 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+const dbUtils = require('../../lib/db/util')
+const assert = require('insist')
+const P = require('bluebird')
+
+describe('utils', () => {
+  it('createHashScrypt', () => {
+    const input = 'somethingcool'
+    return dbUtils.createHashScrypt(input)
+      .then((result) => {
+        assert.ok(result.hash, 'hash exists')
+        assert.ok(result.salt, 'salt exists')
+        assert.equal(result.hash.length, 32)
+        assert.equal(result.salt.length, 32)
+      })
+  })
+
+  describe('compareHashScrypt', () => {
+    const inputA = 'thing1', inputB = 'thing2'
+    let resultA, resultB
+
+    before(() => {
+      return P.all([dbUtils.createHashScrypt(inputA), dbUtils.createHashScrypt(inputB)])
+        .spread((hashA, hashB) => {
+          resultA = hashA
+          resultB = hashB
+        })
+    })
+
+    it('should fail for different input', () => {
+      return dbUtils.compareHashScrypt(inputA, resultB.hash, resultB.salt)
+        .then((result) => {
+          assert.equal(result, false, 'strings do not match')
+          return dbUtils.compareHashScrypt(inputB, resultA.hash, resultA.salt)
+        })
+        .then((result) => {
+          assert.equal(result, false, 'strings do not match')
+        })
+    })
+
+    it('should succeed for same input', () => {
+      return dbUtils.compareHashScrypt(inputA, resultA.hash, resultA.salt)
+        .then((result) => {
+          assert.equal(result, true, 'strings do match')
+        })
+    })
+  })
+
+  describe('generateRecoveryCodes', () => {
+    const codeLength = 10, codeCount = 5, keyspace = 'abcdefghijklmnopqrstuvwxyz0123456789'
+    let codes
+    before(() => {
+      return dbUtils.generateRecoveryCodes(codeCount, keyspace, codeLength)
+        .then((result) => codes = result)
+    })
+
+    it('should not fail for empty keyspace', () => {
+      return dbUtils.generateRecoveryCodes(1, '', 1)
+        .then((result) => {
+          assert.equal(result[0], '')
+        })
+    })
+
+    it('should generate correct count of codes', () => {
+      assert.equal(codes.length, codeCount, 'correct number of codees generated')
+    })
+
+    it('should generate correct length of code', () => {
+      codes.forEach((code) => {
+        assert.equal(code.length, codeLength, 'code is correct length')
+      })
+    })
+
+    it('should generate code in keyspace', () => {
+      const reg = /[a-z0-9]/
+      codes.forEach((code) => {
+        assert.equal(reg.test(code), true, 'code is in correct keyspace')
+      })
+    })
+  })
+})


### PR DESCRIPTION
I was going through and reviewing requirements for recovery codes and found that there are some differences in implementation

* Should be 10 characters vs current 8
* Should be alphanumeric vs hex
* Should use scrypt/bcrypt vs sha

Ref https://docs.google.com/document/d/1m4D_7DZAfXt4e-bEbfI-5s_x2XFO7TEQo1a_SQcj1O8/edit#heading=h.yzz637baqr7a