### PR TITLE
feat(devices): Add ability to associate a device record with a refesh token

### DIFF
--- a/db-server/index.js
+++ b/db-server/index.js
@@ -92,6 +92,7 @@ function createServer(db) {
     'passCode',
     'recoveryKeyId',
     'sessionTokenId',
+    'refreshTokenId',
     'tokenId',
     'tokenVerificationId',
     'uid',

--- a/db-server/test/fake.js
+++ b/db-server/test/fake.js
@@ -69,14 +69,30 @@ module.exports.newUserDataHex = function() {
   data.device = {
     uid: data.accountId,
     sessionTokenId: data.sessionTokenId,
+    refreshTokenId: null,
     createdAt: Date.now(),
     name: 'fake device name',
     type: 'fake device type',
     callbackURL: 'fake callback URL',
     callbackPublicKey: base64_65(),
     callbackAuthKey: base64_16(),
-    callbackIsExpired: false,
-    capabilities: ['messages']
+    callbackIsExpired: false
+  }
+
+  // oauth device
+  data.refreshTokenId = hex32()
+  data.oauthDeviceId = hex16()
+  data.oauthDevice = {
+    uid: data.accountId,
+    sessionTokenId: null,
+    refreshTokenId: data.refreshTokenId,
+    createdAt: Date.now(),
+    name: 'fake oauth device name',
+    type: 'oauth device',
+    callbackURL: 'fake oauth callback URL',
+    callbackPublicKey: base64_65(),
+    callbackAuthKey: base64_16(),
+    callbackIsExpired: false
   }
 
   // keyFetchToken

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -322,7 +322,7 @@ module.exports = function (log, error) {
     }, [])
   }
 
-  const CREATE_DEVICE = 'CALL createDevice_4(?, ?, ?, ?, ?, ?, ?, ?, ?)'
+  const CREATE_DEVICE = 'CALL createDevice_5(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
 
   MySql.prototype.createDevice = function (uid, deviceId, deviceInfo) {
     const statements = [{
@@ -331,6 +331,7 @@ module.exports = function (log, error) {
         uid,
         deviceId,
         deviceInfo.sessionTokenId,
+        deviceInfo.refreshTokenId,
         deviceInfo.name, // inNameUtf8
         deviceInfo.type,
         deviceInfo.createdAt,
@@ -345,7 +346,7 @@ module.exports = function (log, error) {
     return this.writeMultiple(statements)
   }
 
-  const UPDATE_DEVICE = 'CALL updateDevice_5(?, ?, ?, ?, ?, ?, ?, ?, ?)'
+  const UPDATE_DEVICE = 'CALL updateDevice_6(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
 
   MySql.prototype.updateDevice = function (uid, deviceId, deviceInfo) {
     const statements = [{
@@ -354,6 +355,7 @@ module.exports = function (log, error) {
         uid,
         deviceId,
         deviceInfo.sessionTokenId,
+        deviceInfo.refreshTokenId,
         deviceInfo.name, // inNameUtf8
         deviceInfo.type,
         deviceInfo.callbackURL,
@@ -407,12 +409,12 @@ module.exports = function (log, error) {
   }
 
   // Select : devices d, sessionTokens s, deviceAvailableCommands dc, deviceCommandIdentifiers ci
-  // Fields : d.uid, d.id, d.sessionTokenId, d.name, d.type, d.createdAt, d.callbackURL,
+  // Fields : d.uid, d.id, d.sessionTokenId, d.refreshTokenId, d.name, d.type, d.createdAt, d.callbackURL,
   //          d.callbackPublicKey, d.callbackAuthKey, d.callbackIsExpired,
   //          s.uaBrowser, s.uaBrowserVersion, s.uaOS, s.uaOSVersion, s.uaDeviceType,
   //          s.uaFormFactor, s.lastAccessTime, {  ci.commandName : dc.commandData }
   // Where  : d.uid = $1
-  var ACCOUNT_DEVICES = 'CALL accountDevices_15(?)'
+  var ACCOUNT_DEVICES = 'CALL accountDevices_16(?)'
 
   MySql.prototype.accountDevices = function (uid) {
     return this.readAllResults(ACCOUNT_DEVICES, [uid])
@@ -420,12 +422,12 @@ module.exports = function (log, error) {
   }
 
   // Select : devices d, sessionTokens s, deviceAvailableCommands dc, deviceCommandIdentifiers ci
-  // Fields : d.uid, d.id, d.sessionTokenId, d.name, d.type, d.createdAt, d.callbackURL,
+  // Fields : d.uid, d.id, d.sessionTokenId, d.refreshTokenId, d.name, d.type, d.createdAt, d.callbackURL,
   //          d.callbackPublicKey, d.callbackAuthKey, d.callbackIsExpired,
   //          s.uaBrowser, s.uaBrowserVersion, s.uaOS, s.uaOSVersion, s.uaDeviceType,
   //          s.uaFormFactor, s.lastAccessTime, {  ci.commandName : dc.commandData }
   // Where  : d.uid = $1 AND d.id = $2
-  var DEVICE = 'CALL device_2(?, ?)'
+  var DEVICE = 'CALL device_3(?, ?)'
 
   MySql.prototype.device = function (uid, id) {
     return this.readAllResults(DEVICE, [uid, id])
@@ -683,10 +685,10 @@ module.exports = function (log, error) {
   }
 
   // Select : devices
-  // Fields : sessionTokenId
+  // Fields : sessionTokenId, refreshTokenId
   // Delete : devices, sessionTokens, unverifiedTokens
   // Where  : uid = $1, deviceId = $2
-  var DELETE_DEVICE = 'CALL deleteDevice_3(?, ?)'
+  var DELETE_DEVICE = 'CALL deleteDevice_4(?, ?)'
 
   MySql.prototype.deleteDevice = function (uid, deviceId) {
     return this.write(DELETE_DEVICE, [ uid, deviceId ], results => {

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 96
+module.exports.level = 97

--- a/lib/db/schema/patch-096-097.sql
+++ b/lib/db/schema/patch-096-097.sql
@@ -1,0 +1,210 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('96');
+
+-- This migration adds an optional `refreshTokenId` column to the `devices` table,
+-- allowing OAuth clients to participate in the sync device ecosystem.
+
+-- First, in order for the migration to apply cleanly via migration tooling,
+-- we need to drop `FOREIGN KEY` constraints on the `devices` table. There's
+-- one instance of this in the old `deviceCapabilities` table which is no
+-- longer used and should be safe to drop entirely.
+
+DROP TABLE IF EXISTS deviceCapabilities;
+
+-- And there are two foreign keys on the `deviceCommands` table, so we might
+-- as well remove both while we're here.  The first links to the `deviceCommandIdentifiers`
+-- table, from which we never delete and so which will not be affected by removal.
+-- The second links to `devices` with `ON DELETE CASCADE`, and a previous migration
+-- has added explicit deletions as a replacement.  So they're both safe to drop.
+
+ALTER TABLE deviceCommands
+  DROP FOREIGN KEY deviceCommands_ibfk_1,
+  DROP FOREIGN KEY deviceCommands_ibfk_2,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+-- With that, we can actually add the new columns.
+
+ALTER TABLE devices
+  ADD COLUMN refreshTokenId BINARY(32) DEFAULT NULL,
+  ADD CONSTRAINT UQ_devices_refreshTokenId UNIQUE (uid, refreshTokenId),
+ALGORITHM = INPLACE, LOCK = NONE;
+
+-- And the stored procedures to use them.
+
+CREATE PROCEDURE `createDevice_5` (
+  IN `inUid` BINARY(16),
+  IN `inId` BINARY(16),
+  IN `inSessionTokenId` BINARY(32),
+  IN `inRefreshTokenId` BINARY(32),
+  IN `inNameUtf8` VARCHAR(255),
+  IN `inType` VARCHAR(16),
+  IN `inCreatedAt` BIGINT UNSIGNED,
+  IN `inCallbackURL` VARCHAR(255),
+  IN `inCallbackPublicKey` CHAR(88),
+  IN `inCallbackAuthKey` CHAR(24)
+)
+BEGIN
+  INSERT INTO devices(
+    uid,
+    id,
+    sessionTokenId,
+    refreshTokenId,
+    nameUtf8,
+    type,
+    createdAt,
+    callbackURL,
+    callbackPublicKey,
+    callbackAuthKey
+  )
+  VALUES (
+    inUid,
+    inId,
+    inSessionTokenId,
+    inRefreshTokenId,
+    inNameUtf8,
+    inType,
+    inCreatedAt,
+    inCallbackURL,
+    inCallbackPublicKey,
+    inCallbackAuthKey
+  );
+END;
+
+
+CREATE PROCEDURE `updateDevice_6` (
+  IN `inUid` BINARY(16),
+  IN `inId` BINARY(16),
+  IN `inSessionTokenId` BINARY(32),
+  IN `inRefreshTokenId` BINARY(32),
+  IN `inNameUtf8` VARCHAR(255),
+  IN `inType` VARCHAR(16),
+  IN `inCallbackURL` VARCHAR(255),
+  IN `inCallbackPublicKey` CHAR(88),
+  IN `inCallbackAuthKey` CHAR(24),
+  IN `inCallbackIsExpired` BOOLEAN
+)
+BEGIN
+  UPDATE devices
+  SET
+    sessionTokenId = COALESCE(inSessionTokenId, sessionTokenId),
+    refreshTokenId = COALESCE(inRefreshTokenId, refreshTokenId),
+    nameUtf8 = COALESCE(inNameUtf8, nameUtf8),
+    type = COALESCE(inType, type),
+    callbackURL = COALESCE(inCallbackURL, callbackURL),
+    callbackPublicKey = COALESCE(inCallbackPublicKey, callbackPublicKey),
+    callbackAuthKey = COALESCE(inCallbackAuthKey, callbackAuthKey),
+    callbackIsExpired = COALESCE(inCallbackIsExpired, callbackIsExpired)
+  WHERE uid = inUid AND id = inId;
+END;
+
+
+-- Return the sessionTokenId and refreshTokenId from deleteDevice
+-- so the auth server can remove them from other data stores.
+CREATE PROCEDURE `deleteDevice_4` (
+  IN `uidArg` BINARY(16),
+  IN `idArg` BINARY(16)
+)
+BEGIN
+  SELECT devices.sessionTokenId, devices.refreshTokenId FROM devices
+  WHERE devices.uid = uidArg AND devices.id = idArg;
+
+  DELETE devices, deviceCommands, sessionTokens, unverifiedTokens
+  FROM devices
+  LEFT JOIN deviceCommands
+    ON (deviceCommands.uid = devices.uid AND deviceCommands.deviceId = devices.id)
+  LEFT JOIN sessionTokens
+    ON devices.sessionTokenId = sessionTokens.tokenId
+  LEFT JOIN unverifiedTokens
+    ON sessionTokens.tokenId = unverifiedTokens.tokenId
+  WHERE devices.uid = uidArg
+    AND devices.id = idArg;
+END;
+
+
+CREATE PROCEDURE `accountDevices_16` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  SELECT
+    d.uid,
+    d.id,
+    s.tokenId AS sessionTokenId, -- Ensure we only return valid sessionToken ids
+    d.refreshTokenId,
+    d.nameUtf8 AS name,
+    d.type,
+    d.createdAt,
+    d.callbackURL,
+    d.callbackPublicKey,
+    d.callbackAuthKey,
+    d.callbackIsExpired,
+    s.uaBrowser,
+    s.uaBrowserVersion,
+    s.uaOS,
+    s.uaOSVersion,
+    s.uaDeviceType,
+    s.uaFormFactor,
+    s.lastAccessTime,
+    ci.commandName,
+    dc.commandData
+  FROM devices AS d
+  -- Left join, because it might not have a sessionToken.
+  LEFT JOIN sessionTokens AS s
+    ON d.sessionTokenId = s.tokenId
+  LEFT JOIN (
+    deviceCommands AS dc FORCE INDEX (PRIMARY)
+    INNER JOIN deviceCommandIdentifiers AS ci FORCE INDEX (PRIMARY)
+      ON ci.commandId = dc.commandId
+  ) ON (dc.uid = d.uid AND dc.deviceId = d.id)
+  WHERE d.uid = uidArg
+  -- We don't want to return 'zombie' device records where the sessionToken
+  -- no longer exists in the sessionTokens table.
+  AND (s.tokenId IS NOT NULL OR d.refreshTokenId IS NOT NULL)
+  -- For easy flattening, ensure rows are ordered by device id.
+  ORDER BY 1, 2;
+END;
+
+
+CREATE PROCEDURE `device_3` (
+  IN `uidArg` BINARY(16),
+  IN `idArg` BINARY(16)
+)
+BEGIN
+  SELECT
+    d.uid,
+    d.id,
+    s.tokenId AS sessionTokenId, -- Ensure we only return valid sessionToken ids
+    d.refreshTokenId,
+    d.nameUtf8 AS name,
+    d.type,
+    d.createdAt,
+    d.callbackURL,
+    d.callbackPublicKey,
+    d.callbackAuthKey,
+    d.callbackIsExpired,
+    s.uaBrowser,
+    s.uaBrowserVersion,
+    s.uaOS,
+    s.uaOSVersion,
+    s.uaDeviceType,
+    s.uaFormFactor,
+    s.lastAccessTime,
+    ci.commandName,
+    dc.commandData
+  FROM devices AS d
+  -- Left join, because it might not have a sessionToken.
+  LEFT JOIN sessionTokens AS s
+    ON d.sessionTokenId = s.tokenId
+  LEFT JOIN (
+    deviceCommands AS dc FORCE INDEX (PRIMARY)
+    INNER JOIN deviceCommandIdentifiers AS ci FORCE INDEX (PRIMARY)
+      ON ci.commandId = dc.commandId
+  ) ON (dc.uid = d.uid AND dc.deviceId = d.id)
+  WHERE d.uid = uidArg
+  AND d.id = idArg
+  -- We don't want to return 'zombie' device records where the sessionToken
+  -- no longer exists in the sessionTokens table.
+  AND (s.tokenId IS NOT NULL OR d.refreshTokenId IS NOT NULL);
+END;
+
+UPDATE dbMetadata SET value = '97' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-097-096.sql
+++ b/lib/db/schema/patch-097-096.sql
@@ -1,0 +1,28 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- This migration adds an optional `refreshTokenId` column to the `devices` table,
+-- allowing OAuth clients to participate in the sync device ecosystem.
+
+-- DROP PROCEDURE `createDevice_5`;
+-- DROP PROCEDURE `updateDevice_6`;
+-- DROP PROCEDURE `deleteDevice_4`;
+-- DROP PROCEDURE `accountDevices_16`;
+-- DROP PROCEDURE `device_3`;
+
+-- ALTER TABLE devices
+--   DROP COLUMN refreshTokenId,
+--   DROP INDEX UQ_devices_refreshTokenId;
+
+-- ALTER TABLE deviceCommands
+--   ADD CONSTRAINT `deviceCommands_ibfk_1` FOREIGN KEY (`commandId`) REFERENCES `deviceCommandIdentifiers` (`commandId`) ON DELETE CASCADE,
+--   ADD CONSTRAINT `deviceCommands_ibfk_2` FOREIGN KEY (`uid`, `deviceId`) REFERENCES `devices` (`uid`, `id`) ON DELETE CASCADE;
+
+-- CREATE TABLE `deviceCapabilities` (
+--   `uid` binary(16) NOT NULL,
+--   `deviceId` binary(16) NOT NULL,
+--   `capability` tinyint(3) unsigned NOT NULL,
+--   PRIMARY KEY (`uid`,`deviceId`,`capability`),
+--   CONSTRAINT `devicecapabilities_ibfk_1` FOREIGN KEY (`uid`, `deviceId`) REFERENCES `devices` (`uid`, `id`) ON DELETE CASCADE
+-- ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+-- UPDATE dbMetadata SET value = '96' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
~~Extremely WIP, but sharing early for context.  PR is currently targetting #482 since it builds on that db migration chain, we'll have to get that merged and rebase this PR before we can merge to master.~~

~~This is now ready for testing and review, but I'm going to leave it as "draft" until we've tried it end-to-end with the corresponding auth-server changes.~~

This is ready for merge, but IIUC we want to do it as a point-release after #492 has hit production.

Fixes #480, Fixes #485; /cc @vladikoff @shane-tomlinson @eoger 