### PR TITLE
fix(scripts): remove nonsense (but harmless) comparison of bool to -1

### DIFF
--- a/scripts/analyze-mx-stats.js
+++ b/scripts/analyze-mx-stats.js
@@ -160,10 +160,10 @@ function canStaticallyDetermineMx(host, mxDomain) {
   if (host === 'gmail.com' && mxDomain === 'google.com') {
     return true
   }
-  if (host === 'yahoo.com' !== -1 && mxDomain === 'yahoodns.net') {
+  if (host === 'yahoo.com' && mxDomain === 'yahoodns.net') {
     return true
   }
-  if (host === 'fastmail.fm' !== -1 && mxDomain === 'messagingengine.com') {
+  if (host === 'fastmail.fm' && mxDomain === 'messagingengine.com') {
     return true
   }
   return false


### PR DESCRIPTION
Spotted this in the [lgtm alerts](https://lgtm.com/projects/g/mozilla/fxa-auth-db-mysql/alerts), presumably these `!== -1` tests are left over from an old `indexOf` test. Let's get rid of them.

@mozilla/fxa-devs r?