### PR TITLE
feat(scripts): add boilerplate to detect missing migrations

### DIFF
--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 82
+module.exports.level = 83

--- a/lib/db/schema/patch-082-083.sql
+++ b/lib/db/schema/patch-082-083.sql
@@ -1,0 +1,13 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CREATE PROCEDURE `assertPatchLevel` (
+  IN `requiredLevel` TEXT
+)
+BEGIN
+  SELECT @currentPatchLevel := value FROM dbMetadata WHERE name = 'schema-patch-level';
+  IF @currentPatchLevel != requiredLevel THEN
+    SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 1643, MESSAGE_TEXT = 'Missing migration detected';
+  END IF;
+END;
+
+UPDATE dbMetadata SET value = '83' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-083-082.sql
+++ b/lib/db/schema/patch-083-082.sql
@@ -1,0 +1,5 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DROP PROCEDURE `assertPatchLevel`;
+
+-- UPDATE dbMetadata SET value = '82' WHERE name = 'schema-patch-level';

--- a/scripts/migration.sh
+++ b/scripts/migration.sh
@@ -33,12 +33,13 @@ fi
 printf "Generating migration boilerplate for patch level $NEW_LEVEL..."
 
 echo "SET NAMES utf8mb4 COLLATE utf8mb4_bin;\n" > "$FWD_SCHEMA"
+echo "CALL assertPatchLevel('$PREV_LEVEL');\n" >> "$FWD_SCHEMA"
 echo "-- TODO: Implement your forward migration here\n" >> "$FWD_SCHEMA"
-echo "UPDATE dbMetadata SET value = '$NEW_LEVEL' WHERE name = 'schema-patch-level';\n" >> "$FWD_SCHEMA"
+echo "UPDATE dbMetadata SET value = '$NEW_LEVEL' WHERE name = 'schema-patch-level';" >> "$FWD_SCHEMA"
 
-echo '-- -- TODO: Implement your *commented-out* reverse migration here\n' > "$REV_SCHEMA"
-echo "-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;\n" >> "$REV_SCHEMA"
-echo "-- UPDATE dbMetadata SET value = '$PREV_LEVEL' WHERE name = 'schema-patch-level';\n" >> "$REV_SCHEMA"
+echo "-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;\n" > "$REV_SCHEMA"
+echo '-- -- TODO: Implement your *commented-out* reverse migration here\n' >> "$REV_SCHEMA"
+echo "-- UPDATE dbMetadata SET value = '$PREV_LEVEL' WHERE name = 'schema-patch-level';" >> "$REV_SCHEMA"
 
 sed -i '' "s/^module.exports.level = $PREV_LEVEL\$/module.exports.level = $NEW_LEVEL/" $PATCH_SRC
 


### PR DESCRIPTION
Fixes #328.

While I was pootling around in this repo just now I realised we never got this implemented, so here's my stab at it. It just checks the current patch level matches what it should be before proceeding with the rest of the migration.

~~I had to wrap that check in a temporary stored procedure because MySQL complains if I try to do `IF` outside of one. The preceding `DROP` is so that we clean up in the presence of repeated failures. I've named the procedure specifically to the current patch level to make it hopefully more self-documenting.~~

If you want to test it out, create a fresh migration using the script and then manually change the patch level to a different value. When you run `node bin/db_patcher` it should fail like so:

```
~/c/fxa-auth-db-mysql (pb/detect-missing-migrations) $ node bin/db_patcher
{"Timestamp":1530029634691000000,"Logger":"fxa-auth-db-server","Type":"bin.db_patcher.patch-error","Severity":2,"Pid":43591,"EnvVersion":"2.0","Fields":{"err":"Error: ER_SIGNAL_NOT_FOUND: Missing migration detected"}}
```

@mozilla/fxa-devs, @jrgm, @jbuck r?