### PR TITLE
fix(devices): Rename pushbox capability to messages

### DIFF
--- a/db-server/test/backend/db_tests.js
+++ b/db-server/test/backend/db_tests.js
@@ -100,7 +100,7 @@ function makeMockDevice(tokenId) {
     callbackPublicKey: 'foo',
     callbackAuthKey: 'bar',
     callbackIsExpired: false,
-    capabilities: ['pushbox']
+    capabilities: ['messages']
   }
   device.deviceId = newUuid()
   return device
@@ -476,7 +476,7 @@ module.exports = function (config, DB) {
               assert.equal(sessions[0].deviceCallbackPublicKey, 'foo')
               assert.equal(sessions[0].deviceCallbackAuthKey, 'bar')
               assert.equal(sessions[0].deviceCallbackIsExpired, false)
-              assert.deepEqual(sessions[0].deviceCapabilities, ['pushbox'])
+              assert.deepEqual(sessions[0].deviceCapabilities, ['messages'])
             })
         })
 
@@ -994,7 +994,7 @@ module.exports = function (config, DB) {
 
       it('should fail to update a device with unknown capabilities', () => {
         const newDevice = Object.assign({}, deviceInfo, {
-          capabilities: ['unknown', 'newpushbox']
+          capabilities: ['unknown', 'newmessages']
         })
         return db.updateDevice(accountData.uid, deviceInfo.deviceId, newDevice)
           .then(assert.fail, (err) => {
@@ -1002,7 +1002,7 @@ module.exports = function (config, DB) {
             assert.equal(err.errno, 139, 'err.errno')
             return db.accountDevices(accountData.uid)
           })
-          .then((devices) => assert.deepEqual(devices[0].capabilities, ['pushbox']))
+          .then((devices) => assert.deepEqual(devices[0].capabilities, ['messages']))
       })
 
       it('capabilities are not cleared if not specified', () => {
@@ -1012,7 +1012,7 @@ module.exports = function (config, DB) {
           .then(() => {
             return db.accountDevices(accountData.uid)
           })
-          .then((devices) => assert.deepEqual(devices[0].capabilities, ['pushbox']))
+          .then((devices) => assert.deepEqual(devices[0].capabilities, ['messages']))
       })
 
       it('capabilities are overwritten on update', () => {

--- a/db-server/test/backend/remote.js
+++ b/db-server/test/backend/remote.js
@@ -528,7 +528,7 @@ module.exports = function(cfg, makeServer) {
             assert(s.deviceCallbackPublicKey)
             assert.equal(s.deviceCallbackURL, 'fake callback URL')
             assert.equal(s.deviceCallbackIsExpired, false)
-            assert.deepEqual(s.deviceCapabilities, ['pushbox'])
+            assert.deepEqual(s.deviceCapabilities, ['messages'])
             assert(s.deviceCreatedAt)
             assert(s.deviceId)
             assert.equal(s.deviceName, 'fake device name')
@@ -599,7 +599,7 @@ module.exports = function(cfg, makeServer) {
           .then(function(r) {
             assert.equal(r.obj.length, 0, 'devices is empty')
             const myDevice = Object.assign({}, user.device, {
-              capabilities: ['unknown', 'pushbox']
+              capabilities: ['unknown', 'messages']
             })
             return client.putThen('/account/' + user.accountId + '/device/' + user.deviceId, myDevice)
             .then(() => {

--- a/db-server/test/fake.js
+++ b/db-server/test/fake.js
@@ -76,7 +76,7 @@ module.exports.newUserDataHex = function() {
     callbackPublicKey: base64_65(),
     callbackAuthKey: base64_16(),
     callbackIsExpired: false,
-    capabilities: ['pushbox']
+    capabilities: ['messages']
   }
 
   // keyFetchToken

--- a/docs/API.md
+++ b/docs/API.md
@@ -666,7 +666,7 @@ Content-Type: application/json
         "callbackPublicKey": "BCp93zru09_hab2Bg37LpTNG__Pw6eMPEP2hrQpwuytoj3h4chXpGc-3qqdKyqjuvAiEupsnOd_RLyc7erJHWgA",
         "callbackAuthKey": "w3b14Zjc-Afj2SDOLOyong",
         "callbackIsExpired": false,
-        "capabilities": ["pushbox"],
+        "capabilities": ["messages"],
         "uaBrowser": "Firefox",
         "uaBrowserVersion": "42",
         "uaOS": "Android",
@@ -725,7 +725,7 @@ Content-Type: application/json
     "callbackPublicKey": "BCp93zru09_hab2Bg37LpTNG__Pw6eMPEP2hrQpwuytoj3h4chXpGc-3qqdKyqjuvAiEupsnOd_RLyc7erJHWgA",
     "callbackAuthKey": "w3b14Zjc-Afj2SDOLOyong",
     "callbackIsExpired": false,
-    "capabilities": ["pushbox"]
+    "capabilities": ["messages"]
 }
 ```
 
@@ -761,7 +761,7 @@ curl \
       "callbackPublicKey": "BCp93zru09_hab2Bg37LpTNG__Pw6eMPEP2hrQpwuytoj3h4chXpGc-3qqdKyqjuvAiEupsnOd_RLyc7erJHWgA",
       "callbackAuthKey": "w3b14Zjc-Afj2SDOLOyong",
       "callbackIsExpired": false,
-      "capabilities": ["pushbox"]
+      "capabilities": ["messages"]
     }'
 ```
 
@@ -810,7 +810,7 @@ curl \
       "callbackPublicKey": "BCp93zru09_hab2Bg37LpTNG__Pw6eMPEP2hrQpwuytoj3h4chXpGc-3qqdKyqjuvAiEupsnOd_RLyc7erJHWgA",
       "callbackAuthKey": "w3b14Zjc-Afj2SDOLOyong",
       "callbackIsExpired": false,
-      "capabilities": ["pushbox"]
+      "capabilities": ["messages"]
     }'
 ```
 
@@ -924,7 +924,7 @@ Content-Length: 285
     "deviceCallbackURL":null,
     "deviceCallbackPublicKey":null,
     "deviceCallbackIsExpired":false,
-    "deviceCapabilities":["pushbox"],
+    "deviceCapabilities":["messages"],
     "mustVerify":true,
     "tokenVerificationId":"12c41fac80fd6149f3f695e188b5f846"
 }
@@ -991,7 +991,7 @@ Content-Length: 285
     "deviceCallbackURL":null,
     "deviceCallbackPublicKey":null,
     "deviceCallbackIsExpired":false,
-    "deviceCapabilities":["pushbox"],
+    "deviceCapabilities":["messages"],
     "mustVerify":true,
     "tokenVerificationId":"12c41fac80fd6149f3f695e188b5f846"
 }

--- a/lib/db/util.js
+++ b/lib/db/util.js
@@ -42,10 +42,10 @@ const VERIFICATION_METHODS = new Map([
 
 // If you modify one of these maps, modify the other.
 const DEVICE_CAPABILITIES = new Map([
-  ['pushbox', 1]
+  ['messages', 1]
 ])
 const DEVICE_CAPABILITIES_IDS = new Map([
-  [1, 'pushbox']
+  [1, 'messages']
 ])
 
 module.exports = {

--- a/lib/db/util.js
+++ b/lib/db/util.js
@@ -42,10 +42,12 @@ const VERIFICATION_METHODS = new Map([
 
 // If you modify one of these maps, modify the other.
 const DEVICE_CAPABILITIES = new Map([
-  ['messages', 1]
+  ['messages', 1],
+  ['messages.sendtab', 2]
 ])
 const DEVICE_CAPABILITIES_IDS = new Map([
-  [1, 'messages']
+  [1, 'messages'],
+  [2, 'messages.sendtab']
 ])
 
 module.exports = {


### PR DESCRIPTION
This is safe as we have no existing clients using capabilities yet and capabilities are stored as integers.