### PR TITLE
feat(account): add `profileChangedAt` property to account table

### DIFF
--- a/docs/DB_API.md
+++ b/docs/DB_API.md
@@ -139,7 +139,19 @@ Parameters:
 
 Returns:
 
-* success - returns the account object above
+* data:
+    * email - (string)
+    * normalizedEmail - (string) the same as above but `.toLowerCase()`
+    * emailCode - (Buffer16)
+    * emailVerified - (number) 0|1, to show whether an account has been verified
+    * createdAt - (number) an epoch, such as that created with `Date.now()`
+    * verifyHash - (Buffer32)
+    * authSalt - (Buffer32)
+    * wrapWrapKb - (Buffer32)
+    * verifierSetAt - (number) an epoch, such as that created with `Date.now()`
+    * verifierVersion - (number) currently always set to 1, may be 2 or more in the future
+    * profileChangedAt - (number) an epoch, such as that created with `Date.now()`
+
 * error (can be either):
     * a `error.notFound()` if this account does not exist
     * an error from the underlying storage system
@@ -384,6 +396,7 @@ Returns:
         * authSalt - (Buffer32)
         * verifierSetAt - (number) an epoch
         * primaryEmail - (string)
+        * profileChangedAt = (number) an epoch
 * rejects: with one of:
     * `error.notFound()` if no account exists for this email address
     * any error from the underlying storage engine

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -460,7 +460,7 @@ module.exports = function (log, error) {
   // Fields : t.tokenData, t.uid, t.createdAt, t.uaBrowser, t.uaBrowserVersion, t.uaOS,
   //          t.uaOSVersion, t.uaDeviceType, t.uaFormFactor, t.lastAccessTime, t.authAt,
   //          a.emailVerified, a.email, a.emailCode, a.verifierSetAt, a.locale,
-  //          a.createdAt AS accountCreatedAt,
+  //          a.createdAt AS accountCreatedAt, a.profileChangedAt,
   //          d.id AS deviceId, d.name AS deviceName, d.type AS deviceType, d.createdAt
   //          AS deviceCreatedAt, d.callbackURL AS deviceCallbackURL, d.callbackPublicKey
   //          AS deviceCallbackPublicKey, d.callbackAuthKey AS deviceCallbackAuthKey,
@@ -468,7 +468,7 @@ module.exports = function (log, error) {
   //          ut.tokenVerificationId, ut.mustVerify
   // Where  : t.tokenId = $1 AND t.uid = a.uid AND t.tokenId = d.sessionTokenId AND
   //          t.uid = d.uid AND t.tokenId = u.tokenId
-  var SESSION_DEVICE = 'CALL sessionWithDevice_15(?)'
+  var SESSION_DEVICE = 'CALL sessionWithDevice_16(?)'
 
   MySql.prototype.sessionToken = function (id) {
     return this.readAllResults(SESSION_DEVICE, [id])
@@ -552,9 +552,10 @@ module.exports = function (log, error) {
   }
 
   // Select : accounts
-  // Fields : uid, email, normalizedEmail, emailVerified, emailCode, kA, wrapWrapKb, verifierVersion, authSalt, verifierSetAt, createdAt, locale, lockedAt
+  // Fields : uid, email, normalizedEmail, emailVerified, emailCode, kA, wrapWrapKb, verifierVersion, authSalt,
+  //          verifierSetAt, createdAt, locale, lockedAt, profileChangedAt
   // Where  : accounts.uid = LOWER($1)
-  var ACCOUNT = 'CALL account_3(?)'
+  var ACCOUNT = 'CALL account_4(?)'
 
   MySql.prototype.account = function (uid) {
     return this.readFirstResult(ACCOUNT, [uid])
@@ -774,7 +775,7 @@ module.exports = function (log, error) {
   // Update : accounts
   // Set    : verifyHash = $2, authSalt = $3, wrapWrapKb = $4, verifierSetAt = $5, verifierVersion = $6
   // Where  : uid = $1
-  var RESET_ACCOUNT = 'CALL resetAccount_8(?, ?, ?, ?, ?, ?)'
+  var RESET_ACCOUNT = 'CALL resetAccount_9(?, ?, ?, ?, ?, ?)'
 
   MySql.prototype.resetAccount = function (uid, data) {
     return this.write(
@@ -786,7 +787,7 @@ module.exports = function (log, error) {
   // Update : accounts, emails
   // Set    : emailVerified = true if email is in accounts table or isVerified = true if on email table
   // Where  : uid = $1, emailCode = $2
-  var VERIFY_EMAIL = 'CALL verifyEmail_5(?, ?)'
+  var VERIFY_EMAIL = 'CALL verifyEmail_6(?, ?)'
 
   MySql.prototype.verifyEmail = function (uid, emailCode) {
     return this.write(VERIFY_EMAIL, [uid, emailCode])
@@ -892,9 +893,10 @@ module.exports = function (log, error) {
   }
 
   // Select : accounts
-  // Fields : uid, email, normalizedEmail, emailVerified, emailCode, kA, wrapWrapKb, verifierVersion, authSalt, verifierSetAt, createdAt, lockedAt, primaryEmail
+  // Fields : uid, email, normalizedEmail, emailVerified, emailCode, kA, wrapWrapKb, verifierVersion, authSalt,
+  //          verifierSetAt, createdAt, lockedAt, primaryEmail, profileChangedAt
   // Where  : emails.normalizedEmail = LOWER($1)
-  var GET_ACCOUNT_RECORD = 'CALL accountRecord_2(?)'
+  var GET_ACCOUNT_RECORD = 'CALL accountRecord_3(?)'
   MySql.prototype.accountRecord = function (email) {
     return this.readFirstResult(GET_ACCOUNT_RECORD, [email])
   }
@@ -913,7 +915,7 @@ module.exports = function (log, error) {
 
   // Update : emails
   // Values : uid = $1, email = $2
-  var SET_PRIMARY_EMAIL = 'CALL setPrimaryEmail_1(?, ?)'
+  var SET_PRIMARY_EMAIL = 'CALL setPrimaryEmail_2(?, ?)'
   MySql.prototype.setPrimaryEmail = function (uid, email) {
     return this.write(
       SET_PRIMARY_EMAIL,
@@ -926,7 +928,7 @@ module.exports = function (log, error) {
 
   // Delete : emails
   // Values : uid = $1, email = $2
-  var DELETE_EMAIL = 'CALL deleteEmail_2(?, ?)'
+  var DELETE_EMAIL = 'CALL deleteEmail_3(?, ?)'
   MySql.prototype.deleteEmail = function (uid, email) {
     return this.write(
       DELETE_EMAIL,
@@ -1407,12 +1409,12 @@ module.exports = function (log, error) {
     return this.readFirstResult(GET_TOTP_TOKEN, [uid])
   }
 
-  const DELETE_TOTP_TOKEN = 'CALL deleteTotpToken_1(?)'
+  const DELETE_TOTP_TOKEN = 'CALL deleteTotpToken_2(?)'
   MySql.prototype.deleteTotpToken = function (uid) {
     return this.write(DELETE_TOTP_TOKEN, [uid])
   }
 
-  const UPDATE_TOTP_TOKEN = 'CALL updateTotpToken_1(?, ?, ?)'
+  const UPDATE_TOTP_TOKEN = 'CALL updateTotpToken_2(?, ?, ?)'
   MySql.prototype.updateTotpToken = function (uid, token) {
     return this.read(UPDATE_TOTP_TOKEN, [
       uid,

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 86
+module.exports.level = 87

--- a/lib/db/schema/patch-086-087.sql
+++ b/lib/db/schema/patch-086-087.sql
@@ -1,0 +1,252 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('86');
+
+-- Add the `profileChangedAt` column to the accounts table.
+-- Default NULL implies that the account profile hasn't changed since it
+-- was created.
+ALTER TABLE accounts ADD COLUMN profileChangedAt BIGINT UNSIGNED DEFAULT NULL,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+-- Update `profileChangedAt` when emails are changed, verified or deleted
+CREATE PROCEDURE `setPrimaryEmail_2` (
+  IN `inUid` BINARY(16),
+  IN `inNormalizedEmail` VARCHAR(255)
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+     UPDATE emails SET isPrimary = false WHERE uid = inUid AND isPrimary = true;
+     UPDATE emails SET isPrimary = true WHERE uid = inUid AND isPrimary = false AND normalizedEmail = inNormalizedEmail;
+
+     SELECT ROW_COUNT() INTO @updateCount;
+     IF @updateCount = 0 THEN
+        SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 1062, MESSAGE_TEXT = 'Can not change email. Could not find email.';
+     END IF;
+
+     UPDATE accounts SET profileChangedAt = (UNIX_TIMESTAMP(NOW(3)) * 1000) WHERE uid = inUid;
+  COMMIT;
+END;
+
+CREATE PROCEDURE `verifyEmail_6`(
+    IN `inUid` BINARY(16),
+    IN `inEmailCode` BINARY(16)
+)
+BEGIN
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    START TRANSACTION;
+
+    UPDATE accounts SET emailVerified = true WHERE uid = inUid AND emailCode = inEmailCode;
+    UPDATE emails SET isVerified = true WHERE uid = inUid AND emailCode = inEmailCode;
+
+    UPDATE accounts SET profileChangedAt = (UNIX_TIMESTAMP(NOW(3)) * 1000) WHERE uid = inUid;
+
+    COMMIT;
+END;
+
+CREATE PROCEDURE `deleteEmail_3` (
+    IN `inUid` BINARY(16),
+    IN `inNormalizedEmail` VARCHAR(255)
+)
+BEGIN
+    SET @primaryEmailCount = 0;
+
+    -- Don't delete primary email addresses
+    SELECT COUNT(*) INTO @primaryEmailCount FROM emails WHERE normalizedEmail = inNormalizedEmail AND uid = inUid AND isPrimary = true;
+    IF @primaryEmailCount = 1 THEN
+        SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 2100, MESSAGE_TEXT = 'Can not delete a primary email address.';
+    END IF;
+
+    DELETE FROM emails WHERE normalizedEmail = inNormalizedEmail AND uid = inUid AND isPrimary = false;
+
+    UPDATE accounts SET profileChangedAt = (UNIX_TIMESTAMP(NOW(3)) * 1000) WHERE uid = inUid;
+END;
+
+-- Update `profileChangedAt` when TOTP is only verified or deleted on an account.
+-- When a TOTP token is created, it doesn't get "turned on" until after a
+-- call to updateTotpToken. An unverified token would not have changed anything on the account.
+CREATE PROCEDURE `deleteTotpToken_2` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  DELETE FROM totp WHERE uid = uidArg;
+
+  UPDATE accounts SET profileChangedAt = (UNIX_TIMESTAMP(NOW(3)) * 1000) WHERE uid = uidArg;
+END;
+
+CREATE PROCEDURE `updateTotpToken_2` (
+  IN `uidArg` BINARY(16),
+  IN `verifiedArg` BOOLEAN,
+  IN `enabledArg` BOOLEAN
+)
+BEGIN
+
+  UPDATE `totp` SET verified = verifiedArg, enabled = enabledArg WHERE uid = uidArg;
+
+  UPDATE accounts SET profileChangedAt = (UNIX_TIMESTAMP(NOW(3)) * 1000) WHERE uid = uidArg;
+END;
+
+
+CREATE PROCEDURE `resetAccount_9` (
+  IN `uidArg` BINARY(16),
+  IN `verifyHashArg` BINARY(32),
+  IN `authSaltArg` BINARY(32),
+  IN `wrapWrapKbArg` BINARY(32),
+  IN `verifierSetAtArg` BIGINT UNSIGNED,
+  IN `VerifierVersionArg` TINYINT UNSIGNED
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  DELETE FROM sessionTokens WHERE uid = uidArg;
+  DELETE FROM keyFetchTokens WHERE uid = uidArg;
+  DELETE FROM accountResetTokens WHERE uid = uidArg;
+  DELETE FROM passwordChangeTokens WHERE uid = uidArg;
+  DELETE FROM passwordForgotTokens WHERE uid = uidArg;
+  DELETE FROM devices WHERE uid = uidArg;
+  DELETE FROM unverifiedTokens WHERE uid = uidArg;
+
+  UPDATE accounts
+  SET
+    verifyHash = verifyHashArg,
+    authSalt = authSaltArg,
+    wrapWrapKb = wrapWrapKbArg,
+    verifierSetAt = verifierSetAtArg,
+    verifierVersion = verifierVersionArg,
+    profileChangedAt = verifierSetAtArg
+  WHERE uid = uidArg;
+
+  COMMIT;
+END;
+
+-- Update get sessionToken to return `profileChangedAt`
+CREATE PROCEDURE `sessionWithDevice_16` (
+  IN `tokenIdArg` BINARY(32)
+)
+BEGIN
+  SELECT
+    t.tokenData,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.uaFormFactor,
+    t.lastAccessTime,
+    t.verificationMethod,
+    t.verifiedAt,
+    COALESCE(t.authAt, t.createdAt) AS authAt,
+    e.isVerified AS emailVerified,
+    e.email,
+    e.emailCode,
+    a.verifierSetAt,
+    a.locale,
+    COALESCE(a.profileChangedAt, a.verifierSetAt, a.createdAt) AS profileChangedAt,
+    a.createdAt AS accountCreatedAt,
+    d.id AS deviceId,
+    d.nameUtf8 AS deviceName,
+    d.type AS deviceType,
+    d.createdAt AS deviceCreatedAt,
+    d.callbackURL AS deviceCallbackURL,
+    d.callbackPublicKey AS deviceCallbackPublicKey,
+    d.callbackAuthKey AS deviceCallbackAuthKey,
+    d.callbackIsExpired AS deviceCallbackIsExpired,
+    ci.commandName AS deviceCommandName,
+    dc.commandData AS deviceCommandData,
+    ut.tokenVerificationId,
+    COALESCE(t.mustVerify, ut.mustVerify) AS mustVerify
+  FROM sessionTokens AS t
+  LEFT JOIN accounts AS a
+    ON t.uid = a.uid
+  LEFT JOIN emails AS e
+    ON t.uid = e.uid
+    AND e.isPrimary = true
+  LEFT JOIN devices AS d
+    ON (t.tokenId = d.sessionTokenId AND t.uid = d.uid)
+  LEFT JOIN (
+    deviceCommands AS dc FORCE INDEX (PRIMARY)
+    INNER JOIN deviceCommandIdentifiers AS ci FORCE INDEX (PRIMARY)
+      ON ci.commandId = dc.commandId
+  ) ON (dc.uid = d.uid AND dc.deviceId = d.id)
+  LEFT JOIN unverifiedTokens AS ut
+    ON t.tokenId = ut.tokenId
+  WHERE t.tokenId = tokenIdArg;
+END;
+
+-- Return `profileChangedAt` with account record
+CREATE PROCEDURE `accountRecord_3` (
+  IN `inEmail` VARCHAR(255)
+)
+BEGIN
+    SELECT
+        a.uid,
+        a.email,
+        a.normalizedEmail,
+        a.emailVerified,
+        a.emailCode,
+        a.kA,
+        a.wrapWrapKb,
+        a.verifierVersion,
+        a.authSalt,
+        a.verifierSetAt,
+        a.createdAt,
+        a.locale,
+        a.lockedAt,
+        COALESCE(a.profileChangedAt, a.verifierSetAt, a.createdAt) AS profileChangedAt,
+        e.normalizedEmail AS primaryEmail
+    FROM
+        accounts a,
+        emails e
+    WHERE
+        a.uid = (SELECT uid FROM emails WHERE normalizedEmail = LOWER(inEmail))
+    AND
+        a.uid = e.uid
+    AND
+        e.isPrimary = true;
+END;
+
+CREATE PROCEDURE `account_4` (
+    IN `inUid` BINARY(16)
+)
+BEGIN
+    SELECT
+        a.uid,
+        a.email,
+        a.normalizedEmail,
+        a.emailVerified,
+        a.emailCode,
+        a.kA,
+        a.wrapWrapKb,
+        a.verifierVersion,
+        a.authSalt,
+        a.verifierSetAt,
+        a.createdAt,
+        a.locale,
+        a.lockedAt,
+        COALESCE(a.profileChangedAt, a.verifierSetAt, a.createdAt) AS profileChangedAt
+    FROM
+        accounts a
+    WHERE
+        a.uid = LOWER(inUid)
+    ;
+END;
+
+UPDATE dbMetadata SET value = '87' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-087-086.sql
+++ b/lib/db/schema/patch-087-086.sql
@@ -1,0 +1,16 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- ALTER TABLE accounts DROP COLUMN profileChangedAt, ALGORITHM = INPLACE, LOCK = NONE;
+
+-- DROP PROCEDURE setPrimaryEmail_2;
+-- DROP PROCEDURE verifyEmail_6;
+-- DROP PROCEDURE deleteEmail_3;
+-- DROP PROCEDURE deleteTotpToken_2;
+-- DROP PROCEDURE updateTotpToken_2;
+-- DROP PROCEDURE resetAccount_9;
+
+-- DROP PROCEDURE sessionWithDevice_16;
+-- DROP PROCEDURE account_4;
+-- DROP PROCEDURE accountRecord_3;
+
+-- UPDATE dbMetadata SET value = '86' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
Connects to https://github.com/mozilla/fxa-auth-server/issues/2490
Fixes https://github.com/mozilla/fxa-auth-db-mysql/issues/397

- [x] Add memory implementation
- [x] Update account procedures to return new value
- [x] Update unit test

This PR adds the `profileChangedAt` property to the accounts table. The property currently updated when a successful call to these methods are made

* setPrimaryEmail
* verifyEmail
* deleteEmail
* deleteTotpToken
* updateTotpToken
* deletePasswordChangeToken (password changed)
* resetAccount

I opted not to update the value when changes were made to recovery keys since that didn't feel like a core profile change (can be convinced otherwise).

The property is returned when using these methods
* sessionToken
* account
* accountRecord