### PR TITLE
chore(db): use mariadb-friendly drop index syntax

### DIFF
--- a/lib/db/schema/patch-035-036.sql
+++ b/lib/db/schema/patch-035-036.sql
@@ -95,9 +95,9 @@ END;
 -- Any queries that were using it will just start using the
 -- new one instead.
 
-DROP INDEX securityEvents_uid_ipAddrHmac
-ON securityEvents
-ALGORITHM = INPLACE LOCK = NONE;
+ALTER TABLE securityEvents
+DROP INDEX securityEvents_uid_ipAddrHmac,
+ALGORITHM = INPLACE, LOCK = NONE;
 
 -- But it's *not* safe to do the following in the same deployment,
 -- because of the potential for `verifyToken_2` to be called:

--- a/lib/db/schema/patch-038-039.sql
+++ b/lib/db/schema/patch-038-039.sql
@@ -13,9 +13,9 @@ DROP TABLE eventLog;
 
 DROP TABLE eventLogPublishState;
 
-DROP INDEX securityEvents_uid_tokenId
-ON securityEvents
-ALGORITHM = INPLACE LOCK = NONE;
+ALTER TABLE securityEvents
+DROP INDEX securityEvents_uid_tokenId,
+ALGORITHM = INPLACE, LOCK = NONE;
 
 ALTER TABLE securityEvents
 DROP COLUMN tokenId,


### PR DESCRIPTION
Fixes #393.

Sometimes we get self-hosters or contributors showing up who want to use MariaDB. Even though the official line is that we don't support it, it happens often enough that we may as well just fix the places where we're incompatible. Afaik, that is just the `DROP INDEX` syntax in a couple of places.

Note there are also occurrences in the reverse migrations, which I haven't bothered to fix. Seeing as they're not invoked in normal running and need to be manually uncommented before running anyway, it seems reasonable for them to be manually edited if anyone needs to do so.

@mozilla/fxa-devs r?