### PR TITLE
fix(restify): set a sane max param length value for restify

### DIFF
--- a/db-server/index.js
+++ b/db-server/index.js
@@ -51,7 +51,9 @@ function createServer(db) {
     formatters: {
       'application/json; q=0.9': safeJsonFormatter
     },
-    maxParamLength: 256
+    // Auth-server accepts 255 unicode email address and sends them over has hex encoded values.
+    // These values could be as large as 1530 characters.
+    maxParamLength: 1530
   })
 
   api.use(restify.plugins.bodyParser())

--- a/db-server/index.js
+++ b/db-server/index.js
@@ -50,7 +50,8 @@ function createServer(db) {
   const api = restify.createServer({
     formatters: {
       'application/json; q=0.9': safeJsonFormatter
-    }
+    },
+    maxParamLength: 256
   })
 
   api.use(restify.plugins.bodyParser())


### PR DESCRIPTION
The new restify uses `find-my-way` router module which defaults to max param size of [100](https://github.com/delvedor/find-my-way/blob/15b6e94667fae12a35f6eccc5f0670428dec4a20/index.js#L35). When using email routes, they could be over 100 characters after being hexed and potentially produce a 404.

Connects to https://github.com/mozilla/fxa-auth-server/issues/2433