### PR TITLE
fix(tests): move local utils tests so they get run by npm t

### DIFF
--- a/test/local/utils.js
+++ b/test/local/utils.js
@@ -56,13 +56,6 @@ describe('utils', () => {
         .then((result) => codes = result)
     })
 
-    it('should not fail for empty keyspace', () => {
-      return dbUtils.generateRecoveryCodes(1, '', 1)
-        .then((result) => {
-          assert.equal(result[0], '')
-        })
-    })
-
     it('should generate correct count of codes', () => {
       assert.equal(codes.length, codeCount, 'correct number of codees generated')
     })


### PR DESCRIPTION
Fixes #376.

The tests in `test/lib/utils.js` weren't being exercised by `npm t`. Moving them into `test/local` fixes that.

Because they weren't being exercised, one of the tests had got into a failing state. Looking at it, I think it's a redundant test now because there is no keyspace argument to `generateRecoveryCodes`. Hence it's deleted here.

@mozilla/fxa-devs r?