### PR TITLE
feat(mysql): Add config option for REQUIRED_SQL_MODES.

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -70,6 +70,12 @@ module.exports = function (fs, path, url, convict) {
       format: 'duration',
       env: 'SIGNIN_CODES_MAX_AGE',
     },
+    requiredSQLModes: {
+      doc: 'Comma-separated list of SQL mode flags to enforce on each connection',
+      default: '',
+      format: 'String',
+      env: 'REQUIRED_SQL_MODES',
+    },
     master: {
       user: {
         doc: 'The user to connect to for MySql',


### PR DESCRIPTION
This also tweaks the implementation to preserve any existing mode flags on the connection, rather than overwriting them with just the modes from the required list.  That's in line with how profile-server and oauth-server approach it.

@vladikoff r?