### PR TITLE
feat(account): Add `profileChangedAt` and `keysChangedAt` columns

### DIFF
--- a/db-server/test/backend/db_tests.js
+++ b/db-server/test/backend/db_tests.js
@@ -748,9 +748,7 @@ module.exports = function (config, DB) {
         .then(function (account) {
           assert(account.emailVerified, 'account should now be emailVerified (truthy)')
           assert.equal(account.emailVerified, 1, 'account should now be emailVerified (1)')
-
-          // With migration 91, profileChangedAt will at a minimum be the createdAt timestamp
-          assert.equal(account.profileChangedAt >= account.createdAt, true, 'profileChangedAt updated')
+          assert.equal(account.profileChangedAt > account.createdAt, true, 'profileChangedAt updated')
         })
     })
 
@@ -1623,8 +1621,7 @@ module.exports = function (config, DB) {
 
             return db.account(accountData.uid)
               .then((account) => {
-                // With migration 91, profileChangedAt will at a minimum be the createdAt timestamp
-                assert.equal(account.profileChangedAt >= account.createdAt, true, 'profileChangedAt updated')
+                assert.equal(account.profileChangedAt > account.createdAt, true, 'profileChangedAt updated')
               })
           })
       })
@@ -1648,8 +1645,7 @@ module.exports = function (config, DB) {
 
             return db.account(accountData.uid)
               .then((account) => {
-                // With migration 91, profileChangedAt will at a minimum be the createdAt timestamp
-                assert.equal(account.profileChangedAt >= account.createdAt, true, 'profileChangedAt updated')
+                assert.equal(account.profileChangedAt > account.createdAt, true, 'profileChangedAt updated')
               })
           })
       })
@@ -2095,8 +2091,7 @@ module.exports = function (config, DB) {
                 return db.account(accountData.uid)
               })
               .then((account) => {
-                // With migration 91, profileChangedAt will at a minimum be the createdAt timestamp
-                assert.equal(account.profileChangedAt >= account.createdAt, true, 'profileChangedAt updated')
+                assert.equal(account.profileChangedAt > account.createdAt, true, 'profileChangedAt updated')
               })
           })
       })
@@ -2115,8 +2110,7 @@ module.exports = function (config, DB) {
                 return db.account(accountData.uid)
               })
               .then((account) => {
-                // With migration 91, profileChangedAt will at a minimum be the createdAt timestamp
-                assert.equal(account.profileChangedAt >= account.createdAt, true, 'profileChangedAt updated')
+                assert.equal(account.profileChangedAt > account.createdAt, true, 'profileChangedAt updated')
               })
           })
       })

--- a/lib/db/mem.js
+++ b/lib/db/mem.js
@@ -72,7 +72,8 @@ module.exports = function (log, error) {
     var item = extend({}, account)
     delete item.verifyHash
 
-    item.profileChangedAt = item.verifierSetAt || item.createdAt
+    item.profileChangedAt = item.profileChangedAt || item.verifierSetAt || item.createdAt
+    item.keysChangedAt = item.keysChangedAt || item.verifierSetAt || item.createdAt
 
     return P.resolve(item)
   }
@@ -569,7 +570,8 @@ module.exports = function (log, error) {
     var account = accounts[accountId]
 
     item.verifierSetAt = account.verifierSetAt
-    item.profileChangedAt =  account.verifierSetAt || account.createdAt
+    item.profileChangedAt =  account.profileChangedAt || account.verifierSetAt || account.createdAt
+    item.keysChangedAt = account.keysChangedAt || account.verifierSetAt || account.createdAt
     item.locale = account.locale
     item.accountCreatedAt = account.createdAt
 
@@ -832,6 +834,7 @@ module.exports = function (log, error) {
             // Verify email record if it matches emailCode
             if (emailRecord.emailCode.toString('hex') === emailCode.toString('hex')) {
               emailRecord.isVerified = 1
+              account.profileChangedAt = Date.now()
               return true
             }
 
@@ -887,6 +890,7 @@ module.exports = function (log, error) {
           account.wrapWrapKb = data.wrapWrapKb
           account.verifierSetAt = data.verifierSetAt
           account.verifierVersion = data.verifierVersion
+          account.profileChangedAt = data.verifierSetAt
           account.devices = {}
           return []
         }
@@ -1128,8 +1132,6 @@ module.exports = function (log, error) {
           }
         })
 
-        account.profileChangedAt = account.verifierSetAt || account.createdAt
-
         return account
       })
   }
@@ -1168,6 +1170,7 @@ module.exports = function (log, error) {
 
     return getAccountByUid(uid)
       .then((account) => {
+        account.profileChangedAt = Date.now()
         return P.resolve({})
       })
   }
@@ -1199,6 +1202,7 @@ module.exports = function (log, error) {
 
     return getAccountByUid(uid)
       .then((account) => {
+        account.profileChangedAt = Date.now()
         return P.resolve({})
       })
   }
@@ -1273,6 +1277,7 @@ module.exports = function (log, error) {
 
     return getAccountByUid(uid)
       .then((account) => {
+        account.profileChangedAt = Date.now()
         return Promise.resolve({})
       })
   }
@@ -1296,6 +1301,7 @@ module.exports = function (log, error) {
 
     return getAccountByUid(uid)
       .then((account) => {
+        account.profileChangedAt = Date.now()
         return Promise.resolve({})
       })
   }

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -460,7 +460,7 @@ module.exports = function (log, error) {
   // Fields : t.tokenData, t.uid, t.createdAt, t.uaBrowser, t.uaBrowserVersion, t.uaOS,
   //          t.uaOSVersion, t.uaDeviceType, t.uaFormFactor, t.lastAccessTime, t.authAt,
   //          a.emailVerified, a.email, a.emailCode, a.verifierSetAt, a.locale,
-  //          a.createdAt AS accountCreatedAt, a.profileChangedAt,
+  //          a.createdAt AS accountCreatedAt, a.profileChangedAt, a.keysChangedAt,
   //          d.id AS deviceId, d.name AS deviceName, d.type AS deviceType, d.createdAt
   //          AS deviceCreatedAt, d.callbackURL AS deviceCallbackURL, d.callbackPublicKey
   //          AS deviceCallbackPublicKey, d.callbackAuthKey AS deviceCallbackAuthKey,
@@ -468,7 +468,7 @@ module.exports = function (log, error) {
   //          ut.tokenVerificationId, ut.mustVerify
   // Where  : t.tokenId = $1 AND t.uid = a.uid AND t.tokenId = d.sessionTokenId AND
   //          t.uid = d.uid AND t.tokenId = u.tokenId
-  var SESSION_DEVICE = 'CALL sessionWithDevice_17(?)'
+  var SESSION_DEVICE = 'CALL sessionWithDevice_18(?)'
 
   MySql.prototype.sessionToken = function (id) {
     return this.readAllResults(SESSION_DEVICE, [id])
@@ -553,9 +553,9 @@ module.exports = function (log, error) {
 
   // Select : accounts
   // Fields : uid, email, normalizedEmail, emailVerified, emailCode, kA, wrapWrapKb, verifierVersion, authSalt,
-  //          verifierSetAt, createdAt, locale, lockedAt, profileChangedAt
+  //          verifierSetAt, createdAt, locale, lockedAt, profileChangedAt, keysChangedAt
   // Where  : accounts.uid = $1
-  var ACCOUNT = 'CALL account_6(?)'
+  var ACCOUNT = 'CALL account_7(?)'
 
   MySql.prototype.account = function (uid) {
     return this.readFirstResult(ACCOUNT, [uid])
@@ -775,7 +775,7 @@ module.exports = function (log, error) {
   // Update : accounts
   // Set    : verifyHash = $2, authSalt = $3, wrapWrapKb = $4, verifierSetAt = $5, verifierVersion = $6
   // Where  : uid = $1
-  var RESET_ACCOUNT = 'CALL resetAccount_10(?, ?, ?, ?, ?, ?)'
+  var RESET_ACCOUNT = 'CALL resetAccount_11(?, ?, ?, ?, ?, ?)'
 
   MySql.prototype.resetAccount = function (uid, data) {
     return this.write(
@@ -787,7 +787,7 @@ module.exports = function (log, error) {
   // Update : accounts, emails
   // Set    : emailVerified = true if email is in accounts table or isVerified = true if on email table
   // Where  : uid = $1, emailCode = $2
-  var VERIFY_EMAIL = 'CALL verifyEmail_7(?, ?)'
+  var VERIFY_EMAIL = 'CALL verifyEmail_8(?, ?)'
 
   MySql.prototype.verifyEmail = function (uid, emailCode) {
     return this.write(VERIFY_EMAIL, [uid, emailCode])
@@ -894,10 +894,10 @@ module.exports = function (log, error) {
 
   // Select : accounts
   // Fields : uid, email, normalizedEmail, emailVerified, emailCode, kA, wrapWrapKb, verifierVersion, authSalt,
-  //          verifierSetAt, createdAt, lockedAt, primaryEmail, profileChangedAt
+  //          verifierSetAt, createdAt, lockedAt, primaryEmail, profileChangedAt, keysChangedAt
   // Where  : emails.normalizedEmail = LOWER($1)
   //
-  var GET_ACCOUNT_RECORD = 'CALL accountRecord_5(?)'
+  var GET_ACCOUNT_RECORD = 'CALL accountRecord_6(?)'
   MySql.prototype.accountRecord = function (email) {
     return this.readFirstResult(GET_ACCOUNT_RECORD, [email])
   }
@@ -916,7 +916,7 @@ module.exports = function (log, error) {
 
   // Update : emails
   // Values : uid = $1, email = $2
-  var SET_PRIMARY_EMAIL = 'CALL setPrimaryEmail_5(?, ?)'
+  var SET_PRIMARY_EMAIL = 'CALL setPrimaryEmail_6(?, ?)'
   MySql.prototype.setPrimaryEmail = function (uid, email) {
     return this.write(SET_PRIMARY_EMAIL, [uid, email])
       .then(() => {
@@ -933,7 +933,7 @@ module.exports = function (log, error) {
 
   // Delete : emails
   // Values : uid = $1, email = $2
-  var DELETE_EMAIL = 'CALL deleteEmail_4(?, ?)'
+  var DELETE_EMAIL = 'CALL deleteEmail_5(?, ?)'
   MySql.prototype.deleteEmail = function (uid, email) {
     return this.write(
       DELETE_EMAIL,
@@ -1414,12 +1414,12 @@ module.exports = function (log, error) {
     return this.readFirstResult(GET_TOTP_TOKEN, [uid])
   }
 
-  const DELETE_TOTP_TOKEN = 'CALL deleteTotpToken_3(?)'
+  const DELETE_TOTP_TOKEN = 'CALL deleteTotpToken_4(?)'
   MySql.prototype.deleteTotpToken = function (uid) {
     return this.write(DELETE_TOTP_TOKEN, [uid])
   }
 
-  const UPDATE_TOTP_TOKEN = 'CALL updateTotpToken_3(?, ?, ?)'
+  const UPDATE_TOTP_TOKEN = 'CALL updateTotpToken_4(?, ?, ?)'
   MySql.prototype.updateTotpToken = function (uid, token) {
     return this.read(UPDATE_TOTP_TOKEN, [
       uid,

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 94
+module.exports.level = 95

--- a/lib/db/schema/patch-094-095.sql
+++ b/lib/db/schema/patch-094-095.sql
@@ -1,0 +1,273 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('94');
+
+-- This re-instates the `profileChangedAt` column on the `accounts` table, which
+-- we had briefly added and then backed out after some operational issues with
+-- running the migration in production.  We've now successfully done the migration
+-- in production, and this migration brings our db schema back into line with what
+-- is on the live db.
+--
+-- It also adds a new `keysChangedAt` column which was added as part of the same
+-- production migration.
+
+ALTER TABLE accounts
+  ADD COLUMN profileChangedAt BIGINT UNSIGNED DEFAULT NULL,
+  ADD COLUMN keysChangedAt BIGINT UNSIGNED DEFAULT NULL,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+-- Read `profileChangedAt` and `keysChangedAt` when accessing a sessionToken,
+-- filling in sensible defaults if the new columns are NULL.
+CREATE PROCEDURE `sessionWithDevice_18` (
+  IN `tokenIdArg` BINARY(32)
+)
+BEGIN
+  SELECT
+    t.tokenData,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.uaFormFactor,
+    t.lastAccessTime,
+    t.verificationMethod,
+    t.verifiedAt,
+    COALESCE(t.authAt, t.createdAt) AS authAt,
+    e.isVerified AS emailVerified,
+    e.email,
+    e.emailCode,
+    a.verifierSetAt,
+    a.locale,
+    COALESCE(a.profileChangedAt, a.verifierSetAt, a.createdAt) AS profileChangedAt,
+    COALESCE(a.keysChangedAt, a.verifierSetAt, a.createdAt) AS keysChangedAt,
+    a.createdAt AS accountCreatedAt,
+    d.id AS deviceId,
+    d.nameUtf8 AS deviceName,
+    d.type AS deviceType,
+    d.createdAt AS deviceCreatedAt,
+    d.callbackURL AS deviceCallbackURL,
+    d.callbackPublicKey AS deviceCallbackPublicKey,
+    d.callbackAuthKey AS deviceCallbackAuthKey,
+    d.callbackIsExpired AS deviceCallbackIsExpired,
+    ci.commandName AS deviceCommandName,
+    dc.commandData AS deviceCommandData,
+    ut.tokenVerificationId,
+    COALESCE(t.mustVerify, ut.mustVerify) AS mustVerify
+  FROM sessionTokens AS t
+  LEFT JOIN accounts AS a
+    ON t.uid = a.uid
+  LEFT JOIN emails AS e
+    ON t.uid = e.uid
+    AND e.isPrimary = true
+  LEFT JOIN devices AS d
+    ON (t.tokenId = d.sessionTokenId AND t.uid = d.uid)
+  LEFT JOIN (
+    deviceCommands AS dc FORCE INDEX (PRIMARY)
+    INNER JOIN deviceCommandIdentifiers AS ci FORCE INDEX (PRIMARY)
+      ON ci.commandId = dc.commandId
+  ) ON (dc.uid = d.uid AND dc.deviceId = d.id)
+  LEFT JOIN unverifiedTokens AS ut
+    ON t.tokenId = ut.tokenId
+  WHERE t.tokenId = tokenIdArg;
+END;
+
+-- Read `profileChangedAt` and `keysChangedAt` when accessing an account,
+-- filling in sensible defaults if the new columns are NULL.
+CREATE PROCEDURE `account_7` (
+    IN `inUid` BINARY(16)
+)
+BEGIN
+    SELECT
+        a.uid,
+        a.email,
+        a.normalizedEmail,
+        a.emailVerified,
+        a.emailCode,
+        a.kA,
+        a.wrapWrapKb,
+        a.verifierVersion,
+        a.authSalt,
+        a.verifierSetAt,
+        a.createdAt,
+        a.locale,
+        a.lockedAt,
+        COALESCE(a.profileChangedAt, a.verifierSetAt, a.createdAt) AS profileChangedAt,
+        COALESCE(a.keysChangedAt, a.verifierSetAt, a.createdAt) AS keysChangedAt
+    FROM
+        accounts a
+    WHERE
+        a.uid = inUid
+    ;
+END;
+
+
+-- Read `profileChangedAt` and `keysChangedAt` when accessing an account,
+-- filling in sensible defaults if the new columns are NULL.
+CREATE PROCEDURE `accountRecord_6` (
+  IN `inEmail` VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_bin
+)
+BEGIN
+    SELECT
+        a.uid,
+        a.email,
+        a.normalizedEmail,
+        a.emailVerified,
+        a.emailCode,
+        a.kA,
+        a.wrapWrapKb,
+        a.verifierVersion,
+        a.authSalt,
+        a.verifierSetAt,
+        a.createdAt,
+        a.locale,
+        a.lockedAt,
+        COALESCE(a.profileChangedAt, a.verifierSetAt, a.createdAt) AS profileChangedAt,
+        COALESCE(a.keysChangedAt, a.verifierSetAt, a.createdAt) AS keysChangedAt,
+        e.normalizedEmail AS primaryEmail
+    FROM
+        accounts a,
+        emails e
+    WHERE
+        a.uid = (SELECT uid FROM emails WHERE normalizedEmail = LOWER(inEmail))
+    AND
+        a.uid = e.uid
+    AND
+        e.isPrimary = true;
+END;
+
+-- Set `profileChangedAt` when resetting an account.
+-- Note that we will *eventually* want to set `keysChangedAt` here as well,
+-- but we need the auth-server to send us an explicit signal to know whether
+-- or not the keys have actually changed.  That will be done in a follow-up.
+CREATE PROCEDURE `resetAccount_11` (
+  IN `uidArg` BINARY(16),
+  IN `verifyHashArg` BINARY(32),
+  IN `authSaltArg` BINARY(32),
+  IN `wrapWrapKbArg` BINARY(32),
+  IN `verifierSetAtArg` BIGINT UNSIGNED,
+  IN `verifierVersionArg` TINYINT UNSIGNED
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  DELETE FROM sessionTokens WHERE uid = uidArg;
+  DELETE FROM keyFetchTokens WHERE uid = uidArg;
+  DELETE FROM accountResetTokens WHERE uid = uidArg;
+  DELETE FROM passwordChangeTokens WHERE uid = uidArg;
+  DELETE FROM passwordForgotTokens WHERE uid = uidArg;
+  DELETE FROM devices WHERE uid = uidArg;
+  DELETE FROM unverifiedTokens WHERE uid = uidArg;
+
+  UPDATE accounts
+  SET
+    verifyHash = verifyHashArg,
+    authSalt = authSaltArg,
+    wrapWrapKb = wrapWrapKbArg,
+    verifierSetAt = verifierSetAtArg,
+    verifierVersion = verifierVersionArg,
+    profileChangedAt = verifierSetAtArg
+  WHERE uid = uidArg;
+
+  COMMIT;
+END;
+
+-- Set `profileChangedAt` when an email gets successfully verified.
+CREATE PROCEDURE `verifyEmail_8`(
+    IN `inUid` BINARY(16),
+    IN `inEmailCode` BINARY(16)
+)
+BEGIN
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    START TRANSACTION;
+
+    UPDATE accounts SET emailVerified = true WHERE uid = inUid AND emailCode = inEmailCode;
+    UPDATE emails SET isVerified = true WHERE uid = inUid AND emailCode = inEmailCode;
+    UPDATE accounts SET profileChangedAt = (UNIX_TIMESTAMP(NOW(3)) * 1000) WHERE uid = inUid;
+
+    COMMIT;
+END;
+
+
+-- Set `profileChangedAt` when changing primary email.
+--
+-- Note that this procedure does *not* prevent setting a primary email to an unverified email.
+-- The check is currently having some unexpected behavior when done here in the DB, and is instead
+-- performed in the auth-server before it sets the new primary email.
+-- Ref: https://github.com/mozilla/fxa-auth-server/blob/30e65674e70ee42befc1ba09b6fc0fd7dde2f608/lib/routes/emails.js#L763
+CREATE PROCEDURE `setPrimaryEmail_6` (
+  IN `inUid` BINARY(16),
+  IN `inNormalizedEmail` VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_bin
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+    SELECT normalizedEmail INTO @foundEmail FROM emails WHERE uid = inUid AND normalizedEmail = inNormalizedEmail AND isVerified;
+    IF @foundEmail IS NULL THEN
+     SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 1062, MESSAGE_TEXT = 'Can not change email. Could not find email.';
+    END IF;
+
+    UPDATE emails SET isPrimary = false WHERE uid = inUid AND isPrimary = true;
+    UPDATE emails SET isPrimary = true WHERE uid = inUid AND isPrimary = false AND normalizedEmail = inNormalizedEmail;
+    UPDATE accounts SET profileChangedAt = (UNIX_TIMESTAMP(NOW(3)) * 1000) WHERE uid = inUid;
+  COMMIT;
+END;
+
+-- Set `profileChangedAt` when deleting an email.
+CREATE PROCEDURE `deleteEmail_5` (
+    IN `inUid` BINARY(16),
+    IN `inNormalizedEmail` VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_bin
+)
+BEGIN
+    SET @primaryEmailCount = 0;
+
+    -- Don't delete primary email addresses
+    SELECT COUNT(*) INTO @primaryEmailCount FROM emails WHERE normalizedEmail = inNormalizedEmail AND uid = inUid AND isPrimary = true;
+    IF @primaryEmailCount = 1 THEN
+        SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 2100, MESSAGE_TEXT = 'Can not delete a primary email address.';
+    END IF;
+
+    DELETE FROM emails WHERE normalizedEmail = inNormalizedEmail AND uid = inUid AND isPrimary = false;
+    UPDATE accounts SET profileChangedAt = (UNIX_TIMESTAMP(NOW(3)) * 1000) WHERE uid = inUid;
+END;
+
+-- Set `profileChangedAt` when removing TOTP from an account.
+CREATE PROCEDURE `deleteTotpToken_4` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  DELETE FROM totp WHERE uid = uidArg;
+  UPDATE accounts SET profileChangedAt = (UNIX_TIMESTAMP(NOW(3)) * 1000) WHERE uid = uidArg;
+END;
+
+-- Set `profileChangedAt` when TOTP becomes active on an account.
+CREATE PROCEDURE `updateTotpToken_4` (
+  IN `uidArg` BINARY(16),
+  IN `verifiedArg` BOOLEAN,
+  IN `enabledArg` BOOLEAN
+)
+BEGIN
+  UPDATE `totp` SET verified = verifiedArg, enabled = enabledArg WHERE uid = uidArg;
+  UPDATE accounts SET profileChangedAt = (UNIX_TIMESTAMP(NOW(3)) * 1000) WHERE uid = uidArg;
+END;
+
+UPDATE dbMetadata SET value = '95' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-095-094.sql
+++ b/lib/db/schema/patch-095-094.sql
@@ -1,0 +1,15 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DROP PROCEDURE `sessionWithDevice_18`;
+-- DROP PROCEDURE `account_7`;
+-- DROP PROCEDURE `accountRecord_6`;
+-- DROP PROCEDURE `resetAccount_11`;
+-- DROP PROCEDURE `verifyEmail_8`;
+-- DROP PROCEDURE `setPrimaryEmail_6`;
+-- DROP PROCEDURE `deleteEmail_5`;
+-- DROP PROCEDURE `deleteTotpToken_4`;
+-- DROP PROCEDURE `updateTotpToken_4`;
+
+-- ALTER TABLE accounts DROP COLUMN profileChangedAt, DROP COLUMN keysChangedAt;
+
+-- UPDATE dbMetadata SET value = '94' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
Fixes #481.

This undoes the backout in https://github.com/mozilla/fxa-auth-db-mysql/pull/417, and adds some very minimal code for reading the new `keysChangedAt` column which was added as part of the same production migration.  The `keysChangedAt` column will always be null for now, until we add code in the auth-server to know when to set it.