### PR TITLE
fix(restify): set keepAliveTimeout correctly on api.server object

### DIFF
--- a/db-server/index.js
+++ b/db-server/index.js
@@ -73,7 +73,7 @@ function createServer(db) {
   // idle-time is 5 seconds.  This can cause a lot of unneeded churn in server
   // connections. Setting this to 120s makes node8 behave more like node6. -
   // https://nodejs.org/docs/latest-v8.x/api/http.html#http_server_keepalivetimeout
-  api.keepAliveTimeout = 120000
+  api.server.keepAliveTimeout = 120000
 
   api.use(restify.plugins.bodyParser())
   api.use(restify.plugins.queryParser())


### PR DESCRIPTION
(Same as fxa-customs-server):

Hey @vladikoff. I biffed setting this on my first try. This is the correct object location, and I've verified by watching tcpdump/netstat in stage with this fix that connections are held open until idle for 2 minutes.