### PR TITLE
chore(devices): Add explicit deletes to replace `ON DELETE CASCADE`.

### DIFF
--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -600,17 +600,18 @@ module.exports = function (log, error) {
   // DELETE
 
   // Delete : sessionTokens, keyFetchTokens, accountResetTokens, passwordChangeTokens,
-  //          passwordForgotTokens, accounts, devices, unverifiedTokens, emails, signinCodes, totp
+  //          passwordForgotTokens, accounts, devices, deviceCommands, unverifiedTokens,
+  //          emails, signinCodes, totp
   // Where  : uid = $1
-  var DELETE_ACCOUNT = 'CALL deleteAccount_15(?)'
+  var DELETE_ACCOUNT = 'CALL deleteAccount_16(?)'
 
   MySql.prototype.deleteAccount = function (uid) {
     return this.write(DELETE_ACCOUNT, [uid])
   }
 
-  // Delete : sessionTokens, unverifiedTokens, devices
+  // Delete : sessionTokens, unverifiedTokens, devices, deviceCommands
   // Where  : tokenId = $1
-  var DELETE_SESSION_TOKEN = 'CALL deleteSessionToken_3(?)'
+  var DELETE_SESSION_TOKEN = 'CALL deleteSessionToken_4(?)'
 
   MySql.prototype.deleteSessionToken = function (tokenId) {
     return this.write(DELETE_SESSION_TOKEN, [tokenId])
@@ -768,14 +769,14 @@ module.exports = function (log, error) {
 
   // Step   : 1
   // Delete : sessionTokens, keyFetchTokens, accountResetTokens, passwordChangeTokens,
-  //          passwordForgotTokens, devices, unverifiedTokens
+  //          passwordForgotTokens, devices, deviceCommands, unverifiedTokens
   // Where  : uid = $1
   //
   // Step   : 2
   // Update : accounts
   // Set    : verifyHash = $2, authSalt = $3, wrapWrapKb = $4, verifierSetAt = $5, verifierVersion = $6
   // Where  : uid = $1
-  var RESET_ACCOUNT = 'CALL resetAccount_11(?, ?, ?, ?, ?, ?)'
+  var RESET_ACCOUNT = 'CALL resetAccount_12(?, ?, ?, ?, ?, ?)'
 
   MySql.prototype.resetAccount = function (uid, data) {
     return this.write(

--- a/lib/db/patch.js
+++ b/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 95
+module.exports.level = 96

--- a/lib/db/schema/patch-095-096.sql
+++ b/lib/db/schema/patch-095-096.sql
@@ -1,0 +1,98 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('95');
+
+-- In order for future migrations on the `devices` table to apply cleanly via migration
+-- tooling, we need to drop `FOREIGN KEY` constraints on the `devices` table.  This
+-- is a preparatory migration that adds explicit deletions in the places where we're
+-- currently relying on `ON DELETE CASCADE`.  Once the new stored procedures are being
+-- used, we'll be free to drop the FK constraints without the risk of missing any deletions.
+
+CREATE PROCEDURE `deleteAccount_16` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  DELETE FROM sessionTokens WHERE uid = uidArg;
+  DELETE FROM keyFetchTokens WHERE uid = uidArg;
+  DELETE FROM accountResetTokens WHERE uid = uidArg;
+  DELETE FROM passwordChangeTokens WHERE uid = uidArg;
+  DELETE FROM passwordForgotTokens WHERE uid = uidArg;
+  DELETE FROM accounts WHERE uid = uidArg;
+  DELETE devices, deviceCommands FROM devices LEFT JOIN deviceCommands
+    ON (deviceCommands.uid = devices.uid AND deviceCommands.deviceId = devices.id)
+    WHERE devices.uid = uidArg;
+  DELETE FROM unverifiedTokens WHERE uid = uidArg;
+  DELETE FROM unblockCodes WHERE uid = uidArg;
+  DELETE FROM emails WHERE uid = uidArg;
+  DELETE FROM signinCodes WHERE uid = uidArg;
+  DELETE FROM totp WHERE uid = uidArg;
+  DELETE FROM recoveryKeys WHERE uid = uidArg;
+  DELETE FROM recoveryCodes WHERE uid = uidArg;
+  DELETE FROM securityEvents WHERE uid = uidArg;
+
+  COMMIT;
+END;
+
+CREATE PROCEDURE `resetAccount_12` (
+  IN `uidArg` BINARY(16),
+  IN `verifyHashArg` BINARY(32),
+  IN `authSaltArg` BINARY(32),
+  IN `wrapWrapKbArg` BINARY(32),
+  IN `verifierSetAtArg` BIGINT UNSIGNED,
+  IN `verifierVersionArg` TINYINT UNSIGNED
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  DELETE FROM sessionTokens WHERE uid = uidArg;
+  DELETE FROM keyFetchTokens WHERE uid = uidArg;
+  DELETE FROM accountResetTokens WHERE uid = uidArg;
+  DELETE FROM passwordChangeTokens WHERE uid = uidArg;
+  DELETE FROM passwordForgotTokens WHERE uid = uidArg;
+  DELETE devices, deviceCommands FROM devices LEFT JOIN deviceCommands
+    ON (deviceCommands.uid = devices.uid AND deviceCommands.deviceId = devices.id)
+    WHERE devices.uid = uidArg;  DELETE FROM unverifiedTokens WHERE uid = uidArg;
+  UPDATE accounts
+  SET
+    verifyHash = verifyHashArg,
+    authSalt = authSaltArg,
+    wrapWrapKb = wrapWrapKbArg,
+    verifierSetAt = verifierSetAtArg,
+    verifierVersion = verifierVersionArg,
+    profileChangedAt = verifierSetAtArg
+  WHERE uid = uidArg;
+
+  COMMIT;
+END;
+
+CREATE PROCEDURE `deleteSessionToken_4` (
+  IN `tokenIdArg` BINARY(32)
+)
+BEGIN
+  DELETE sessionTokens, unverifiedTokens, devices, deviceCommands
+  FROM sessionTokens
+  LEFT JOIN unverifiedTokens
+    ON sessionTokens.tokenId = unverifiedTokens.tokenId
+  LEFT JOIN devices
+    ON (sessionTokens.uid = devices.uid AND sessionTokens.tokenId = devices.sessionTokenId)
+  LEFT JOIN deviceCommands
+    ON (deviceCommands.uid = devices.uid AND deviceCommands.deviceId = devices.id)
+  WHERE
+    sessionTokens.tokenId = tokenIdArg;
+END;
+
+UPDATE dbMetadata SET value = '96' WHERE name = 'schema-patch-level';

--- a/lib/db/schema/patch-096-095.sql
+++ b/lib/db/schema/patch-096-095.sql
@@ -1,0 +1,7 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DROP PROCEDURE `deleteAccount_16`;
+-- DROP PROCEDURE `resetAccount_12`;
+-- DROP PROCEDURE `deleteSessionToken_4`;
+
+-- UPDATE dbMetadata SET value = '95' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
Per https://github.com/mozilla/fxa-auth-db-mysql/pull/483/files#r265148343 this is a preparatory migration that should allow us to fix https://github.com/mozilla/fxa-auth-db-mysql/issues/485 without missing any deletes.

This will need to be deployed before #483 in order to get the desired affect.