### PR TITLE
fix(accountRecord): Improve query performance by avoiding a subselect.

### DIFF
--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -896,7 +896,7 @@ module.exports = function (log, error) {
   // Fields : uid, email, normalizedEmail, emailVerified, emailCode, kA, wrapWrapKb, verifierVersion, authSalt,
   //          verifierSetAt, createdAt, lockedAt, primaryEmail, profileChangedAt
   // Where  : emails.normalizedEmail = LOWER($1)
-  var GET_ACCOUNT_RECORD = 'CALL accountRecord_4(?)'
+  var GET_ACCOUNT_RECORD = 'CALL accountRecord_5(?)'
   MySql.prototype.accountRecord = function (email) {
     return this.readFirstResult(GET_ACCOUNT_RECORD, [email])
   }

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 91
+module.exports.level = 92

--- a/lib/db/schema/patch-091-092.sql
+++ b/lib/db/schema/patch-091-092.sql
@@ -1,0 +1,40 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('91');
+
+-- Re-write the `accountRecord` procedure to use a temporary variable
+-- rather than a sub-select, since sub-selects seems to cause some
+-- trouble for the query planner.
+CREATE PROCEDURE `accountRecord_5` (
+  IN `inEmail` VARCHAR(255)
+)
+BEGIN
+    SELECT uid INTO @owningUid FROM emails WHERE normalizedEmail = LOWER(inEmail);
+    SELECT
+        a.uid,
+        a.email,
+        a.normalizedEmail,
+        a.emailVerified,
+        a.emailCode,
+        a.kA,
+        a.wrapWrapKb,
+        a.verifierVersion,
+        a.authSalt,
+        a.verifierSetAt,
+        a.createdAt,
+        a.locale,
+        a.lockedAt,
+        COALESCE(a.verifierSetAt, a.createdAt) AS profileChangedAt,
+        e.normalizedEmail AS primaryEmail
+    FROM
+        accounts a,
+        emails e
+    WHERE
+        a.uid = @owningUid
+    AND
+        e.uid = a.uid
+    AND
+        e.isPrimary = true;
+END;
+
+UPDATE dbMetadata SET value = '92' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-092-091.sql
+++ b/lib/db/schema/patch-092-091.sql
@@ -1,0 +1,5 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DROP PROCEDURE accountRecord_5;
+
+-- UPDATE dbMetadata SET value = '91' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
Connects to https://github.com/mozilla/fxa-auth-db-mysql/issues/433.  For your consideration @jrgm, does avoiding the subselect help create a performant version of this query?

(This can wait until after train-123 deployment has been resolved)