### PR TITLE
fix(tests): Don't put binary data into fake email addresses.

### DIFF
--- a/db-server/test/fake.js
+++ b/db-server/test/fake.js
@@ -143,7 +143,7 @@ module.exports.newUserDataBuffer = function() {
   // account
   data.accountId = buf16()
   data.account = {
-    email: buf16() + '@example.com',
+    email: hex16() + '@example.com',
     emailCode: buf16(),
     emailVerified: false,
     verifierVersion: 1,


### PR DESCRIPTION
Fixes #428.

I happened to be running a local MySQL with latin1 as the default encoding, and the sporadic token-pruning test failure from #428 triggered every single time on my machine.  It turns out that this test was trying to create an account for an email address of the form `<16 random bytes>@example.com`.

My theory is that on our CI machines where MySQL is using utf8 by default, such a string can *almost always* be stored correctly and allow the tests to pass.  But if the 16 random bytes happen to produce, say, the surrogate pair encoding of an emoji, then MySQL will do its fun utf8-versus-utf8mb4 thing and truncate the string, triggering a strict-mode failure.

On my local machine with latin1 encoding, such a string can *almost never* be stored correctly and hence I was able to reproduce the issue.'

Anyway, using hex rather than bytes appears to fix the issue.