### PR TITLE
chore(db): ensure mem db behaves like mysql db

### DIFF
--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -532,7 +532,8 @@ module.exports = function (log, error) {
             callbackPublicKey: device.callbackPublicKey,
             callbackAuthKey: device.callbackAuthKey,
             callbackIsExpired: device.callbackIsExpired,
-            availableCommands: device.availableCommands
+            // HACK: Disabled while we work through issues in prod
+            availableCommands: {}
           })
         }
       )
@@ -610,7 +611,8 @@ module.exports = function (log, error) {
           item.deviceCallbackPublicKey = device.callbackPublicKey
           item.deviceCallbackAuthKey = device.callbackAuthKey
           item.deviceCallbackIsExpired = device.callbackIsExpired
-          item.deviceAvailableCommands = device.availableCommands
+          // HACK: Disabled while we work through issues in prod
+          item.deviceAvailableCommands = {}
         }
 
         return item
@@ -689,7 +691,8 @@ module.exports = function (log, error) {
           deviceCallbackPublicKey: deviceInfo.callbackPublicKey || null,
           deviceCallbackAuthKey: deviceInfo.callbackAuthKey || null,
           deviceCallbackIsExpired: deviceInfo.callbackIsExpired !== undefined ? deviceInfo.callbackIsExpired : null,
-          deviceAvailableCommands: deviceInfo.availableCommands || null
+          // HACK: Disabled while we work through issues in prod
+          deviceAvailableCommands: deviceInfo.availableCommands ? {} : null
         }
 
         return session


### PR DESCRIPTION
In #383, we temporarily disabled insertion of device commands into the MySQL db. We didn't do the same with the memory db though, which means the auth server tests see different behaviour depending on which backend they're running against. This change forces the memory backend to behave the same way.

@mozilla/fxa-devs r?