### PR TITLE
fix(codes): remove current recovery codes before applying migration 79

### DIFF
--- a/lib/db/schema/patch-078-079.sql
+++ b/lib/db/schema/patch-078-079.sql
@@ -1,5 +1,9 @@
 SET NAMES utf8mb4 COLLATE utf8mb4_bin;
 
+-- Since we are altering the size of the `codeHash` column
+-- we need to make sure that the column is empty before it can be applied
+DELETE from recoveryCodes;
+
 ALTER TABLE recoveryCodes MODIFY COLUMN codeHash BINARY(32);
 
 ALTER TABLE recoveryCodes ADD COLUMN salt BINARY(32);


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-auth-db-mysql/issues/336