### PR TITLE
chore(tests): add test coverage for ORDER BY clause of fetchEmailBounces

### DIFF
--- a/db-server/test/backend/db_tests.js
+++ b/db-server/test/backend/db_tests.js
@@ -1523,20 +1523,26 @@ module.exports = function (config, DB) {
     it(
       'emailBounces',
       () => {
-        const data = {
-          email: ('' + Math.random()).substr(2) + '@email.bounces',
+        const email = `${`${Math.random()}`.substr(2)}@example.com`
+        return db.createEmailBounce({
+          email,
           bounceType: 'Permanent',
           bounceSubType: 'NoEmail'
-        }
-        return db.createEmailBounce(data)
-          .then(() => {
-            return db.fetchEmailBounces(data.email)
-          })
+        })
+          .then(() => db.createEmailBounce({
+            email,
+            bounceType: 'Transient',
+            bounceSubType: 'General'
+          }))
+          .then(() => db.fetchEmailBounces(email))
           .then(bounces => {
-            assert.equal(bounces.length, 1)
-            assert.equal(bounces[0].email, data.email)
-            assert.equal(bounces[0].bounceType, 1)
-            assert.equal(bounces[0].bounceSubType, 3)
+            assert.equal(bounces.length, 2)
+            assert.equal(bounces[0].email, email)
+            assert.equal(bounces[0].bounceType, 2)
+            assert.equal(bounces[0].bounceSubType, 2)
+            assert.equal(bounces[1].email, email)
+            assert.equal(bounces[1].bounceType, 1)
+            assert.equal(bounces[1].bounceSubType, 3)
           })
       }
     )


### PR DESCRIPTION
While debugging what seems like it may be a bug in fxa-email-service, I noticed there was no test coverage in this repo for the order of results returned by `fetchEmailBounces`. Since the ordering is a pre-requisite for our bounce logic to work sanely, it seems like something we should test for here. (there is some coverage in the auth server too)

@mozilla/fxa-devs r?