### PR TITLE
fix(scripts): stop the explain script tripping over git grep colours

### DIFF
--- a/scripts/explain-warn.js
+++ b/scripts/explain-warn.js
@@ -301,11 +301,15 @@ function getProcedureNames () {
 }
 
 function getPath (procedure) {
-  return cp.execSync(
-    `git grep "${procedure}" | grep 'CREATE PROCEDURE' | cut -d ':' -f 1 | sed '/^$/d'`,
+  const path = cp.execSync(
+    `git grep "${procedure}" | grep 'CREATE PROCEDURE' | sed '/^$/d'`,
     RETURN_STRING
   )
-    .trim()
+    .match(/(lib\/db\/schema\/patch-[0-9]+-[0-9]+\.sql)/)
+
+  if (path) {
+    return path[1]
+  }
 }
 
 function extractSelects (path, procedure) {


### PR DESCRIPTION
The explain script was using `cut` to split paths from git grep before the colon character. This fails on systems where control characters such as colours are emitted before the colon.

A more robust approach is to use a regex to pull out the specific text we're looking for. The script is already hard-coded with other paths like `lib/db/mysql.js`, so matching against the expected migration path doesn't seem like too much of a stretch to me.

@mozilla/fxa-devs r? (but mostly @shane-tomlinson r? because he has the system where we know it fails)