### PR TITLE
fix(tests): increase timeout on recovery code tests

### DIFF
--- a/db-server/test/backend/db_tests.js
+++ b/db-server/test/backend/db_tests.js
@@ -2089,7 +2089,11 @@ module.exports = function (config, DB) {
           })
       })
 
-      describe('should consume recovery codes', () => {
+      describe('should consume recovery codes', function () {
+        // Consuming recovery codes is more time intensive since the scrypt hashes need
+        // to be compared. Let set timeout higher than 2s default.
+        this.timeout(12000)
+
         let recoveryCodes
         beforeEach(() => {
           return db.replaceRecoveryCodes(account.uid, 2)

--- a/db-server/test/backend/remote.js
+++ b/db-server/test/backend/remote.js
@@ -1685,7 +1685,11 @@ module.exports = function(cfg, makeServer) {
       })
     })
 
-    describe('recovery codes', () => {
+    describe('recovery codes', function () {
+      // Consuming recovery codes is more time intensive since the scrypt hashes need
+      // to be compared. Let set timeout higher than 2s default.
+      this.timeout(12000)
+
       let user
       beforeEach(() => {
         user = fake.newUserDataHex()


### PR DESCRIPTION
This PR increases timeout for recovery code related tests and fixes https://github.com/mozilla/fxa-auth-db-mysql/issues/338. Doing recovery code comparisons (with scrypt) was taking longer than the default 2 second timeout for tests.

```
    recovery codes
      ✓ should generate new recovery codes (1469ms)
      ✓ should fail to consume unknown recovery code
      ✓ should consume recovery code (3193ms)
```

@mozilla/fxa-devs r?