### PR TITLE
chore(db): stop calling the upsertAvailableCommands procedure

### DIFF
--- a/db-server/test/backend/db_tests.js
+++ b/db-server/test/backend/db_tests.js
@@ -101,7 +101,8 @@ function makeMockDevice(tokenId) {
     callbackAuthKey: 'bar',
     callbackIsExpired: false,
     availableCommands: {
-      'https://identity.mozilla.com/cmd/display-uri': 'metadata-bundle'
+      // HACK: Disabled while we work through issues in prod
+      //'https://identity.mozilla.com/cmd/display-uri': 'metadata-bundle'
     }
   }
   device.deviceId = newUuid()
@@ -1024,15 +1025,17 @@ module.exports = function (config, DB) {
             return db.device(accountData.uid, deviceInfo.deviceId)
           })
           .then(device => assert.deepEqual(device.availableCommands, {
-            'https://identity.mozilla.com/cmd/display-uri': 'metadata-bundle'
+            // HACK: Disabled while we work through issues in prod
+            //'https://identity.mozilla.com/cmd/display-uri': 'metadata-bundle'
           }))
       })
 
       it('availableCommands are overwritten on update', () => {
         const newDevice = Object.assign({}, deviceInfo, {
           availableCommands: {
-            foo: 'bar',
-            second: 'command'
+            // HACK: Disabled while we work through issues in prod
+            //foo: 'bar',
+            //second: 'command'
           }
         })
         return db.updateDevice(accountData.uid, deviceInfo.deviceId, newDevice)
@@ -1040,15 +1043,17 @@ module.exports = function (config, DB) {
             return db.device(accountData.uid, deviceInfo.deviceId)
           })
           .then(device => assert.deepEqual(device.availableCommands, {
-            foo: 'bar',
-            second: 'command'
+            // HACK: Disabled while we work through issues in prod
+            //foo: 'bar',
+            //second: 'command'
           }))
       })
 
       it('availableCommands can update metadata on an existing command', () => {
         const newDevice = Object.assign({}, deviceInfo, {
           availableCommands: {
-            'https://identity.mozilla.com/cmd/display-uri': 'new-metadata'
+            // HACK: Disabled while we work through issues in prod
+            //'https://identity.mozilla.com/cmd/display-uri': 'new-metadata'
           }
         })
         return db.updateDevice(accountData.uid, deviceInfo.deviceId, newDevice)
@@ -1056,7 +1061,8 @@ module.exports = function (config, DB) {
             return db.device(accountData.uid, deviceInfo.deviceId)
           })
           .then(device => assert.deepEqual(device.availableCommands, {
-            'https://identity.mozilla.com/cmd/display-uri': 'new-metadata'
+            // HACK: Disabled while we work through issues in prod
+            //'https://identity.mozilla.com/cmd/display-uri': 'new-metadata'
           }))
       })
 
@@ -1072,8 +1078,9 @@ module.exports = function (config, DB) {
         const sessionToken2 = makeMockSessionToken(accountData.uid)
         const deviceInfo2 = Object.assign(makeMockDevice(sessionToken2.tokenId), {
           availableCommands: {
-            'https://identity.mozilla.com/cmd/display-uri': 'device-two-metadata',
-            'extra-command': 'extra-data'
+            // HACK: Disabled while we work through issues in prod
+            //'https://identity.mozilla.com/cmd/display-uri': 'device-two-metadata',
+            //'extra-command': 'extra-data'
           }
         })
         const sessionToken3 = makeMockSessionToken(accountData.uid)
@@ -1107,8 +1114,9 @@ module.exports = function (config, DB) {
         const sessionToken2 = makeMockSessionToken(accountData.uid)
         const deviceInfo2 = Object.assign(makeMockDevice(sessionToken2.tokenId), {
           availableCommands: {
-            'https://identity.mozilla.com/cmd/display-uri': 'device-two-metadata',
-            'extra-command': 'extra-data'
+            // HACK: Disabled while we work through issues in prod
+            //'https://identity.mozilla.com/cmd/display-uri': 'device-two-metadata',
+            //'extra-command': 'extra-data'
           }
         })
         const sessionToken3 = makeMockSessionToken(accountData.uid)

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -307,19 +307,22 @@ module.exports = function (log, error) {
     )
   }
 
+  // eslint-disable-next-line no-unused-vars
   const UPSERT_AVAILABLE_COMMAND = 'CALL upsertAvailableCommand_1(?, ?, ?, ?)'
   const PURGE_AVAILABLE_COMMANDS = 'CALL purgeAvailableCommands_1(?, ?)'
 
   function makeStatementsToAddAvailableCommands(uid, deviceId, deviceInfo) {
-    const availableCommands = deviceInfo.availableCommands || {}
-    return Object.keys(availableCommands).reduce((acc, commandName) => {
-      const commandData = availableCommands[commandName]
-      acc.push({
-        sql: UPSERT_AVAILABLE_COMMAND,
-        params: [uid, deviceId, commandName, commandData]
-      })
-      return acc
-    }, [])
+    // HACK: Disabled while we work through issues in prod
+    return []
+    //const availableCommands = deviceInfo.availableCommands || {}
+    //return Object.keys(availableCommands).reduce((acc, commandName) => {
+    //  const commandData = availableCommands[commandName]
+    //  acc.push({
+    //    sql: UPSERT_AVAILABLE_COMMAND,
+    //    params: [uid, deviceId, commandName, commandData]
+    //  })
+    //  return acc
+    //}, [])
   }
 
   const CREATE_DEVICE = 'CALL createDevice_4(?, ?, ?, ?, ?, ?, ?, ?, ?)'


### PR DESCRIPTION
Temporary hack to stop writing to the `deviceCommands` table. Since we're tagging a release I figured it made sense to leave the stored procedure in place and make `makeStatementsToAddAvailableCommands` a nop in the js code instead. And of course, a bunch of tests needed to change too.

@jbuck @jrgm @eoger r?