### PR TITLE
fix(query): remove `ROW_COUNT()` from remaining procedures

### DIFF
--- a/db-server/lib/error.js
+++ b/db-server/lib/error.js
@@ -92,6 +92,28 @@ AppError.recoveryKeyInvalid = () => {
   })
 }
 
+AppError.cannotSetUnverifiedPrimaryEmail = function () {
+  return new AppError(
+    {
+      code: 400,
+      error: 'Bad request',
+      errno: 147,
+      message: 'Can not set unverified primary email'
+    }
+  )
+}
+
+AppError.cannotSetUnownedPrimaryEmail = function () {
+  return new AppError(
+    {
+      code: 400,
+      error: 'Bad request',
+      errno: 148,
+      message: 'Can not set primary email to email that is not owned by account'
+    }
+  )
+}
+
 AppError.wrap = function (err) {
   // Don't re-wrap!
   if (err instanceof AppError) {

--- a/db-server/test/backend/db_tests.js
+++ b/db-server/test/backend/db_tests.js
@@ -1941,6 +1941,39 @@ module.exports = function (config, DB) {
             assert.equal(res[0].profileChangedAt >= res[0].createdAt, true, 'profileChangedAt updated')
           })
       })
+
+      it('shouldn\'t set primary email to email that is not owned by account', () => {
+        const anotherAccount = createAccount()
+        anotherAccount.emailVerified = true
+        const anotherEmail = createEmail({
+          uid: anotherAccount.uid,
+          isVerified: true
+        })
+        return db.createAccount(anotherAccount.uid, anotherAccount)
+          .then(() => {
+            return db.createEmail(anotherAccount.uid, anotherEmail)
+          })
+          .then(() => {
+            return db.setPrimaryEmail(account.uid, anotherEmail.email)
+          })
+          .catch((err) => {
+            assert.equal(err.errno, 148, 'correct errno set')
+          })
+      })
+
+      it('shouldn\'t set primary email to unverified email', () => {
+        const anotherEmail = createEmail({
+          uid: account.uid,
+          isVerified: false
+        })
+        return db.createEmail(account.uid, anotherEmail)
+          .then(() => {
+            return db.setPrimaryEmail(account.uid, anotherEmail.email)
+          })
+          .catch((err) => {
+            assert.equal(err.errno, 147, 'correct errno set')
+          })
+      })
     })
 
     describe('db.verifyTokenCode', () => {

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 92
+module.exports.level = 93

--- a/lib/db/schema/patch-092-093.sql
+++ b/lib/db/schema/patch-092-093.sql
@@ -1,0 +1,59 @@
+-- This migration removes the use of `ROW_COUNT()` on the last
+-- remaining procedures.
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('92');
+
+-- Updated to not use `ROW_COUNT()`. The previous procedure used row count to ensure that
+-- the uid actually owned the email specified.
+CREATE PROCEDURE `setPrimaryEmail_4` (
+  IN `inUid` BINARY(16),
+  IN `inNormalizedEmail` VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_bin
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+    SELECT normalizedEmail INTO @foundEmail FROM emails WHERE uid = inUid AND normalizedEmail = inNormalizedEmail AND isVerified = false;
+    IF @foundEmail IS NOT NULL THEN
+     SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 1643, MESSAGE_TEXT = 'Can not change email. Email is not verified.';
+    END IF;
+
+    SELECT normalizedEmail INTO @foundEmail FROM emails WHERE uid = inUid AND normalizedEmail = inNormalizedEmail AND isVerified;
+    IF @foundEmail IS NULL THEN
+     SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 1062, MESSAGE_TEXT = 'Can not change email. Could not find email.';
+    END IF;
+
+    UPDATE emails SET isPrimary = false WHERE uid = inUid AND isPrimary = true;
+    UPDATE emails SET isPrimary = true WHERE uid = inUid AND isPrimary = false AND normalizedEmail = inNormalizedEmail;
+  COMMIT;
+END;
+
+-- Updated to not use `ROW_COUNT()`. The previous procedure used row count to check to see
+-- if the given code was actually found. The new procedure moves the responsibility to `db.consumeRecoveryCode`
+-- where all recovery codes are retrieved and filtered to only the matching code.
+CREATE PROCEDURE `consumeRecoveryCode_3` (
+  IN `uidArg` BINARY(16),
+  IN `codeHashArg` BINARY(32)
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  DELETE FROM `recoveryCodes` WHERE `uid` = `uidArg` AND `codeHash` = `codeHashArg`;
+
+  SELECT COUNT(*) AS count FROM `recoveryCodes` WHERE `uid` = `uidArg`;
+
+  COMMIT;
+END;
+
+UPDATE dbMetadata SET value = '93' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-093-092.sql
+++ b/lib/db/schema/patch-093-092.sql
@@ -1,0 +1,6 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DROP PROCEDURE setPrimaryEmail_4;
+-- DROP PROCEDURE consumeRecoveryCode_3;
+
+-- UPDATE dbMetadata SET value = '92' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
Fixes #411 

This PR removes the use of `ROW_COUNT()` from our remaining procedures. Below is a summary of our use of `ROW_COUNT()` and when they were fixed.

- setPrimaryEmail
  - Fixed in setPrimaryEmail_4 (this PR)
- consumeRecoveryCode
  - Fixed in consumeRecoveryCode_3 (this PR)
- verifyTokensWithMethod
  - Fixed in verifyTokensWithMethod_3
- deleteEmail
  - Fixed in deleteEmail_2
- verifyTokenCode
  - Fixed in verifyTokenCode_2
- verifyEmail
  - Fixed in verifyEmail_4