### PR TITLE
fix(mem): ensure emailBounces are stored most-recent first

### DIFF
--- a/db-server/test/backend/db_tests.js
+++ b/db-server/test/backend/db_tests.js
@@ -1523,20 +1523,26 @@ module.exports = function (config, DB) {
     it(
       'emailBounces',
       () => {
-        const data = {
-          email: ('' + Math.random()).substr(2) + '@email.bounces',
+        const email = `${`${Math.random()}`.substr(2)}@example.com`
+        return db.createEmailBounce({
+          email,
           bounceType: 'Permanent',
           bounceSubType: 'NoEmail'
-        }
-        return db.createEmailBounce(data)
-          .then(() => {
-            return db.fetchEmailBounces(data.email)
-          })
+        })
+          .then(() => db.createEmailBounce({
+            email,
+            bounceType: 'Transient',
+            bounceSubType: 'General'
+          }))
+          .then(() => db.fetchEmailBounces(email))
           .then(bounces => {
-            assert.equal(bounces.length, 1)
-            assert.equal(bounces[0].email, data.email)
-            assert.equal(bounces[0].bounceType, 1)
-            assert.equal(bounces[0].bounceSubType, 3)
+            assert.equal(bounces.length, 2)
+            assert.equal(bounces[0].email, email)
+            assert.equal(bounces[0].bounceType, 2)
+            assert.equal(bounces[0].bounceSubType, 2)
+            assert.equal(bounces[1].email, email)
+            assert.equal(bounces[1].bounceType, 1)
+            assert.equal(bounces[1].bounceSubType, 3)
           })
       }
     )

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -1074,7 +1074,7 @@ module.exports = function (log, error) {
     bounce.createdAt = Date.now()
     bounce.bounceType = dbUtil.mapEmailBounceType(bounce.bounceType)
     bounce.bounceSubType = dbUtil.mapEmailBounceSubType(bounce.bounceSubType)
-    row.push(bounce)
+    row.unshift(bounce)
     return P.resolve({})
   }
 


### PR DESCRIPTION
The memory backend was appending to the bounce/complaint array, which meant it was returning items in the opposite order to the MySQL backend. The order of those items is significant to our bounce and complaint handling logic.

@mozilla/fxa-devs r?