### PR TITLE
fix(account): don't use `LOWER(uid)` in account query, update `accountRecord`

### DIFF
--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -897,20 +897,9 @@ module.exports = function (log, error) {
   //          verifierSetAt, createdAt, lockedAt, primaryEmail, profileChangedAt
   // Where  : emails.normalizedEmail = LOWER($1)
   //
-  // There's a newer version of this query named `accountRecord_4`
-  // which coalesces the `profileChangedAt` column from values in the db.
-  // We're experiencing unexpectedly bad query performance for reasons
-  // that we don't yet understand, so we've reverted to using an older
-  // version of the query while we're figuring that out, and doing the
-  // coalesce here in code.
-  // Ref: https://github.com/mozilla/fxa-content-server/issues/6655
-  var GET_ACCOUNT_RECORD = 'CALL accountRecord_2(?)'
+  var GET_ACCOUNT_RECORD = 'CALL accountRecord_5(?)'
   MySql.prototype.accountRecord = function (email) {
     return this.readFirstResult(GET_ACCOUNT_RECORD, [email])
-      .then(record => {
-        record.profileChangedAt = record.verifierSetAt || record.createdAt
-        return record
-      })
   }
 
   // Select : emails

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -554,8 +554,8 @@ module.exports = function (log, error) {
   // Select : accounts
   // Fields : uid, email, normalizedEmail, emailVerified, emailCode, kA, wrapWrapKb, verifierVersion, authSalt,
   //          verifierSetAt, createdAt, locale, lockedAt, profileChangedAt
-  // Where  : accounts.uid = LOWER($1)
-  var ACCOUNT = 'CALL account_5(?)'
+  // Where  : accounts.uid = $1
+  var ACCOUNT = 'CALL account_6(?)'
 
   MySql.prototype.account = function (uid) {
     return this.readFirstResult(ACCOUNT, [uid])

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 91
+module.exports.level = 92

--- a/lib/db/schema/patch-091-092.sql
+++ b/lib/db/schema/patch-091-092.sql
@@ -29,4 +29,38 @@ BEGIN
     ;
 END;
 
+-- Specify the email string encoding for `inEmail`. MySQL fails to use the
+-- correct index in subquery if this is not set.
+-- Ref: https://github.com/mozilla/fxa-auth-db-mysql/issues/440
+CREATE PROCEDURE `accountRecord_5` (
+  IN `inEmail` VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_bin
+)
+BEGIN
+    SELECT
+        a.uid,
+        a.email,
+        a.normalizedEmail,
+        a.emailVerified,
+        a.emailCode,
+        a.kA,
+        a.wrapWrapKb,
+        a.verifierVersion,
+        a.authSalt,
+        a.verifierSetAt,
+        a.createdAt,
+        a.locale,
+        a.lockedAt,
+        COALESCE(a.verifierSetAt, a.createdAt) AS profileChangedAt,
+        e.normalizedEmail AS primaryEmail
+    FROM
+        accounts a,
+        emails e
+    WHERE
+        a.uid = (SELECT uid FROM emails WHERE normalizedEmail = LOWER(inEmail))
+    AND
+        a.uid = e.uid
+    AND
+        e.isPrimary = true;
+END;
+
 UPDATE dbMetadata SET value = '92' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-091-092.sql
+++ b/lib/db/schema/patch-091-092.sql
@@ -1,0 +1,32 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('91');
+
+-- Removes the LOWER(inUid) requirement on the WHERE clause
+CREATE PROCEDURE `account_6` (
+    IN `inUid` BINARY(16)
+)
+BEGIN
+    SELECT
+        a.uid,
+        a.email,
+        a.normalizedEmail,
+        a.emailVerified,
+        a.emailCode,
+        a.kA,
+        a.wrapWrapKb,
+        a.verifierVersion,
+        a.authSalt,
+        a.verifierSetAt,
+        a.createdAt,
+        a.locale,
+        a.lockedAt,
+        COALESCE(a.verifierSetAt, a.createdAt) AS profileChangedAt
+    FROM
+        accounts a
+    WHERE
+        a.uid = inUid
+    ;
+END;
+
+UPDATE dbMetadata SET value = '92' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-092-091.sql
+++ b/lib/db/schema/patch-092-091.sql
@@ -1,0 +1,5 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DROP PROCEDURE account_6;
+
+-- UPDATE dbMetadata SET value = '91' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-092-091.sql
+++ b/lib/db/schema/patch-092-091.sql
@@ -1,5 +1,6 @@
 -- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
 
 -- DROP PROCEDURE account_6;
+-- DROP PROCEDURE accountRecord_5;
 
 -- UPDATE dbMetadata SET value = '91' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
Fixes #438 
Connects to https://github.com/mozilla/fxa-auth-db-mysql/issues/440

Opted to pull these two issues into one migration since they were both fairly small and not to introduce too much headache with merge conflicts for https://github.com/mozilla/fxa-auth-db-mysql/pull/436.

First commit:
Removes the `LOWER(uid)` from the `account_` stored procedure since it doesn't really change the query.

Second commit:
From https://github.com/mozilla/fxa-auth-db-mysql/issues/440, it specifies the charact set for `inEmail` as utf8 for the `accountRecord_` procedure. It also re enables coalescing in SQL rather than in code.