### PR TITLE
feat(recovery): update account recovery GET/DEL to not accept recoveryKeyId

### DIFF
--- a/db-server/index.js
+++ b/db-server/index.js
@@ -83,6 +83,7 @@ function createServer(db) {
     'kA',
     'keyBundle',
     'passCode',
+    'recoveryKeyId',
     'sessionTokenId',
     'tokenId',
     'tokenVerificationId',
@@ -236,9 +237,9 @@ function createServer(db) {
     op((req) => db.consumeRecoveryCode(req.params.id, req.params.code))
   )
 
-  api.get('/account/:id/recoveryKeys/:recoveryKeyId', withParams(db.getRecoveryKey))
-  api.del('/account/:id/recoveryKeys/:recoveryKeyId', withParams(db.deleteRecoveryKey))
-  api.post('/account/:id/recoveryKeys', withIdAndBody(db.createRecoveryKey))
+  api.get('/account/:id/recoveryKey', withParams(db.getRecoveryKey))
+  api.del('/account/:id/recoveryKey', withParams(db.deleteRecoveryKey))
+  api.post('/account/:id/recoveryKey', withIdAndBody(db.createRecoveryKey))
 
   api.get(
     '/',

--- a/db-server/test/backend/db_tests.js
+++ b/db-server/test/backend/db_tests.js
@@ -154,8 +154,8 @@ function makeMockAccountResetToken(uid, tokenId) {
 
 function createRecoveryData() {
   const data = {
-    recoveryKeyId: crypto.randomBytes(64),
-    recoveryData: crypto.randomBytes(64).toString('hex')
+    recoveryKeyId: hex(16),
+    recoveryData: crypto.randomBytes(32).toString('hex')
   }
   return data
 }
@@ -2279,8 +2279,7 @@ module.exports = function (config, DB) {
 
       it('should get account recovery key', () => {
         const options = {
-          id: account.uid,
-          recoveryKeyId: data.recoveryKeyId
+          id: account.uid
         }
         return db.getRecoveryKey(options)
           .then((res) => {
@@ -2291,8 +2290,7 @@ module.exports = function (config, DB) {
 
       it('should fail to get key for incorrect user', () => {
         const options = {
-          id: 'unknown',
-          recoveryKeyId: data.recoveryKeyId
+          id: 'unknown'
         }
         return db.getRecoveryKey(options)
           .then(assert.fail, (err) => {
@@ -2301,13 +2299,16 @@ module.exports = function (config, DB) {
       })
 
       it('should fail to get unknown key', () => {
-        const options = {
-          id: account.uid,
-          recoveryKeyId: 'not real recovery key'
-        }
-        return db.getRecoveryKey(options)
-          .then(assert.fail, (err) => {
-            assert.equal(err.errno, 116, 'not found')
+        account = createAccount()
+        return db.createAccount(account.uid, account)
+          .then(() => {
+            const options = {
+              id: account.uid
+            }
+            return db.getRecoveryKey(options)
+              .then(assert.fail, (err) => {
+                assert.equal(err.errno, 116, 'not found')
+              })
           })
       })
 

--- a/db-server/test/backend/remote.js
+++ b/db-server/test/backend/remote.js
@@ -1726,7 +1726,7 @@ module.exports = function(cfg, makeServer) {
       })
     })
 
-    describe('recovery keys', function () {
+    describe('recovery key', function () {
       let user, recoveryKey
       beforeEach(() => {
         user = fake.newUserDataHex()
@@ -1734,10 +1734,10 @@ module.exports = function(cfg, makeServer) {
           .then((r) => {
             respOkEmpty(r)
             recoveryKey = {
-              recoveryKeyId: crypto.randomBytes(32).toString('hex'),
+              recoveryKeyId: crypto.randomBytes(16).toString('hex'),
               recoveryData: crypto.randomBytes(64).toString('hex')
             }
-            return client.postThen('/account/' + user.accountId + '/recoveryKeys', recoveryKey)
+            return client.postThen('/account/' + user.accountId + '/recoveryKey', recoveryKey)
           })
           .then((r) => {
             respOkEmpty(r)
@@ -1749,7 +1749,7 @@ module.exports = function(cfg, makeServer) {
       })
 
       it('should get a recovery key', () => {
-        return client.getThen('/account/' + user.accountId + '/recoveryKeys/' + recoveryKey.recoveryKeyId)
+        return client.getThen('/account/' + user.accountId + '/recoveryKey')
           .then((res) => {
             const recoveryKeyResult = res.obj
             assert.equal(recoveryKeyResult.recoveryData, recoveryKey.recoveryData, 'recoveryData match')
@@ -1757,7 +1757,7 @@ module.exports = function(cfg, makeServer) {
       })
 
       it('should delete a recovery key', () => {
-        return client.delThen('/account/' + user.accountId + '/recoveryKeys/' + recoveryKey.recoveryKeyId.toString('hex'))
+        return client.delThen('/account/' + user.accountId + '/recoveryKey')
           .then((r) => {
             respOkEmpty(r)
           })

--- a/docs/API.md
+++ b/docs/API.md
@@ -1912,9 +1912,9 @@ Used to create a TOTP token for a user.
 curl \
     -v \
     -X PUT \
-    -H "Content-Type: application/json" \  
-    -d '{"sharedSecret": "LEVXGTLWMFITC6BSIF2DOQKTIU2WUOKJ", "epoch": 0}' \  
-    http://localhost:8000/totp/1234567890ab    
+    -H "Content-Type: application/json" \
+    -d '{"sharedSecret": "LEVXGTLWMFITC6BSIF2DOQKTIU2WUOKJ", "epoch": 0}' \
+    http://localhost:8000/totp/1234567890ab
 ```
 
 ### Request
@@ -1924,7 +1924,7 @@ curl \
     * `uid` : hex
 * Params:
     * `sharedSecret` : hex10
-    * `epoch` : epoch    
+    * `epoch` : epoch
 
 ### Response
 
@@ -1958,7 +1958,7 @@ Get the user's TOTP token.
 curl \
     -v \
     -X GET \
-    -H "Content-Type: application/json" \    
+    -H "Content-Type: application/json" \
     http://localhost:8000/totp/1234567890ab
 ```
 
@@ -1966,7 +1966,7 @@ curl \
 
 * Method : `GET`
 * Path : `/totp/<uid>`
-    * `uid` : hex   
+    * `uid` : hex
 
 ### Response
 
@@ -2004,15 +2004,15 @@ Delete the user's TOTP token.
 curl \
     -v \
     -X DEL \
-    -H "Content-Type: application/json" \    
-    http://localhost:8000/totp/1234567890ab    
+    -H "Content-Type: application/json" \
+    http://localhost:8000/totp/1234567890ab
 ```
 
 ### Request
 
 * Method : `DEL`
 * Path : `/totp/<uid>`
-    * `uid` : hex   
+    * `uid` : hex
 
 ### Response
 
@@ -2026,7 +2026,7 @@ Content-Length: 2
 
 * Status Code : `200 OK`
     * Content-Type : `application/json`
-    * Body : `{}`  
+    * Body : `{}`
 * Status Code : `500 Internal Server Error`
     * Conditions: if something goes wrong on the server
     * Content-Type : `application/json`
@@ -2046,15 +2046,15 @@ curl \
     -d '{
         "verified" : true,
         "enable": true
-    }' \    
-    http://localhost:8000/totp/1234567890ab/update   
+    }' \
+    http://localhost:8000/totp/1234567890ab/update
 ```
 
 ### Request
 
 * Method : `POST`
 * Path : `/totp/<uid>/update`
-    * `uid` : hex   
+    * `uid` : hex
 
 ### Response
 
@@ -2068,7 +2068,7 @@ Content-Length: 2
 
 * Status Code : `200 OK`
     * Content-Type : `application/json`
-    * Body : `{}`  
+    * Body : `{}`
 * Status Code : `500 Internal Server Error`
     * Conditions: if something goes wrong on the server
     * Content-Type : `application/json`
@@ -2086,16 +2086,16 @@ curl \
     -X POST \
     -H "Content-Type: application/json" \
     -d '{
-        "count" : 8        
+        "count" : 8
     }'
-    http://localhost:8000/account/1234567890ab/recoveryCodes   
+    http://localhost:8000/account/1234567890ab/recoveryCodes
 ```
 
 ### Request
 
 * Method : `POST`
 * Path : `/account/<uid>/recoveryCodes`
-    * `uid` : hex   
+    * `uid` : hex
 *
 
 ### Response
@@ -2129,8 +2129,8 @@ Consumes a recovery code.
 curl \
     -v \
     -X POST \
-    -H "Content-Type: application/json" \    
-    http://localhost:8000/account/1234567890ab/recoveryCodes/1123  
+    -H "Content-Type: application/json" \
+    http://localhost:8000/account/1234567890ab/recoveryCodes/1123
 ```
 
 ### Request
@@ -2201,9 +2201,9 @@ Content-Length: 2
     * Content-Type : `application/json`
     * Body : `{"code":"InternalError","message":"..."}`
 
-## getRecoveryKey : `GET /account/:uid/recoveryKeys/:recoveryKeyId`
+## getRecoveryKey : `GET /account/:uid/recoveryKey`
 
-Returns the recovery key data for a user.
+Returns recovery key data for a user.
 
 ### Example
 
@@ -2212,16 +2212,14 @@ curl \
     -v \
     -X GET \
     -H "Content-Type: application/json" \
-    http://localhost:8000/account/1234567890ab/recoveryKeys/1234567890ab
+    http://localhost:8000/account/1234567890ab/recoveryKey
 ```
 
 ### Request
 
 * Method : `GET`
-* Path : `/account/<uid>/recoveryKeys/<recoveryKeyId>`
+* Path : `/account/<uid>/recoveryKey`
     * `uid` : hex
-    * `recoveryKeyId`: hex
-    * `recoveryKeyData`: hex
 
 ### Response
 
@@ -2230,7 +2228,10 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Content-Length: 2
 
-{}
+{
+    "recoveryKeyId": "6aa248931704886f54ac64b81b111bc0",
+    "recoveryData": "eyJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIiwia2lkIjoiNmFhMjQ4OTMxNzA0ODg2ZjU0YWM2NGI4MWIxMTFiYzAifQ"
+}
 ```
 
 * Status Code : `200 OK`
@@ -2243,7 +2244,7 @@ Content-Length: 2
     * Content-Type : `application/json`
     * Body : `{"code":"InternalError","message":"..."}`
 
-## deleteRecoveryKey : `DELETE /account/:uid/recoveryKeys/:recoveryKeyId`
+## deleteRecoveryKey : `DELETE /account/:uid/recoveryKey`
 
 Delete a user's recovery data.
 
@@ -2254,15 +2255,14 @@ curl \
     -v \
     -X DELETE \
     -H "Content-Type: application/json" \
-    http://localhost:8000/account/1234567890ab/recoveryKeys/1234567890ab
+    http://localhost:8000/account/1234567890ab/recoveryKey
 ```
 
 ### Request
 
 * Method : `DELETE`
-* Path : `/account/<uid>/recoveryKeys/<recoveryKeyId>`
+* Path : `/account/<uid>/recoveryKey`
     * `uid` : hex
-    * `recoveryKeyId`: hex
 
 ### Response
 

--- a/docs/DB_API.md
+++ b/docs/DB_API.md
@@ -72,8 +72,8 @@ There are a number of methods that a DB storage backend should implement:
     * .consumeRecoveryCode(uid, code)
 * Recovery keys
     * .createRecoveryKey(uid, data)
-    * .getRecoveryKey(uid, recoveryKeyId)
-    * .deleteRecoveryKey(uid, recoveryKeyId)
+    * .getRecoveryKey(uid)
+    * .deleteRecoveryKey(uid)
 * General
     * .ping()
     * .close()
@@ -422,7 +422,7 @@ Returns:
         * emailCode - (Buffer16)
         * isPrimary - (boolean)
         * isVerified - (boolean)
-        * normalizedEmail - (string)        
+        * normalizedEmail - (string)
         * createdAt - (number)
 * rejects: with one of:
     * `error.notFound()` if no email address exists on emails table
@@ -617,7 +617,7 @@ Returns a promise that:
   if there was no matching token.
 * Rejects with any error
   from the underlying storage system
-  (wrapped in `error.wrap()`).  
+  (wrapped in `error.wrap()`).
 
 ## .verifyTokenCode(code, accountData)
 
@@ -638,7 +638,7 @@ Returns a promise that:
     if token expired.
   * Rejects with any error
     from the underlying storage system
-    (wrapped in `error.wrap()`).  
+    (wrapped in `error.wrap()`).
 
 ## .forgotPasswordVerified(tokenId, accountResetToken) ##
 
@@ -954,7 +954,7 @@ Returns:
   * Any error from the underlying storage system (wrapped in `error.wrap()`)
   * `error.notFound()` if this user found
 
-## getRecoveryKey(uid, recoveryKeyId)
+## getRecoveryKey(uid)
 
 Get the recovery key for this user.
 
@@ -962,8 +962,6 @@ Parameters:
 
 * `uid` (Buffer16):
   The uid of the owning account
-* `recoveryKeyId` (String)
-  The id for the recovery key
 
 Returns:
 
@@ -974,7 +972,7 @@ Returns:
   * Any error from the underlying storage system (wrapped in `error.wrap()`)
   * `error.notFound()` if this user or recovery key not found
 
-## deleteRecoveryKey(uid, recoveryKeyId)
+## deleteRecoveryKey(uid)
 
 Delete the recovery key for this user.
 
@@ -982,8 +980,6 @@ Parameters:
 
 * `uid` (Buffer16):
   The uid of the owning account
-* `recoveryKeyId` (String)
-  The id for the recovery key
 
 Returns:
 

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -1363,25 +1363,13 @@ module.exports = function (log, error) {
 
   Memory.prototype.createRecoveryKey = function (uid, data) {
     uid = uid.toString('hex')
-    const recoveryKeyId = data.recoveryKeyId.toString('hex')
     return getAccountByUid(uid)
       .then(() => {
-        if (! recoveryKeys[uid]) {
-          recoveryKeys[uid] = {}
-        }
-
-        const storedKeys = recoveryKeys[uid]
-
-        if (Object.keys(storedKeys).length > 0) {
-          // Temporarily throw duplicate if more than one key exists
+        if (recoveryKeys[uid]) {
           return P.reject(error.duplicate())
         }
 
-        if (storedKeys[recoveryKeyId]) {
-          return P.reject(error.duplicate())
-        }
-
-        storedKeys[recoveryKeyId] = {
+        recoveryKeys[uid] = {
           uid,
           recoveryKeyId: data.recoveryKeyId,
           recoveryData: data.recoveryData
@@ -1393,32 +1381,24 @@ module.exports = function (log, error) {
 
   Memory.prototype.getRecoveryKey = function (options) {
     const uid = options.id.toString('hex')
-    const recoveryKeyId = options.recoveryKeyId.toString('hex')
     return getAccountByUid(uid)
       .then(() => {
-        const keys = recoveryKeys[uid]
+        const recoveryKey = recoveryKeys[uid]
 
-        if (! keys || ! keys[recoveryKeyId]) {
+        if (! recoveryKey) {
           return P.reject(error.notFound())
         }
 
-        return keys[recoveryKeyId]
+        return recoveryKey
       })
   }
 
   Memory.prototype.deleteRecoveryKey = function (options) {
     const uid = options.id.toString('hex')
-    const recoveryKeyId = options.recoveryKeyId.toString('hex')
     return getAccountByUid(uid)
       .then(() => {
 
-        const keys = recoveryKeys[uid]
-
-        if (! keys || ! keys[recoveryKeyId]) {
-          return {}
-        }
-
-        delete keys[recoveryKeyId]
+        delete recoveryKeys[uid]
 
         return {}
       })

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -1531,7 +1531,7 @@ module.exports = function (log, error) {
       })
   }
 
-  const CREATE_RECOVERY_KEY = 'CALL createRecoveryKey_1(?, ?, ?)'
+  const CREATE_RECOVERY_KEY = 'CALL createRecoveryKey_2(?, ?, ?)'
   MySql.prototype.createRecoveryKey = function (uid, data) {
     const recoveryKeyId = data.recoveryKeyId
     const recoveryData = data.recoveryData
@@ -1548,9 +1548,9 @@ module.exports = function (log, error) {
       })
   }
 
-  const GET_RECOVERY_KEY = 'CALL getRecoveryKey_1(?, ?)'
+  const GET_RECOVERY_KEY = 'CALL getRecoveryKey_2(?)'
   MySql.prototype.getRecoveryKey = function (options) {
-    return this.readFirstResult(GET_RECOVERY_KEY, [options.id, options.recoveryKeyId])
+    return this.readFirstResult(GET_RECOVERY_KEY, [options.id])
       .then((results) => {
         // Throw if this user has no recovery keys
         if (results.length === 0) {
@@ -1561,9 +1561,9 @@ module.exports = function (log, error) {
       })
   }
 
-  const DELETE_RECOVERY_KEY = 'CALL deleteRecoveryKey_1(?, ?)'
+  const DELETE_RECOVERY_KEY = 'CALL deleteRecoveryKey_2(?)'
   MySql.prototype.deleteRecoveryKey = function (options) {
-    return this.write(DELETE_RECOVERY_KEY, [options.id, options.recoveryKeyId])
+    return this.write(DELETE_RECOVERY_KEY, [options.id])
       .then(() => {
         return {}
       })

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 83
+module.exports.level = 84

--- a/lib/db/schema/patch-083-084.sql
+++ b/lib/db/schema/patch-083-084.sql
@@ -1,0 +1,59 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('83');
+
+-- Since we are altering the size of the `recoveryKeyId` column
+-- we need to make sure that the column is empty before it can be applied.
+-- This table is ok to clear at this point because no user facing api
+-- has landed to create recovery keys.
+DELETE from recoveryKeys;
+
+ALTER TABLE recoveryKeys MODIFY COLUMN recoveryKeyId BINARY(16);
+
+CREATE PROCEDURE `createRecoveryKey_2` (
+  IN `uidArg` BINARY(16),
+  IN `recoveryKeyIdArg` BINARY(16),
+  IN `recoveryDataArg` TEXT
+)
+BEGIN
+
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  SET @accountCount = 0;
+
+  -- Signal error if no user found
+  SELECT COUNT(*) INTO @accountCount FROM `accounts` WHERE `uid` = `uidArg`;
+  IF @accountCount = 0 THEN
+    SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 1643, MESSAGE_TEXT = 'Can not create recovery key for unknown user.';
+  END IF;
+
+  INSERT INTO recoveryKeys (uid, recoveryKeyId, recoveryData) VALUES (uidArg, recoveryKeyIdArg, recoveryDataArg);
+
+  COMMIT;
+END;
+
+CREATE PROCEDURE `getRecoveryKey_2` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+
+  SELECT recoveryKeyId, recoveryData FROM recoveryKeys WHERE uid = uidArg;
+
+END;
+
+CREATE PROCEDURE `deleteRecoveryKey_2` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+
+  DELETE FROM recoveryKeys WHERE uid = uidArg;
+
+END;
+
+UPDATE dbMetadata SET value = '84' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-084-083.sql
+++ b/lib/db/schema/patch-084-083.sql
@@ -1,0 +1,9 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- ALTER TABLE recoveryKeys MODIFY COLUMN recoveryKeyId BINARY(64),
+-- ALGORITHM = COPY, LOCK = SHARED;
+-- DROP PROCEDURE createRecoveryKey_2;
+-- DROP PROCEDURE getRecoveryKey_2;
+-- DROP PROCEDURE deleteRecoveryKey_2;
+
+-- UPDATE dbMetadata SET value = '83' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
While building out https://github.com/mozilla/fxa-content-server/pull/6203, it has become more apparent that we don't need to pass the `recoveryKeyId` to get/delete a user's recovery data. `recoveryKeyId` can only be generated from the recovery key, which would cause us to prompt for it in order to get/delete the recovery data.

Additionally, user's can currently only have one recovery key so. In the future, we could re-look at removing the unique contraint.

This PR will cause some breakage in auth-server. WIP until auth-server PR is ready.