### PR TITLE
Let devices register "available commands" with associated metadata.

### DIFF
--- a/db-server/lib/error.js
+++ b/db-server/lib/error.js
@@ -83,17 +83,6 @@ AppError.invalidVerificationMethod = function () {
   )
 }
 
-AppError.unknownDeviceCapability = function () {
-  return new AppError(
-    {
-      code: 400,
-      error: 'Bad request',
-      errno: 139,
-      message: 'Unknown device capability'
-    }
-  )
-}
-
 AppError.wrap = function (err) {
   // Don't re-wrap!
   if (err instanceof AppError) {

--- a/db-server/test/backend/db_tests.js
+++ b/db-server/test/backend/db_tests.js
@@ -100,7 +100,9 @@ function makeMockDevice(tokenId) {
     callbackPublicKey: 'foo',
     callbackAuthKey: 'bar',
     callbackIsExpired: false,
-    capabilities: ['messages']
+    availableCommands: {
+      'https://identity.mozilla.com/cmd/display-uri': 'metadata-bundle'
+    }
   }
   device.deviceId = newUuid()
   return device
@@ -484,7 +486,6 @@ module.exports = function (config, DB) {
               assert.equal(sessions[0].deviceCallbackPublicKey, 'foo')
               assert.equal(sessions[0].deviceCallbackAuthKey, 'bar')
               assert.equal(sessions[0].deviceCallbackIsExpired, false)
-              assert.deepEqual(sessions[0].deviceCapabilities, ['messages'])
             })
         })
 
@@ -899,6 +900,22 @@ module.exports = function (config, DB) {
       })
 
       it('should have created device', () => {
+        return db.device(sessionTokenData.uid, deviceInfo.deviceId)
+          .then((d) => {
+            assert.deepEqual(d.uid, sessionTokenData.uid, 'uid')
+            assert.deepEqual(d.id, deviceInfo.deviceId, 'id')
+            assert.equal(d.name, deviceInfo.name, 'name')
+            assert.equal(d.type, deviceInfo.type, 'type')
+            assert.equal(d.createdAt, deviceInfo.createdAt, 'createdAt')
+            assert.equal(d.callbackURL, deviceInfo.callbackURL, 'callbackURL')
+            assert.equal(d.callbackPublicKey, deviceInfo.callbackPublicKey, 'callbackPublicKey')
+            assert.equal(d.callbackAuthKey, deviceInfo.callbackAuthKey, 'callbackAuthKey')
+            assert.equal(d.callbackIsExpired, deviceInfo.callbackIsExpired, 'callbackIsExpired')
+            assert.deepEqual(d.availableCommands, deviceInfo.availableCommands, 'availableCommands')
+          })
+      })
+
+      it('should have linked device to session token', () => {
         return db.sessionToken(sessionTokenData.tokenId)
           .then((s) => {
             assert.deepEqual(s.deviceId, deviceInfo.deviceId, 'id')
@@ -910,7 +927,7 @@ module.exports = function (config, DB) {
             assert.equal(s.deviceCallbackPublicKey, deviceInfo.callbackPublicKey, 'callbackPublicKey')
             assert.equal(s.deviceCallbackAuthKey, deviceInfo.callbackAuthKey, 'callbackAuthKey')
             assert.equal(s.deviceCallbackIsExpired, deviceInfo.callbackIsExpired, 'callbackIsExpired')
-            assert.deepEqual(s.deviceCapabilities, deviceInfo.capabilities, 'capabilities')
+            assert.deepEqual(s.deviceAvailableCommands, deviceInfo.availableCommands, 'availableCommands')
             assert.equal(!! s.mustVerify, !! sessionTokenData.mustVerify, 'mustVerify is correct')
             assert.deepEqual(s.tokenVerificationId, sessionTokenData.tokenVerificationId, 'tokenVerificationId is correct')
           })
@@ -930,9 +947,8 @@ module.exports = function (config, DB) {
             assert.equal(device.callbackPublicKey, deviceInfo.callbackPublicKey, 'callbackPublicKey')
             assert.equal(device.callbackAuthKey, deviceInfo.callbackAuthKey, 'callbackAuthKey')
             assert.equal(device.callbackIsExpired, deviceInfo.callbackIsExpired, 'callbackIsExpired')
-            assert.deepEqual(device.capabilities, deviceInfo.capabilities, 'capabilities')
+            assert.deepEqual(device.availableCommands, deviceInfo.availableCommands, 'availableCommands')
             assert(device.lastAccessTime > 0, 'has a lastAccessTime')
-            assert.equal(device.email, accountData.email, 'email should be account email')
           })
       })
 
@@ -943,7 +959,7 @@ module.exports = function (config, DB) {
         deviceInfo.callbackPublicKey = ''
         deviceInfo.callbackAuthKey = ''
         deviceInfo.callbackIsExpired = true
-        deviceInfo.capabilities = []
+        deviceInfo.availableCommands = {}
 
         const newSessionTokenData = makeMockSessionToken(accountData.uid)
         deviceInfo.sessionTokenId = newSessionTokenData.tokenId
@@ -966,7 +982,7 @@ module.exports = function (config, DB) {
             assert.equal(device.callbackPublicKey, '', 'callbackPublicKey unchanged')
             assert.equal(device.callbackAuthKey, '', 'callbackAuthKey unchanged')
             assert.equal(device.callbackIsExpired, true, 'callbackIsExpired unchanged')
-            assert.deepEqual(device.capabilities, [], 'capabilities updated')
+            assert.deepEqual(device.availableCommands, {}, 'availableCommands updated')
           })
       })
 
@@ -1000,38 +1016,48 @@ module.exports = function (config, DB) {
           })
       })
 
-      it('should fail to update a device with unknown capabilities', () => {
-        const newDevice = Object.assign({}, deviceInfo, {
-          capabilities: ['unknown', 'newmessages']
-        })
-        return db.updateDevice(accountData.uid, deviceInfo.deviceId, newDevice)
-          .then(assert.fail, (err) => {
-            assert.equal(err.code, 400, 'err.code')
-            assert.equal(err.errno, 139, 'err.errno')
-            return db.accountDevices(accountData.uid)
-          })
-          .then((devices) => assert.deepEqual(devices[0].capabilities, ['messages']))
-      })
-
-      it('capabilities are not cleared if not specified', () => {
+      it('availableCommands are not cleared if not specified', () => {
         const newDevice = Object.assign({}, deviceInfo)
-        delete newDevice.capabilities
+        delete newDevice.availableCommands
         return db.updateDevice(accountData.uid, deviceInfo.deviceId, newDevice)
           .then(() => {
-            return db.accountDevices(accountData.uid)
+            return db.device(accountData.uid, deviceInfo.deviceId)
           })
-          .then((devices) => assert.deepEqual(devices[0].capabilities, ['messages']))
+          .then(device => assert.deepEqual(device.availableCommands, {
+            'https://identity.mozilla.com/cmd/display-uri': 'metadata-bundle'
+          }))
       })
 
-      it('capabilities are overwritten on update', () => {
+      it('availableCommands are overwritten on update', () => {
         const newDevice = Object.assign({}, deviceInfo, {
-          capabilities: []
+          availableCommands: {
+            foo: 'bar',
+            second: 'command'
+          }
         })
         return db.updateDevice(accountData.uid, deviceInfo.deviceId, newDevice)
           .then(() => {
-            return db.accountDevices(accountData.uid)
+            return db.device(accountData.uid, deviceInfo.deviceId)
           })
-          .then((devices) => assert.deepEqual(devices[0].capabilities, []))
+          .then(device => assert.deepEqual(device.availableCommands, {
+            foo: 'bar',
+            second: 'command'
+          }))
+      })
+
+      it('availableCommands can update metadata on an existing command', () => {
+        const newDevice = Object.assign({}, deviceInfo, {
+          availableCommands: {
+            'https://identity.mozilla.com/cmd/display-uri': 'new-metadata'
+          }
+        })
+        return db.updateDevice(accountData.uid, deviceInfo.deviceId, newDevice)
+          .then(() => {
+            return db.device(accountData.uid, deviceInfo.deviceId)
+          })
+          .then(device => assert.deepEqual(device.availableCommands, {
+            'https://identity.mozilla.com/cmd/display-uri': 'new-metadata'
+          }))
       })
 
       it('should fail to delete non-existent device', () => {
@@ -1039,6 +1065,73 @@ module.exports = function (config, DB) {
           .then(assert.fail, (err) => {
             assert.equal(err.code, 404, 'err.code')
             assert.equal(err.errno, 116, 'err.errno')
+          })
+      })
+
+      it('should correctly handle multiple devices with different availableCommands maps', () => {
+        const sessionToken2 = makeMockSessionToken(accountData.uid)
+        const deviceInfo2 = Object.assign(makeMockDevice(sessionToken2.tokenId), {
+          availableCommands: {
+            'https://identity.mozilla.com/cmd/display-uri': 'device-two-metadata',
+            'extra-command': 'extra-data'
+          }
+        })
+        const sessionToken3 = makeMockSessionToken(accountData.uid)
+        const deviceInfo3 = Object.assign(makeMockDevice(sessionToken3.tokenId), {
+          availableCommands: {}
+        })
+
+        return db.createSessionToken(sessionToken2.tokenId, sessionToken2)
+          .then(() => db.createDevice(accountData.uid, deviceInfo2.deviceId, deviceInfo2))
+          .then(() => db.createSessionToken(sessionToken3.tokenId, sessionToken3))
+          .then(() => db.createDevice(accountData.uid, deviceInfo3.deviceId, deviceInfo3))
+          .then(() => db.accountDevices(accountData.uid))
+          .then(devices => {
+            assert.equal(devices.length, 3, 'devices length 3')
+
+            const device1 = devices.find(d => d.sessionTokenId.equals(sessionTokenData.tokenId))
+            assert.ok(device1, 'found first device')
+            assert.deepEqual(device1.availableCommands, deviceInfo.availableCommands, 'device1 availableCommands')
+
+            const device2 = devices.find(d => d.sessionTokenId.equals(sessionToken2.tokenId))
+            assert.ok(device2, 'found second device')
+            assert.deepEqual(device2.availableCommands, deviceInfo2.availableCommands, 'device2 availableCommands')
+
+            const device3 = devices.find(d => d.sessionTokenId.equals(sessionToken3.tokenId))
+            assert.ok(device3, 'found third device')
+            assert.deepEqual(device3.availableCommands, deviceInfo3.availableCommands, 'device3 availableCommands')
+          })
+      })
+
+      it('should correctly handle multiple sessions with different availableCommands maps', () => {
+        const sessionToken2 = makeMockSessionToken(accountData.uid)
+        const deviceInfo2 = Object.assign(makeMockDevice(sessionToken2.tokenId), {
+          availableCommands: {
+            'https://identity.mozilla.com/cmd/display-uri': 'device-two-metadata',
+            'extra-command': 'extra-data'
+          }
+        })
+        const sessionToken3 = makeMockSessionToken(accountData.uid)
+
+        return db.createSessionToken(sessionToken2.tokenId, sessionToken2)
+          .then(() => db.createDevice(accountData.uid, deviceInfo2.deviceId, deviceInfo2))
+          .then(() => db.createSessionToken(sessionToken3.tokenId, sessionToken3))
+          .then(() => db.sessions(accountData.uid))
+          .then(sessions => {
+            assert.equal(sessions.length, 3, 'sessions length 3')
+
+            const session1 = sessions.find(s => s.tokenId.equals(sessionTokenData.tokenId))
+            assert.ok(session1, 'found first session')
+            assert.deepEqual(session1.deviceAvailableCommands, deviceInfo.availableCommands, 'session1 availableCommands')
+
+            const session2 = sessions.find(s => s.tokenId.equals(sessionToken2.tokenId))
+            assert.ok(session2, 'found second session')
+            assert.deepEqual(session2.deviceAvailableCommands, deviceInfo2.availableCommands, 'session2 availableCommands')
+
+            const session3 = sessions.find(s => s.tokenId.equals(sessionToken3.tokenId))
+            assert.ok(session3, 'found third session')
+            assert.deepEqual(session3.deviceId, null, 'session3 deviceId')
+            assert.deepEqual(session3.deviceAvailableCommands, null, 'session3 availableCommands')
           })
       })
 

--- a/db-server/test/backend/remote.js
+++ b/db-server/test/backend/remote.js
@@ -528,7 +528,6 @@ module.exports = function(cfg, makeServer) {
             assert(s.deviceCallbackPublicKey)
             assert.equal(s.deviceCallbackURL, 'fake callback URL')
             assert.equal(s.deviceCallbackIsExpired, false)
-            assert.deepEqual(s.deviceCapabilities, ['messages'])
             assert(s.deviceCreatedAt)
             assert(s.deviceId)
             assert.equal(s.deviceName, 'fake device name')
@@ -598,38 +597,16 @@ module.exports = function(cfg, makeServer) {
           })
           .then(function(r) {
             assert.equal(r.obj.length, 0, 'devices is empty')
-            const myDevice = Object.assign({}, user.device, {
-              capabilities: ['unknown', 'messages']
-            })
-            return client.putThen('/account/' + user.accountId + '/device/' + user.deviceId, myDevice)
-            .then(() => {
-              assert(false, 'a device with an unknown capability should make the request fail')
-            })
-            .catch(err => {
-              assert.equal(err.statusCode, 400, 'err.statusCode should be 400')
-              assert.deepEqual(err.body, {
-                message: 'Unknown device capability',
-                errno: 139,
-                error: 'Bad request',
-                code: 400
-              }, 'err.body should have correct properties set')
-            })
-          }).then(function () {
-            return client.getThen('/account/' + user.accountId + '/devices')
-          })
-          .then(function(r) {
-            assert.equal(r.obj.length, 0, 'devices is empty')
             return client.putThen('/account/' + user.accountId + '/device/' + user.deviceId, user.device)
           })
           .then(function(r) {
-            respOk(r)
             return client.getThen('/account/' + user.accountId + '/devices')
           })
           .then(function(r) {
             respOk(r)
             var devices = r.obj
             assert.equal(devices.length, 1, 'devices contains one item')
-            assert.equal(Object.keys(devices[0]).length, 19, 'device has nineteen properties')
+            assert.equal(Object.keys(devices[0]).length, 18, 'device has eighteen properties')
             assert.equal(devices[0].uid, user.accountId, 'uid is correct')
             assert.equal(devices[0].id, user.deviceId, 'id is correct')
             assert.equal(devices[0].sessionTokenId, user.sessionTokenId, 'sessionTokenId is correct')
@@ -640,7 +617,7 @@ module.exports = function(cfg, makeServer) {
             assert.equal(devices[0].callbackPublicKey, user.device.callbackPublicKey, 'callbackPublicKey is correct')
             assert.equal(devices[0].callbackAuthKey, user.device.callbackAuthKey, 'callbackAuthKey is correct')
             assert.equal(devices[0].callbackIsExpired, user.device.callbackIsExpired, 'callbackIsExpired is correct')
-            assert.deepEqual(devices[0].capabilities, user.device.capabilities, 'capabilities is correct')
+            assert.deepEqual(devices[0].availableCommands, {}, 'availableCommands is correct')
             assert.equal(devices[0].uaBrowser, user.sessionToken.uaBrowser, 'uaBrowser is correct')
             assert.equal(devices[0].uaBrowserVersion, user.sessionToken.uaBrowserVersion, 'uaBrowserVersion is correct')
             assert.equal(devices[0].uaOS, user.sessionToken.uaOS, 'uaOS is correct')
@@ -648,7 +625,22 @@ module.exports = function(cfg, makeServer) {
             assert.equal(devices[0].uaDeviceType, user.sessionToken.uaDeviceType, 'uaDeviceType is correct')
             assert.equal(devices[0].uaFormFactor, user.sessionToken.uaFormFactor, 'uaFormFactor is correct')
             assert.equal(devices[0].lastAccessTime, user.sessionToken.createdAt, 'lastAccessTime is correct')
-            assert.equal(devices[0].email, user.account.email, 'email is correct')
+          })
+          .then(function() {
+            return client.getThen('/account/' + user.accountId + '/device/' + user.deviceId)
+          })
+          .then(function(r) {
+            respOk(r)
+            var device = r.obj
+            assert.equal(device.id, user.deviceId, 'id is correct')
+            assert.equal(device.createdAt, user.device.createdAt, 'createdAt is correct')
+            assert.equal(device.name, user.device.name, 'name is correct')
+            assert.equal(device.type, user.device.type, 'type is correct')
+            assert.equal(device.callbackURL, user.device.callbackURL, 'callbackURL is correct')
+            assert.equal(device.callbackPublicKey, user.device.callbackPublicKey, 'callbackPublicKey is correct')
+            assert.equal(device.callbackAuthKey, user.device.callbackAuthKey, 'callbackAuthKey is correct')
+            assert.equal(device.callbackIsExpired, user.device.callbackIsExpired, 'callbackIsExpired is correct')
+            assert.deepEqual(device.availableCommands, {}, 'availableCommands is correct')
           })
           .then(function() {
             return client.getThen('/account/' + user.accountId + '/tokens/' + user.sessionToken.tokenVerificationId + '/device')
@@ -664,7 +656,7 @@ module.exports = function(cfg, makeServer) {
             assert.equal(device.callbackPublicKey, user.device.callbackPublicKey, 'callbackPublicKey is correct')
             assert.equal(device.callbackAuthKey, user.device.callbackAuthKey, 'callbackAuthKey is correct')
             assert.equal(device.callbackIsExpired, user.device.callbackIsExpired, 'callbackIsExpired is correct')
-            assert.deepEqual(device.capabilities, user.device.capabilities, 'capabilities is correct')
+            assert.deepEqual(device.availableCommands, {}, 'availableCommands is correct')
 
             return client.postThen('/account/' + user.accountId + '/device/' + user.deviceId + '/update', {
               name: 'wibble',
@@ -673,7 +665,7 @@ module.exports = function(cfg, makeServer) {
               callbackPublicKey: null,
               callbackAuthKey: null,
               callbackIsExpired: null,
-              capabilities: []
+              availableCommands: {}
             })
           })
           .then(function(r) {
@@ -694,7 +686,7 @@ module.exports = function(cfg, makeServer) {
             assert.equal(devices[0].callbackPublicKey, user.device.callbackPublicKey, 'callbackPublicKey is correct')
             assert.equal(devices[0].callbackAuthKey, user.device.callbackAuthKey, 'callbackAuthKey is correct')
             assert.equal(devices[0].callbackIsExpired, false, 'callbackIsExpired is correct')
-            assert.deepEqual(devices[0].capabilities, [], 'capabilities is correct')
+            assert.deepEqual(devices[0].availableCommands, {}, 'availableCommands is correct')
             assert.equal(devices[0].uaBrowser, user.sessionToken.uaBrowser, 'uaBrowser is correct')
             assert.equal(devices[0].uaBrowserVersion, user.sessionToken.uaBrowserVersion, 'uaBrowserVersion is correct')
             assert.equal(devices[0].uaOS, user.sessionToken.uaOS, 'uaOS is correct')
@@ -702,7 +694,6 @@ module.exports = function(cfg, makeServer) {
             assert.equal(devices[0].uaDeviceType, user.sessionToken.uaDeviceType, 'uaDeviceType is correct')
             assert.equal(devices[0].uaFormFactor, user.sessionToken.uaFormFactor, 'uaFormFactor is correct')
             assert.equal(devices[0].lastAccessTime, user.sessionToken.createdAt, 'lastAccessTime is correct')
-            assert.equal(devices[0].email, user.account.email, 'email is correct')
 
             return client.postThen('/account/' + user.accountId + '/device/' + user.deviceId + '/update', {
               sessionTokenId: zombieUser.sessionTokenId
@@ -754,6 +745,13 @@ module.exports = function(cfg, makeServer) {
           .then(function(r) {
             respOk(r)
             assert.equal(r.obj.length, 0, 'devices is empty')
+
+            return client.getThen('/account/' + user.accountId + '/device' + user.deviceId)
+              .then(function () {
+                assert(false, 'A non-existent deviceId should not have returned anything')
+              }, function (err) {
+                testNotFound(err)
+              })
           })
       }
     )

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -38,7 +38,7 @@ var DEVICE_FIELDS = [
   'callbackPublicKey',
   'callbackAuthKey',
   'callbackIsExpired',
-  'capabilities'
+  'availableCommands'
 ]
 
 const SESSION_DEVICE_FIELDS = [
@@ -207,16 +207,6 @@ module.exports = function (log, error) {
     return P.resolve({})
   }
 
-  function checkCapabilities(deviceInfo) {
-    if (deviceInfo.capabilities) {
-      for (const capability of deviceInfo.capabilities) {
-        if (dbUtil.mapDeviceCapability(capability) == null) {
-          throw error.unknownDeviceCapability()
-        }
-      }
-    }
-  }
-
   Memory.prototype.createDevice = function (uid, deviceId, deviceInfo) {
     return getAccountByUid(uid)
       .then(
@@ -227,9 +217,9 @@ module.exports = function (log, error) {
           }
           var device = {
             uid: uid,
-            id: deviceId
+            id: deviceId,
+            availableCommands: {}
           }
-          checkCapabilities(deviceInfo)
           deviceInfo.callbackIsExpired = false // mimic the db behavior assigning a default false value
           account.devices[deviceKey] = updateDeviceRecord(device, deviceInfo, deviceKey)
           return {}
@@ -277,7 +267,6 @@ module.exports = function (log, error) {
           if (! account.devices[deviceKey]) {
             throw error.notFound()
           }
-          checkCapabilities(deviceInfo)
           var device = account.devices[deviceKey]
           if (device.sessionTokenId) {
             if (deviceInfo.sessionTokenId) {
@@ -475,15 +464,14 @@ module.exports = function (log, error) {
         function(account) {
           return Object.keys(account.devices)
             .map(
-              function (id) {
-                var device = account.devices[id]
+              function (deviceKey) {
+                var device = Object.assign({}, account.devices[deviceKey])
                 var sessionKey = (device.sessionTokenId || '').toString('hex')
                 var session = sessionTokens[sessionKey]
                 if (session) {
                   SESSION_DEVICE_FIELDS.forEach(function (key) {
                     device[key] = session[key]
                   })
-                  device.email = account.email
                   return device
                 }
               }
@@ -498,6 +486,17 @@ module.exports = function (log, error) {
           return []
         }
       )
+  }
+
+  Memory.prototype.device = function (uid, deviceId) {
+    return this.accountDevices(uid)
+      .then(devices => devices.find(d => d.id.equals(deviceId)))
+      .then(device => {
+        if (! device) {
+          throw error.notFound()
+        }
+        return device
+      })
   }
 
   Memory.prototype.deviceFromTokenVerificationId = function (uid, tokenVerificationId) {
@@ -534,7 +533,7 @@ module.exports = function (log, error) {
             callbackPublicKey: device.callbackPublicKey,
             callbackAuthKey: device.callbackAuthKey,
             callbackIsExpired: device.callbackIsExpired,
-            capabilities: device.capabilities || []
+            availableCommands: device.availableCommands
           })
         }
       )
@@ -612,7 +611,7 @@ module.exports = function (log, error) {
           item.deviceCallbackPublicKey = device.callbackPublicKey
           item.deviceCallbackAuthKey = device.callbackAuthKey
           item.deviceCallbackIsExpired = device.callbackIsExpired
-          item.deviceCapabilities = device.capabilities || []
+          item.deviceAvailableCommands = device.availableCommands
         }
 
         return item
@@ -691,7 +690,7 @@ module.exports = function (log, error) {
           deviceCallbackPublicKey: deviceInfo.callbackPublicKey || null,
           deviceCallbackAuthKey: deviceInfo.callbackAuthKey || null,
           deviceCallbackIsExpired: deviceInfo.callbackIsExpired !== undefined ? deviceInfo.callbackIsExpired : null,
-          deviceCapabilities: deviceInfo.capabilities || []
+          deviceAvailableCommands: deviceInfo.availableCommands || null
         }
 
         return session

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 81
+module.exports.level = 82

--- a/lib/db/schema/patch-081-082.sql
+++ b/lib/db/schema/patch-081-082.sql
@@ -1,0 +1,308 @@
+--
+-- This migration lets devices register "available commands",
+-- a simple mapping from opaque command names to opaque blobs of
+-- associated data.
+--
+
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- We expect many devices to register support for a relatively
+-- small set of common commands, so we map command URIs to integer
+-- ids for more efficient storage.
+
+CREATE TABLE IF NOT EXISTS deviceCommandIdentifiers (
+  commandId INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  commandName VARCHAR(191) NOT NULL UNIQUE KEY
+) ENGINE=InnoDB;
+
+-- The mapping from devices to their set of available commands is
+-- a simple one-to-many table with associated data blob.  For now
+-- we expect calling code to update this table by deleting all
+-- rows for a device and then re-adding them.  In the future we
+-- may add support for deleting individual rows, if and when we
+-- grow a client-facing API that needs it.
+
+CREATE TABLE IF NOT EXISTS deviceCommands (
+  uid BINARY(16) NOT NULL,
+  deviceId BINARY(16) NOT NULL,
+  commandId INT UNSIGNED NOT NULL,
+  commandData VARCHAR(2048),
+  PRIMARY KEY (uid, deviceId, commandId),
+  FOREIGN KEY (commandId) REFERENCES deviceCommandIdentifiers(commandId) ON DELETE CASCADE,
+  FOREIGN KEY (uid, deviceId) REFERENCES devices(uid, id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE PROCEDURE `upsertAvailableCommand_1` (
+  IN `inUid` BINARY(16),
+  IN `inDeviceId` BINARY(16),
+  IN `inCommandURI` VARCHAR(255),
+  IN `inCommandData` VARCHAR(2048)
+)
+BEGIN
+
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  -- Find or create the corresponding integer ID for this command.
+  SET @commandId = NULL;
+  SELECT commandId INTO @commandId FROM deviceCommandIdentifiers WHERE commandName = inCommandURI;
+  IF @commandId IS NULL THEN
+    INSERT INTO deviceCommandIdentifiers (commandName) VALUES (inCommandURI);
+    SET @commandId = LAST_INSERT_ID();
+  END IF;
+
+  -- Upsert the device's advertizement of that command.
+  INSERT INTO deviceCommands(
+    uid,
+    deviceId,
+    commandId,
+    commandData
+  )
+  VALUES (
+    inUid,
+    inDeviceId,
+    @commandId,
+    inCommandData
+  )
+  ON DUPLICATE KEY UPDATE
+    commandData = inCommandData
+  ;
+
+  COMMIT;
+END;
+
+CREATE PROCEDURE `purgeAvailableCommands_1` (
+  IN `inUid` BINARY(16),
+  IN `inDeviceId` BINARY(16)
+)
+BEGIN
+  DELETE FROM deviceCommands
+    WHERE uid = inUid
+    AND deviceId = inDeviceId;
+END;
+
+-- When listing all devices, or retrieving a single device,
+-- we select all rows from the deviceCommands table.
+-- Calling code will thus receive multiple rows for each device,
+-- one per available command.  Devices with no available commands
+-- will contain NULL in those columns.  Like this:
+--
+--  +-----+---------+-------+-----+--------------+--------------+
+--  | uid | device1 | name1 | ... | commandName1 | commandData1 |
+--  | uid | device1 | name1 | ... | commandName2 | commandData2 |
+--  | uid | device2 | name2 | ... | commandName1 | commandData3 |
+--  | uid | device3 | name3 | ... | NULL         | NULL         |
+--  +-----+---------+-------+-----+--------------+--------------+
+--
+-- It will need to flatten the rows into a list of devices with
+-- an associated mapping of available commands.
+--
+-- Newer versions of MySQL have an aggregation function called
+-- "JSON_OBJECTAGG" that would allow us to do that flattening
+-- as part of the query, like this:
+--
+--    SELECT uid, id, ..., JSON_OBJECTAGG(commandName, commandData) AS availableCommands
+--    FROM ...
+--    GROUP BY 1, 2
+--
+-- But sadly, we're not on newer versions of MySQL in production.
+
+CREATE PROCEDURE `accountDevices_14` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  SELECT
+    d.uid,
+    d.id,
+    d.sessionTokenId,
+    d.nameUtf8 AS name,
+    d.type,
+    d.createdAt,
+    d.callbackURL,
+    d.callbackPublicKey,
+    d.callbackAuthKey,
+    d.callbackIsExpired,
+    s.uaBrowser,
+    s.uaBrowserVersion,
+    s.uaOS,
+    s.uaOSVersion,
+    s.uaDeviceType,
+    s.uaFormFactor,
+    s.lastAccessTime,
+    ci.commandName,
+    dc.commandData
+  FROM devices AS d
+  INNER JOIN sessionTokens AS s
+    ON d.sessionTokenId = s.tokenId
+  LEFT JOIN (
+    deviceCommands AS dc
+    INNER JOIN deviceCommandIdentifiers AS ci
+      ON ci.commandId = dc.commandId
+  ) ON dc.deviceId = d.id
+  WHERE d.uid = uidArg
+  -- For easy flattening, ensure rows are ordered by device id.
+  ORDER BY 1, 2;
+END;
+
+CREATE PROCEDURE `device_1` (
+  IN `uidArg` BINARY(16),
+  IN `idArg` BINARY(16)
+)
+BEGIN
+  SELECT
+    d.uid,
+    d.id,
+    d.sessionTokenId,
+    d.nameUtf8 AS name,
+    d.type,
+    d.createdAt,
+    d.callbackURL,
+    d.callbackPublicKey,
+    d.callbackAuthKey,
+    d.callbackIsExpired,
+    s.uaBrowser,
+    s.uaBrowserVersion,
+    s.uaOS,
+    s.uaOSVersion,
+    s.uaDeviceType,
+    s.uaFormFactor,
+    s.lastAccessTime,
+    ci.commandName,
+    dc.commandData
+  FROM devices AS d
+  INNER JOIN sessionTokens AS s
+    ON d.sessionTokenId = s.tokenId
+  LEFT JOIN (
+    deviceCommands AS dc
+    INNER JOIN deviceCommandIdentifiers AS ci
+      ON ci.commandId = dc.commandId
+  ) ON dc.deviceId = d.id
+  WHERE d.uid = uidArg
+  AND d.id = idArg;
+END;
+
+CREATE PROCEDURE `deviceFromTokenVerificationId_5` (
+    IN inUid BINARY(16),
+    IN inTokenVerificationId BINARY(16)
+)
+BEGIN
+  SELECT
+    d.id,
+    d.nameUtf8 AS name,
+    d.type,
+    d.createdAt,
+    d.callbackURL,
+    d.callbackPublicKey,
+    d.callbackAuthKey,
+    d.callbackIsExpired,
+    ci.commandName,
+    dc.commandData
+  FROM unverifiedTokens AS u
+  INNER JOIN devices AS d
+    ON (u.tokenId = d.sessionTokenId AND u.uid = d.uid)
+  LEFT JOIN (
+    deviceCommands AS dc
+    INNER JOIN deviceCommandIdentifiers AS ci
+      ON ci.commandId = dc.commandId
+  ) ON dc.deviceId = d.id
+  WHERE u.uid = inUid AND u.tokenVerificationId = inTokenVerificationId;
+END;
+
+CREATE PROCEDURE `sessionWithDevice_14` (
+  IN `tokenIdArg` BINARY(32)
+)
+BEGIN
+  SELECT
+    t.tokenData,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.uaFormFactor,
+    t.lastAccessTime,
+    t.verificationMethod,
+    t.verifiedAt,
+    COALESCE(t.authAt, t.createdAt) AS authAt,
+    e.isVerified AS emailVerified,
+    e.email,
+    e.emailCode,
+    a.verifierSetAt,
+    a.locale,
+    a.createdAt AS accountCreatedAt,
+    d.id AS deviceId,
+    d.nameUtf8 AS deviceName,
+    d.type AS deviceType,
+    d.createdAt AS deviceCreatedAt,
+    d.callbackURL AS deviceCallbackURL,
+    d.callbackPublicKey AS deviceCallbackPublicKey,
+    d.callbackAuthKey AS deviceCallbackAuthKey,
+    d.callbackIsExpired AS deviceCallbackIsExpired,
+    ci.commandName AS deviceCommandName,
+    dc.commandData AS deviceCommandData,
+    ut.tokenVerificationId,
+    COALESCE(t.mustVerify, ut.mustVerify) AS mustVerify
+  FROM sessionTokens AS t
+  LEFT JOIN accounts AS a
+    ON t.uid = a.uid
+  LEFT JOIN emails AS e
+    ON t.uid = e.uid
+    AND e.isPrimary = true
+  LEFT JOIN devices AS d
+    ON (t.tokenId = d.sessionTokenId AND t.uid = d.uid)
+  LEFT JOIN (
+    deviceCommands AS dc
+    INNER JOIN deviceCommandIdentifiers AS ci
+      ON ci.commandId = dc.commandId
+  ) ON dc.deviceId = d.id
+  LEFT JOIN unverifiedTokens AS ut
+    ON t.tokenId = ut.tokenId
+  WHERE t.tokenId = tokenIdArg;
+END;
+
+CREATE PROCEDURE `sessions_10` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  SELECT
+    t.tokenId,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.uaFormFactor,
+    t.lastAccessTime,
+    COALESCE(t.authAt, t.createdAt) AS authAt,
+    d.id AS deviceId,
+    d.nameUtf8 AS deviceName,
+    d.type AS deviceType,
+    d.createdAt AS deviceCreatedAt,
+    d.callbackURL AS deviceCallbackURL,
+    d.callbackPublicKey AS deviceCallbackPublicKey,
+    d.callbackAuthKey AS deviceCallbackAuthKey,
+    d.callbackIsExpired AS deviceCallbackIsExpired,
+    ci.commandName AS deviceCommandName,
+    dc.commandData AS deviceCommandData
+  FROM sessionTokens AS t
+  LEFT JOIN devices AS d
+    ON (t.tokenId = d.sessionTokenId AND t.uid = d.uid)
+  LEFT JOIN (
+    deviceCommands AS dc
+    INNER JOIN deviceCommandIdentifiers AS ci
+      ON ci.commandId = dc.commandId
+  ) ON dc.deviceId = d.id
+  WHERE t.uid = uidArg
+  ORDER BY 1;
+END;
+
+UPDATE dbMetadata SET value = '82' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-082-081.sql
+++ b/lib/db/schema/patch-082-081.sql
@@ -1,0 +1,14 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DROP TABLE deviceCommandIdentifiers;
+-- DROP TABLE deviceCommands;
+
+-- DROP PROCEDURE upsertAvailableCommand_1;
+-- DROP PROCEDURE purgeAvailableCommands_1;
+-- DROP PROCEDURE accountDevices_14;
+-- DROP PROCEDURE device_1;
+-- DROP PROCEDURE deviceFromTokenVerificationId_5;
+-- DROP PROCEDURE sessionWithDevice_14;
+-- DROP PROCEDURE sessions_10;
+
+-- UPDATE dbMetadata SET value = '81' WHERE name = 'schema-patch-level';

--- a/lib/db/util.js
+++ b/lib/db/util.js
@@ -41,25 +41,7 @@ const VERIFICATION_METHODS = new Map([
   ['recovery-code', 3]   // Recovery code
 ])
 
-// If you modify one of these maps, modify the other.
-const DEVICE_CAPABILITIES = new Map([
-  ['messages', 1],
-  ['messages.sendtab', 2]
-])
-const DEVICE_CAPABILITIES_IDS = new Map([
-  [1, 'messages'],
-  [2, 'messages.sendtab']
-])
-
 module.exports = {
-
-  mapDeviceCapability(val) {
-    if (typeof val === 'number') {
-      return DEVICE_CAPABILITIES_IDS.get(val) || null
-    } else {
-      return DEVICE_CAPABILITIES.get(val) || null
-    }
-  },
 
   mapEmailBounceType(val) {
     if (typeof val === 'number') {
@@ -134,5 +116,84 @@ module.exports = {
           return result.join('')
         })
       })
+  },
+
+  // A helper function for aggregating name:value pairs into a JSON object.
+  //
+  // In newer versions of MySQL, there's a neat function called JSON_OBJECTAGG
+  // that can be used with `GROUP BY` to collect name:value pairs into a JSON
+  // object.  Given a table like this, where each `id` can have zero, one or
+  // many names and a corresponding value for each:
+  //
+  //   +-------+-------+--------+
+  //   | id    | name  | value  |
+  //   +-------+-------+--------+
+  //   | one   | name1 | value1 |
+  //   | one   | name2 | value2 |
+  //   | two   | name1 | value1 |
+  //   | three | NULL  | NULL   |
+  //   +-------+-------+--------+
+  //
+  // Then you can do a query like:
+  //
+  //    SELECT id, JSON_OBJECTAGG(name, value) AS result
+  //    FROM data
+  //    GROUP BY 1, 2
+  //
+  // And get a result with one row per `id`, like:
+  //
+  //   +-------+----------------------------------+
+  //   | id    | result                           |
+  //   +-------+----------------------------------+
+  //   | one   | { name1: value1, name2: value2 } |
+  //   | two   | { name1: value1 }                |
+  //   | three | {}                               |
+  //   +-------+----------------------------------+
+  //
+  // Unfortunately, we're not on newer versions of MySQL, so this function implements
+  // the same aggregation logic in sofware.  To use it, select all the target rows
+  // and ensure they're sorted by grouping id:
+  //
+  //    rows = db.readAllResults("
+  //      SELECT id, name, value
+  //      FROM data
+  //      ORDER BY 1
+  //    ")
+  //
+  // Then apply `aggregateNameValuePairs` on the rows, providing the names of the
+  // columns to use for the group-by id, the keys, the values, and the resulting
+  // aggregate:
+  //
+  //    unique_rows = aggregateNameValuePairs(rows, "id", "name", "value", "result")
+  //
+  // The end result will be the same as produced by JSON_OBJECTAGG, including correct
+  // handling of NULL values in all columns.
+
+  aggregateNameValuePairs(rows, idColumn, nameColumn, valueColumn, resultColumn) {
+    return rows.reduce((items, row) => {
+      let curItem = items[items.length - 1]
+      // Start a new aggregated item if:
+      //   * we're at the start of the list, or
+      //   * the upcoming row has a different id then previous.
+      //   * the upcoming row has a NULL id (because NULLs never equal each other)
+      if (! curItem || ! row[idColumn] || ! curItem[idColumn] || ! row[idColumn].equals(curItem[idColumn])) {
+        curItem = {}
+        Object.keys(row).forEach(column => {
+          if (column !== nameColumn && column !== valueColumn) {
+            curItem[column] = row[column]
+          }
+        })
+        // If the id was NULL, this row must have resulted from
+        // an outer join with no match in the joined table.
+        // The correct aggregated result in this case is NULL.
+        curItem[resultColumn] = row[idColumn] ? {} : null
+        items.push(curItem)
+      }
+      if (row[nameColumn]) {
+        curItem[resultColumn][row[nameColumn]] = row[valueColumn]
+      }
+      return items
+    }, [])
   }
+
 }

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -80,4 +80,113 @@ describe('utils', () => {
       })
     })
   })
+
+  describe('aggregateNameValuePairs', () => {
+
+    const ONE = Buffer.from('one')
+    const TWO = Buffer.from('two')
+    const THREE = Buffer.from('three')
+
+    it('should correctly handle an empty result set', () => {
+      assert.deepEqual(dbUtils.aggregateNameValuePairs([], 'id', 'name', 'value', 'result'), [])
+    })
+
+    it('should aggregate based on id', () => {
+      assert.deepEqual(dbUtils.aggregateNameValuePairs([
+        { id: ONE, name: 'name1', value: 'value1' },
+        { id: ONE, name: 'name2', value: 'value2' },
+        { id: TWO, name: 'name1', value: 'value1' }
+      ], 'id', 'name', 'value', 'result'), [
+        { id: ONE, result: { name1: 'value1', name2: 'value2' }},
+        { id: TWO, result: { name1: 'value1' }},
+      ])
+    })
+
+    it('should allow custom column names', () => {
+      assert.deepEqual(dbUtils.aggregateNameValuePairs([
+        { MyID: ONE, TheName: 'name1', ItsValue: 'value1' },
+        { MyID: ONE, TheName: 'name2', ItsValue: 'value2' },
+        { MyID: TWO, TheName: 'name1', ItsValue: 'value1' }
+      ], 'MyID', 'TheName', 'ItsValue', 'AggregateResult'), [
+        { MyID: ONE, AggregateResult: { name1: 'value1', name2: 'value2' }},
+        { MyID: TWO, AggregateResult: { name1: 'value1' }},
+      ])
+    })
+
+    it('should aggregate NULL name/value pairs as an empty object', () => {
+      assert.deepEqual(dbUtils.aggregateNameValuePairs([
+        { id: ONE, name: 'name1', value: 'value1' },
+        { id: ONE, name: 'name2', value: 'value2' },
+        { id: TWO, name: null, value: null },
+        { id: THREE, name: 'name1', value: 'value1' }
+      ], 'id', 'name', 'value', 'result'), [
+        { id: ONE, result: { name1: 'value1', name2: 'value2' }},
+        { id: TWO, result: { }},
+        { id: THREE, result: { name1: 'value1' }},
+      ])
+    })
+
+    it('should copy across additional columns unaggregated', () => {
+      assert.deepEqual(dbUtils.aggregateNameValuePairs([
+        { id: ONE, extra: 'value', name: 'name1', value: 'value1' },
+        { id: ONE, extra: 'value', name: 'name2', value: 'value2' },
+        { id: TWO, extra: 'another-value', name: 'name1', value: 'value1' },
+      ], 'id', 'name', 'value', 'result'), [
+        { id: ONE, extra: 'value', result: { name1: 'value1', name2: 'value2' }},
+        { id: TWO, extra: 'another-value', result: { name1: 'value1' }},
+      ])
+    })
+
+    it('should correct handle null ids from outer joins', () => {
+      // Test NULL in multiple different positions.
+      assert.deepEqual(dbUtils.aggregateNameValuePairs([
+        { uid: ONE, deviceId: TWO, name: 'name1', value: 'value1' },
+        { uid: ONE, deviceId: TWO, name: 'name2', value: 'value2' },
+        { uid: ONE, deviceId: THREE, name: 'name1', value: 'value1' },
+        { uid: ONE, deviceId: null, name: null, value: null },
+      ], 'deviceId', 'name', 'value', 'result'), [
+        { uid: ONE, deviceId: TWO, result: { name1: 'value1', name2: 'value2' }},
+        { uid: ONE, deviceId: THREE, result: { name1: 'value1' }},
+        { uid: ONE, deviceId: null, result: null }
+      ])
+      assert.deepEqual(dbUtils.aggregateNameValuePairs([
+        { uid: ONE, deviceId: TWO, name: 'name1', value: 'value1' },
+        { uid: ONE, deviceId: TWO, name: 'name2', value: 'value2' },
+        { uid: ONE, deviceId: null, name: null, value: null },
+        { uid: ONE, deviceId: THREE, name: 'name1', value: 'value1' },
+      ], 'deviceId', 'name', 'value', 'result'), [
+        { uid: ONE, deviceId: TWO, result: { name1: 'value1', name2: 'value2' }},
+        { uid: ONE, deviceId: null, result: null },
+        { uid: ONE, deviceId: THREE, result: { name1: 'value1' }}
+      ])
+      assert.deepEqual(dbUtils.aggregateNameValuePairs([
+        { uid: ONE, deviceId: null, name: null, value: null },
+        { uid: ONE, deviceId: TWO, name: 'name1', value: 'value1' },
+        { uid: ONE, deviceId: TWO, name: 'name2', value: 'value2' },
+        { uid: ONE, deviceId: THREE, name: 'name1', value: 'value1' },
+      ], 'deviceId', 'name', 'value', 'result'), [
+        { uid: ONE, deviceId: null, result: null },
+        { uid: ONE, deviceId: TWO, result: { name1: 'value1', name2: 'value2' }},
+        { uid: ONE, deviceId: THREE, result: { name1: 'value1' }}
+      ])
+      assert.deepEqual(dbUtils.aggregateNameValuePairs([
+        { uid: ONE, deviceId: null, name: null, value: null },
+        { uid: ONE, deviceId: TWO, name: 'name1', value: 'value1' },
+        { uid: ONE, deviceId: TWO, name: 'name2', value: 'value2' },
+        { uid: ONE, deviceId: null, name: null, value: null },
+        { uid: ONE, deviceId: null, name: null, value: null },
+        { uid: ONE, deviceId: THREE, name: 'name1', value: 'value1' },
+        { uid: ONE, deviceId: null, name: null, value: null },
+        { uid: ONE, deviceId: null, name: null, value: null }
+      ], 'deviceId', 'name', 'value', 'result'), [
+        { uid: ONE, deviceId: null, result: null },
+        { uid: ONE, deviceId: TWO, result: { name1: 'value1', name2: 'value2' }},
+        { uid: ONE, deviceId: null, result: null },
+        { uid: ONE, deviceId: null, result: null },
+        { uid: ONE, deviceId: THREE, result: { name1: 'value1' }},
+        { uid: ONE, deviceId: null, result: null },
+        { uid: ONE, deviceId: null, result: null }
+      ])
+    })
+  })
 })

--- a/test/local/metrics_tests.js
+++ b/test/local/metrics_tests.js
@@ -42,11 +42,11 @@ describe('DB metrics', () => {
       assert.equal(typeof metrics.countAccountsWithMobileDevice, 'string', 'countAccountsWithMobileDevice string was exported')
 
       return P.all([
-        db.readOneFromFirstResult(metrics.countAccounts, times[0]),
-        db.readOneFromFirstResult(metrics.countVerifiedAccounts, times[0]),
-        db.readOneFromFirstResult(metrics.countAccountsWithTwoOrMoreDevices, times[0]),
-        db.readOneFromFirstResult(metrics.countAccountsWithThreeOrMoreDevices, times[0]),
-        db.readOneFromFirstResult(metrics.countAccountsWithMobileDevice, times[0])
+        db.readAllResults(metrics.countAccounts, times[0]),
+        db.readAllResults(metrics.countVerifiedAccounts, times[0]),
+        db.readAllResults(metrics.countAccountsWithTwoOrMoreDevices, times[0]),
+        db.readAllResults(metrics.countAccountsWithThreeOrMoreDevices, times[0]),
+        db.readAllResults(metrics.countAccountsWithMobileDevice, times[0])
       ])
       .then(function (results) {
         results.forEach(function (result, index) {
@@ -104,11 +104,11 @@ describe('DB metrics', () => {
       })
       .then(function () {
         return P.all([
-          db.readOneFromFirstResult(metrics.countAccounts, times[2]),
-          db.readOneFromFirstResult(metrics.countVerifiedAccounts, times[2]),
-          db.readOneFromFirstResult(metrics.countAccountsWithTwoOrMoreDevices, times[2] + 1),
-          db.readOneFromFirstResult(metrics.countAccountsWithThreeOrMoreDevices, times[2] + 1),
-          db.readOneFromFirstResult(metrics.countAccountsWithMobileDevice, times[2] + 1)
+          db.readAllResults(metrics.countAccounts, times[2]),
+          db.readAllResults(metrics.countVerifiedAccounts, times[2]),
+          db.readAllResults(metrics.countAccountsWithTwoOrMoreDevices, times[2] + 1),
+          db.readAllResults(metrics.countAccountsWithThreeOrMoreDevices, times[2] + 1),
+          db.readAllResults(metrics.countAccountsWithMobileDevice, times[2] + 1)
         ])
       })
       .then(function (results) {
@@ -122,9 +122,9 @@ describe('DB metrics', () => {
       })
       .then(function () {
         return P.all([
-          db.readOneFromFirstResult(metrics.countAccountsWithTwoOrMoreDevices, times[2] + 1),
-          db.readOneFromFirstResult(metrics.countAccountsWithThreeOrMoreDevices, times[2] + 1),
-          db.readOneFromFirstResult(metrics.countAccountsWithMobileDevice, times[2] + 1)
+          db.readAllResults(metrics.countAccountsWithTwoOrMoreDevices, times[2] + 1),
+          db.readAllResults(metrics.countAccountsWithThreeOrMoreDevices, times[2] + 1),
+          db.readAllResults(metrics.countAccountsWithMobileDevice, times[2] + 1)
         ])
       })
       .then(function (results) {
@@ -139,9 +139,9 @@ describe('DB metrics', () => {
       })
       .then(function () {
         return P.all([
-          db.readOneFromFirstResult(metrics.countAccountsWithTwoOrMoreDevices, times[2] + 1),
-          db.readOneFromFirstResult(metrics.countAccountsWithThreeOrMoreDevices, times[2] + 1),
-          db.readOneFromFirstResult(metrics.countAccountsWithMobileDevice, times[2] + 1)
+          db.readAllResults(metrics.countAccountsWithTwoOrMoreDevices, times[2] + 1),
+          db.readAllResults(metrics.countAccountsWithThreeOrMoreDevices, times[2] + 1),
+          db.readAllResults(metrics.countAccountsWithMobileDevice, times[2] + 1)
         ])
       })
       .then(function (results) {
@@ -152,9 +152,9 @@ describe('DB metrics', () => {
       })
       .then(function () {
         return P.all([
-          db.readOneFromFirstResult(metrics.countAccountsWithTwoOrMoreDevices, times[2]),
-          db.readOneFromFirstResult(metrics.countAccountsWithThreeOrMoreDevices, times[2]),
-          db.readOneFromFirstResult(metrics.countAccountsWithMobileDevice, times[2])
+          db.readAllResults(metrics.countAccountsWithTwoOrMoreDevices, times[2]),
+          db.readAllResults(metrics.countAccountsWithThreeOrMoreDevices, times[2]),
+          db.readAllResults(metrics.countAccountsWithMobileDevice, times[2])
         ])
       })
       .then(function (results) {


### PR DESCRIPTION
This is a revision of the "device capabilities" feature, to allow devices to associate a metadata blob with each advertised capability.  I've taken the liberty of renaming them from "capabilities" to "commands" for reasons that will become clear in a forthcoming auth-server PR.

WIP for now. /cc @eoger 

Connects to https://github.com/mozilla/fxa-auth-server/issues/2318