### PR TITLE
Train 123 rollback profilechangedat

### DIFF
--- a/db-server/test/backend/db_tests.js
+++ b/db-server/test/backend/db_tests.js
@@ -748,7 +748,9 @@ module.exports = function (config, DB) {
         .then(function (account) {
           assert(account.emailVerified, 'account should now be emailVerified (truthy)')
           assert.equal(account.emailVerified, 1, 'account should now be emailVerified (1)')
-          assert.equal(account.profileChangedAt > account.createdAt, true, 'profileChangedAt updated')
+
+          // With migration 91, profileChangedAt will at a minimum be the createdAt timestamp
+          assert.equal(account.profileChangedAt >= account.createdAt, true, 'profileChangedAt updated')
         })
     })
 
@@ -1621,7 +1623,8 @@ module.exports = function (config, DB) {
 
             return db.account(accountData.uid)
               .then((account) => {
-                assert.equal(account.profileChangedAt > account.createdAt, true, 'profileChangedAt updated')
+                // With migration 91, profileChangedAt will at a minimum be the createdAt timestamp
+                assert.equal(account.profileChangedAt >= account.createdAt, true, 'profileChangedAt updated')
               })
           })
       })
@@ -1645,7 +1648,8 @@ module.exports = function (config, DB) {
 
             return db.account(accountData.uid)
               .then((account) => {
-                assert.equal(account.profileChangedAt > account.createdAt, true, 'profileChangedAt updated')
+                // With migration 91, profileChangedAt will at a minimum be the createdAt timestamp
+                assert.equal(account.profileChangedAt >= account.createdAt, true, 'profileChangedAt updated')
               })
           })
       })
@@ -1934,7 +1938,7 @@ module.exports = function (config, DB) {
             assert.deepEqual(res[0].primaryEmail, secondEmail.email, 'primary email should be set to update email')
             assert.ok(res[0].createdAt, 'should set createdAt')
             assert.deepEqual(res[0].createdAt, res[1].createdAt, 'account records should have the same createdAt')
-            assert.equal(res[0].profileChangedAt > res[0].createdAt, true, 'profileChangedAt updated')
+            assert.equal(res[0].profileChangedAt >= res[0].createdAt, true, 'profileChangedAt updated')
           })
       })
     })
@@ -2072,7 +2076,8 @@ module.exports = function (config, DB) {
                 return db.account(accountData.uid)
               })
               .then((account) => {
-                assert.equal(account.profileChangedAt > account.createdAt, true, 'profileChangedAt updated')
+                // With migration 91, profileChangedAt will at a minimum be the createdAt timestamp
+                assert.equal(account.profileChangedAt >= account.createdAt, true, 'profileChangedAt updated')
               })
           })
       })
@@ -2091,7 +2096,8 @@ module.exports = function (config, DB) {
                 return db.account(accountData.uid)
               })
               .then((account) => {
-                assert.equal(account.profileChangedAt > account.createdAt, true, 'profileChangedAt updated')
+                // With migration 91, profileChangedAt will at a minimum be the createdAt timestamp
+                assert.equal(account.profileChangedAt >= account.createdAt, true, 'profileChangedAt updated')
               })
           })
       })

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -72,7 +72,7 @@ module.exports = function (log, error) {
     var item = extend({}, account)
     delete item.verifyHash
 
-    item.profileChangedAt = item.profileChangedAt || item.verifierSetAt || item.createdAt
+    item.profileChangedAt = item.verifierSetAt || item.createdAt
 
     return P.resolve(item)
   }
@@ -569,7 +569,7 @@ module.exports = function (log, error) {
     var account = accounts[accountId]
 
     item.verifierSetAt = account.verifierSetAt
-    item.profileChangedAt = account.profileChangedAt || account.verifierSetAt || account.createdAt
+    item.profileChangedAt =  account.verifierSetAt || account.createdAt
     item.locale = account.locale
     item.accountCreatedAt = account.createdAt
 
@@ -832,7 +832,6 @@ module.exports = function (log, error) {
             // Verify email record if it matches emailCode
             if (emailRecord.emailCode.toString('hex') === emailCode.toString('hex')) {
               emailRecord.isVerified = 1
-              account.profileChangedAt = Date.now()
               return true
             }
 
@@ -888,7 +887,6 @@ module.exports = function (log, error) {
           account.wrapWrapKb = data.wrapWrapKb
           account.verifierSetAt = data.verifierSetAt
           account.verifierVersion = data.verifierVersion
-          account.profileChangedAt = data.verifierSetAt
           account.devices = {}
           return []
         }
@@ -1130,6 +1128,8 @@ module.exports = function (log, error) {
           }
         })
 
+        account.profileChangedAt = account.verifierSetAt || account.createdAt
+
         return account
       })
   }
@@ -1168,7 +1168,6 @@ module.exports = function (log, error) {
 
     return getAccountByUid(uid)
       .then((account) => {
-        account.profileChangedAt = Date.now()
         return P.resolve({})
       })
   }
@@ -1200,7 +1199,6 @@ module.exports = function (log, error) {
 
     return getAccountByUid(uid)
       .then((account) => {
-        account.profileChangedAt = Date.now()
         return P.resolve({})
       })
   }
@@ -1275,7 +1273,6 @@ module.exports = function (log, error) {
 
     return getAccountByUid(uid)
       .then((account) => {
-        account.profileChangedAt = Date.now()
         return Promise.resolve({})
       })
   }
@@ -1299,7 +1296,6 @@ module.exports = function (log, error) {
 
     return getAccountByUid(uid)
       .then((account) => {
-        account.profileChangedAt = Date.now()
         return Promise.resolve({})
       })
   }

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -468,7 +468,7 @@ module.exports = function (log, error) {
   //          ut.tokenVerificationId, ut.mustVerify
   // Where  : t.tokenId = $1 AND t.uid = a.uid AND t.tokenId = d.sessionTokenId AND
   //          t.uid = d.uid AND t.tokenId = u.tokenId
-  var SESSION_DEVICE = 'CALL sessionWithDevice_16(?)'
+  var SESSION_DEVICE = 'CALL sessionWithDevice_17(?)'
 
   MySql.prototype.sessionToken = function (id) {
     return this.readAllResults(SESSION_DEVICE, [id])
@@ -555,7 +555,7 @@ module.exports = function (log, error) {
   // Fields : uid, email, normalizedEmail, emailVerified, emailCode, kA, wrapWrapKb, verifierVersion, authSalt,
   //          verifierSetAt, createdAt, locale, lockedAt, profileChangedAt
   // Where  : accounts.uid = LOWER($1)
-  var ACCOUNT = 'CALL account_4(?)'
+  var ACCOUNT = 'CALL account_5(?)'
 
   MySql.prototype.account = function (uid) {
     return this.readFirstResult(ACCOUNT, [uid])
@@ -775,7 +775,7 @@ module.exports = function (log, error) {
   // Update : accounts
   // Set    : verifyHash = $2, authSalt = $3, wrapWrapKb = $4, verifierSetAt = $5, verifierVersion = $6
   // Where  : uid = $1
-  var RESET_ACCOUNT = 'CALL resetAccount_9(?, ?, ?, ?, ?, ?)'
+  var RESET_ACCOUNT = 'CALL resetAccount_10(?, ?, ?, ?, ?, ?)'
 
   MySql.prototype.resetAccount = function (uid, data) {
     return this.write(
@@ -787,7 +787,7 @@ module.exports = function (log, error) {
   // Update : accounts, emails
   // Set    : emailVerified = true if email is in accounts table or isVerified = true if on email table
   // Where  : uid = $1, emailCode = $2
-  var VERIFY_EMAIL = 'CALL verifyEmail_6(?, ?)'
+  var VERIFY_EMAIL = 'CALL verifyEmail_7(?, ?)'
 
   MySql.prototype.verifyEmail = function (uid, emailCode) {
     return this.write(VERIFY_EMAIL, [uid, emailCode])
@@ -896,7 +896,7 @@ module.exports = function (log, error) {
   // Fields : uid, email, normalizedEmail, emailVerified, emailCode, kA, wrapWrapKb, verifierVersion, authSalt,
   //          verifierSetAt, createdAt, lockedAt, primaryEmail, profileChangedAt
   // Where  : emails.normalizedEmail = LOWER($1)
-  var GET_ACCOUNT_RECORD = 'CALL accountRecord_3(?)'
+  var GET_ACCOUNT_RECORD = 'CALL accountRecord_4(?)'
   MySql.prototype.accountRecord = function (email) {
     return this.readFirstResult(GET_ACCOUNT_RECORD, [email])
   }
@@ -915,7 +915,7 @@ module.exports = function (log, error) {
 
   // Update : emails
   // Values : uid = $1, email = $2
-  var SET_PRIMARY_EMAIL = 'CALL setPrimaryEmail_2(?, ?)'
+  var SET_PRIMARY_EMAIL = 'CALL setPrimaryEmail_3(?, ?)'
   MySql.prototype.setPrimaryEmail = function (uid, email) {
     return this.write(
       SET_PRIMARY_EMAIL,
@@ -928,7 +928,7 @@ module.exports = function (log, error) {
 
   // Delete : emails
   // Values : uid = $1, email = $2
-  var DELETE_EMAIL = 'CALL deleteEmail_3(?, ?)'
+  var DELETE_EMAIL = 'CALL deleteEmail_4(?, ?)'
   MySql.prototype.deleteEmail = function (uid, email) {
     return this.write(
       DELETE_EMAIL,
@@ -1409,12 +1409,12 @@ module.exports = function (log, error) {
     return this.readFirstResult(GET_TOTP_TOKEN, [uid])
   }
 
-  const DELETE_TOTP_TOKEN = 'CALL deleteTotpToken_2(?)'
+  const DELETE_TOTP_TOKEN = 'CALL deleteTotpToken_3(?)'
   MySql.prototype.deleteTotpToken = function (uid) {
     return this.write(DELETE_TOTP_TOKEN, [uid])
   }
 
-  const UPDATE_TOTP_TOKEN = 'CALL updateTotpToken_2(?, ?, ?)'
+  const UPDATE_TOTP_TOKEN = 'CALL updateTotpToken_3(?, ?, ?)'
   MySql.prototype.updateTotpToken = function (uid, token) {
     return this.read(UPDATE_TOTP_TOKEN, [
       uid,

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 90
+module.exports.level = 91

--- a/lib/db/schema/patch-090-091.sql
+++ b/lib/db/schema/patch-090-091.sql
@@ -1,0 +1,243 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('90');
+
+-- The `profileChangedAt` column may or may not exist in production env depending
+-- on how migration 87 went. If it doesn't exist, then this statement will error because
+-- you can not drop non-existent column in MySQL.
+ALTER TABLE accounts DROP COLUMN profileChangedAt,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+-- Removes the `profileChangedAt` update from setting primary email
+CREATE PROCEDURE `setPrimaryEmail_3` (
+  IN `inUid` BINARY(16),
+  IN `inNormalizedEmail` VARCHAR(255)
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+     UPDATE emails SET isPrimary = false WHERE uid = inUid AND isPrimary = true;
+     UPDATE emails SET isPrimary = true WHERE uid = inUid AND isPrimary = false AND normalizedEmail = inNormalizedEmail;
+
+     SELECT ROW_COUNT() INTO @updateCount;
+     IF @updateCount = 0 THEN
+        SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 1062, MESSAGE_TEXT = 'Can not change email. Could not find email.';
+     END IF;
+
+  COMMIT;
+END;
+
+-- Removes the `profileChangedAt` update when verifying new email
+CREATE PROCEDURE `verifyEmail_7`(
+    IN `inUid` BINARY(16),
+    IN `inEmailCode` BINARY(16)
+)
+BEGIN
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    START TRANSACTION;
+
+    UPDATE accounts SET emailVerified = true WHERE uid = inUid AND emailCode = inEmailCode;
+    UPDATE emails SET isVerified = true WHERE uid = inUid AND emailCode = inEmailCode;
+
+    COMMIT;
+END;
+
+-- Removes the `profileChangedAt` update when deleting email
+CREATE PROCEDURE `deleteEmail_4` (
+    IN `inUid` BINARY(16),
+    IN `inNormalizedEmail` VARCHAR(255)
+)
+BEGIN
+    SET @primaryEmailCount = 0;
+
+    -- Don't delete primary email addresses
+    SELECT COUNT(*) INTO @primaryEmailCount FROM emails WHERE normalizedEmail = inNormalizedEmail AND uid = inUid AND isPrimary = true;
+    IF @primaryEmailCount = 1 THEN
+        SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 2100, MESSAGE_TEXT = 'Can not delete a primary email address.';
+    END IF;
+
+    DELETE FROM emails WHERE normalizedEmail = inNormalizedEmail AND uid = inUid AND isPrimary = false;
+END;
+
+-- Removes the `profileChangedAt` update when a TOTP token is deleted
+CREATE PROCEDURE `deleteTotpToken_3` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  DELETE FROM totp WHERE uid = uidArg;
+END;
+
+-- Removes the `profileChangedAt` update when a TOTP is updated
+CREATE PROCEDURE `updateTotpToken_3` (
+  IN `uidArg` BINARY(16),
+  IN `verifiedArg` BOOLEAN,
+  IN `enabledArg` BOOLEAN
+)
+BEGIN
+  UPDATE `totp` SET verified = verifiedArg, enabled = enabledArg WHERE uid = uidArg;
+END;
+
+-- Removes the `profileChangedAt` update when an account is reset
+CREATE PROCEDURE `resetAccount_10` (
+  IN `uidArg` BINARY(16),
+  IN `verifyHashArg` BINARY(32),
+  IN `authSaltArg` BINARY(32),
+  IN `wrapWrapKbArg` BINARY(32),
+  IN `verifierSetAtArg` BIGINT UNSIGNED,
+  IN `VerifierVersionArg` TINYINT UNSIGNED
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  DELETE FROM sessionTokens WHERE uid = uidArg;
+  DELETE FROM keyFetchTokens WHERE uid = uidArg;
+  DELETE FROM accountResetTokens WHERE uid = uidArg;
+  DELETE FROM passwordChangeTokens WHERE uid = uidArg;
+  DELETE FROM passwordForgotTokens WHERE uid = uidArg;
+  DELETE FROM devices WHERE uid = uidArg;
+  DELETE FROM unverifiedTokens WHERE uid = uidArg;
+
+  UPDATE accounts
+  SET
+    verifyHash = verifyHashArg,
+    authSalt = authSaltArg,
+    wrapWrapKb = wrapWrapKbArg,
+    verifierSetAt = verifierSetAtArg,
+    verifierVersion = verifierVersionArg
+  WHERE uid = uidArg;
+
+  COMMIT;
+END;
+
+-- Coalesce `profileChangedAt` from verifierSetAt and createdAt
+CREATE PROCEDURE `sessionWithDevice_17` (
+  IN `tokenIdArg` BINARY(32)
+)
+BEGIN
+  SELECT
+    t.tokenData,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.uaFormFactor,
+    t.lastAccessTime,
+    t.verificationMethod,
+    t.verifiedAt,
+    COALESCE(t.authAt, t.createdAt) AS authAt,
+    e.isVerified AS emailVerified,
+    e.email,
+    e.emailCode,
+    a.verifierSetAt,
+    a.locale,
+    COALESCE(a.verifierSetAt, a.createdAt) AS profileChangedAt,
+    a.createdAt AS accountCreatedAt,
+    d.id AS deviceId,
+    d.nameUtf8 AS deviceName,
+    d.type AS deviceType,
+    d.createdAt AS deviceCreatedAt,
+    d.callbackURL AS deviceCallbackURL,
+    d.callbackPublicKey AS deviceCallbackPublicKey,
+    d.callbackAuthKey AS deviceCallbackAuthKey,
+    d.callbackIsExpired AS deviceCallbackIsExpired,
+    ci.commandName AS deviceCommandName,
+    dc.commandData AS deviceCommandData,
+    ut.tokenVerificationId,
+    COALESCE(t.mustVerify, ut.mustVerify) AS mustVerify
+  FROM sessionTokens AS t
+  LEFT JOIN accounts AS a
+    ON t.uid = a.uid
+  LEFT JOIN emails AS e
+    ON t.uid = e.uid
+    AND e.isPrimary = true
+  LEFT JOIN devices AS d
+    ON (t.tokenId = d.sessionTokenId AND t.uid = d.uid)
+  LEFT JOIN (
+    deviceCommands AS dc FORCE INDEX (PRIMARY)
+    INNER JOIN deviceCommandIdentifiers AS ci FORCE INDEX (PRIMARY)
+      ON ci.commandId = dc.commandId
+  ) ON (dc.uid = d.uid AND dc.deviceId = d.id)
+  LEFT JOIN unverifiedTokens AS ut
+    ON t.tokenId = ut.tokenId
+  WHERE t.tokenId = tokenIdArg;
+END;
+
+-- Coalesce `profileChangedAt` from verifierSetAt and createdAt
+CREATE PROCEDURE `accountRecord_4` (
+  IN `inEmail` VARCHAR(255)
+)
+BEGIN
+    SELECT
+        a.uid,
+        a.email,
+        a.normalizedEmail,
+        a.emailVerified,
+        a.emailCode,
+        a.kA,
+        a.wrapWrapKb,
+        a.verifierVersion,
+        a.authSalt,
+        a.verifierSetAt,
+        a.createdAt,
+        a.locale,
+        a.lockedAt,
+        COALESCE(a.verifierSetAt, a.createdAt) AS profileChangedAt,
+        e.normalizedEmail AS primaryEmail
+    FROM
+        accounts a,
+        emails e
+    WHERE
+        a.uid = (SELECT uid FROM emails WHERE normalizedEmail = LOWER(inEmail))
+    AND
+        a.uid = e.uid
+    AND
+        e.isPrimary = true;
+END;
+
+-- Coalesce `profileChangedAt` from verifierSetAt and createdAt
+CREATE PROCEDURE `account_5` (
+    IN `inUid` BINARY(16)
+)
+BEGIN
+    SELECT
+        a.uid,
+        a.email,
+        a.normalizedEmail,
+        a.emailVerified,
+        a.emailCode,
+        a.kA,
+        a.wrapWrapKb,
+        a.verifierVersion,
+        a.authSalt,
+        a.verifierSetAt,
+        a.createdAt,
+        a.locale,
+        a.lockedAt,
+        COALESCE(a.verifierSetAt, a.createdAt) AS profileChangedAt
+    FROM
+        accounts a
+    WHERE
+        a.uid = LOWER(inUid)
+    ;
+END;
+
+UPDATE dbMetadata SET value = '91' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-091-090.sql
+++ b/lib/db/schema/patch-091-090.sql
@@ -1,0 +1,16 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- ALTER TABLE accounts ADD COLUMN profileChangedAt BIGINT UNSIGNED DEFAULT NULL,
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- DROP PROCEDURE setPrimaryEmail_3;
+-- DROP PROCEDURE verifyEmail_7;
+-- DROP PROCEDURE deleteEmail_4;
+-- DROP PROCEDURE deleteTotpToken_3;
+-- DROP PROCEDURE updateTotpToken_3;
+-- DROP PROCEDURE resetAccount_10;
+-- DROP PROCEDURE sessionWithDevice_17;
+-- DROP PROCEDURE accountRecord_5;
+-- DROP PROCEDURE account_5;
+
+-- UPDATE dbMetadata SET value = '90' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
From meeting earlier this PR rollbacks the `profileChangedAt` migration on the accounts table. Below are some notes I found while creating this

  * Opted to create new stored procedures instead of dropping procedures in migration 87. There was only once instance where a `DROP PROCEDURE` was performed in a forward migration and that was very early on.
  * Opted to colasce `profileChangedAt` when it is return from the `veriferSetAt` and `createdAt` timestamps since it seemed to reduce code churn in auth-server. I'm not opposed to dropping this value entirely since it doesn't 100% reflect last updated time.
* I haven't fully tested with auth-server, but remote tests seem to work (minus profileChangedAt asserts).

@rfk @jrgm Thoughts on this approach?