### PR TITLE
fix(query): update set primary email query to not check if email is verified

### DIFF
--- a/db-server/test/backend/db_tests.js
+++ b/db-server/test/backend/db_tests.js
@@ -1960,20 +1960,6 @@ module.exports = function (config, DB) {
             assert.equal(err.errno, 148, 'correct errno set')
           })
       })
-
-      it('shouldn\'t set primary email to unverified email', () => {
-        const anotherEmail = createEmail({
-          uid: account.uid,
-          isVerified: false
-        })
-        return db.createEmail(account.uid, anotherEmail)
-          .then(() => {
-            return db.setPrimaryEmail(account.uid, anotherEmail.email)
-          })
-          .catch((err) => {
-            assert.equal(err.errno, 147, 'correct errno set')
-          })
-      })
     })
 
     describe('db.verifyTokenCode', () => {

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -916,7 +916,7 @@ module.exports = function (log, error) {
 
   // Update : emails
   // Values : uid = $1, email = $2
-  var SET_PRIMARY_EMAIL = 'CALL setPrimaryEmail_4(?, ?)'
+  var SET_PRIMARY_EMAIL = 'CALL setPrimaryEmail_5(?, ?)'
   MySql.prototype.setPrimaryEmail = function (uid, email) {
     return this.write(SET_PRIMARY_EMAIL, [uid, email])
       .then(() => {
@@ -925,10 +925,6 @@ module.exports = function (log, error) {
       .catch(err => {
         if (err.errno === error.duplicate().errno) {
           throw error.cannotSetUnownedPrimaryEmail()
-        }
-
-        if ( err.errno === ER_SIGNAL_NOT_FOUND ) {
-          throw error.cannotSetUnverifiedPrimaryEmail()
         }
 
         throw err

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 93
+module.exports.level = 94

--- a/lib/db/schema/patch-093-094.sql
+++ b/lib/db/schema/patch-093-094.sql
@@ -1,0 +1,33 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('93');
+
+-- Removes the check for setting a primary email to an unverified email. The check
+-- is currently having some unexpected behavior. This is safe to remove for now
+-- because the check is performed in the auth-server before it sets the
+-- new primary email.
+-- Ref: https://github.com/mozilla/fxa-auth-server/blob/master/lib/routes/emails.js#L763
+CREATE PROCEDURE `setPrimaryEmail_5` (
+  IN `inUid` BINARY(16),
+  IN `inNormalizedEmail` VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_bin
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+    SELECT normalizedEmail INTO @foundEmail FROM emails WHERE uid = inUid AND normalizedEmail = inNormalizedEmail AND isVerified;
+    IF @foundEmail IS NULL THEN
+     SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 1062, MESSAGE_TEXT = 'Can not change email. Could not find email.';
+    END IF;
+
+    UPDATE emails SET isPrimary = false WHERE uid = inUid AND isPrimary = true;
+    UPDATE emails SET isPrimary = true WHERE uid = inUid AND isPrimary = false AND normalizedEmail = inNormalizedEmail;
+  COMMIT;
+END;
+
+UPDATE dbMetadata SET value = '94' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-094-093.sql
+++ b/lib/db/schema/patch-094-093.sql
@@ -1,0 +1,5 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DROP PROCEDURE setPrimaryEmail_5;
+
+-- UPDATE dbMetadata SET value = '93' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
With the introduction of https://github.com/mozilla/fxa-auth-db-mysql/pull/445, I caused some breakage in set primary email. That PR added the check to ensure the new primary email is verified in db-server before setting it. The goal was to eventually remove it from the [auth-server](https://github.com/mozilla/fxa-auth-server/blob/master/lib/routes/emails.js#L763).

However, the new procedure isn't quite working as expected and content-server tests are failing. To help unblock content-server, this PR removes the check from the db-server and uses the auth-server check.

@mozilla/fxa-devs r?