### PR TITLE
fix(restify): set server.keepAliveTimeout to 120s, similar to in node6

### DIFF
--- a/db-server/index.js
+++ b/db-server/index.js
@@ -68,6 +68,13 @@ function createServer(db) {
     maxParamLength: 1530
   })
 
+  // Allow Keep-Alive connections from the auth-server to be idle up to two
+  // minutes before closing the connection. If this is not set, the default
+  // idle-time is 5 seconds.  This can cause a lot of unneeded churn in server
+  // connections. Setting this to 120s makes node8 behave more like node6. -
+  // https://nodejs.org/docs/latest-v8.x/api/http.html#http_server_keepalivetimeout
+  api.keepAliveTimeout = 120000
+
   api.use(restify.plugins.bodyParser())
   api.use(restify.plugins.queryParser())
   api.use(bufferize.bufferizeRequest.bind(null, new Set([


### PR DESCRIPTION
Same deal as https://github.com/mozilla/fxa-customs-server/pull/266#issue-207169665. Don't be so eager to close down keep-alive connections from auth-server.